### PR TITLE
Stabilize Unicode process inspection contract

### DIFF
--- a/tests/portable-contract.test.mjs
+++ b/tests/portable-contract.test.mjs
@@ -109,12 +109,15 @@ test('macOS ownership uses the complete portable host command, not PID existence
 
 test('Windows process inspection preserves Unicode command-line paths', { skip: process.platform !== 'win32' }, async (t) => {
   const marker = 'USB 移动 后 DSH'
-  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10000)', marker], {
+  const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 60000)', marker], {
     stdio: 'ignore',
     windowsHide: true,
   })
   t.after(() => child.kill())
-  await new Promise((resolve) => setTimeout(resolve, 100))
+  await new Promise((resolve, reject) => {
+    child.once('spawn', resolve)
+    child.once('error', reject)
+  })
   const info = queryWindowsProcess(child.pid)
   assert.ok(info)
   assert.match(info.commandLine, new RegExp(marker))


### PR DESCRIPTION
The Windows CI contract created a child that exited after 10 seconds, but cold CIM initialization on the hosted runner took about 22 seconds. Keep the child alive for the duration of the test and wait for the actual spawn event before querying it. Product runtime code is unchanged.

Local evidence: the focused contract passed 5 consecutive runs and the full 38-test suite passed.