### PR TITLE
Fix Windows bootstrap Unicode and long-path extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Build Windows portable and installer packages
         shell: powershell
         run: ./scripts/build-windows.ps1 -BuildInstaller -IsccPath $env:ISCC_PATH
+      - name: Download, extract, move, and reuse the lightweight Windows bootstrap
+        run: node scripts/smoke-windows-bootstrap.mjs
       - name: Extract and smoke test Windows package
         shell: powershell
         run: |

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.1.0-rc.6-portable.4"
+  #define AppVersion "0.1.0-rc.6-portable.5"
 #endif
 
 [Setup]
@@ -36,7 +36,7 @@ SolidCompression=yes
 WizardStyle=modern
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.1.0.4
+VersionInfoVersion=0.1.0.5
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/installer/windows/DeepSeek-Herness.iss
+++ b/installer/windows/DeepSeek-Herness.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.1.0-rc.6-portable.4"
+  #define AppVersion "0.1.0-rc.6-portable.5"
 #endif
 
 [Setup]
@@ -34,7 +34,7 @@ SolidCompression=yes
 WizardStyle=modern
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.1.0.4
+VersionInfoVersion=0.1.0.5
 VersionInfoProductName=DeepSeek-Herness
 VersionInfoDescription=DeepSeek-Herness installer
 VersionInfoCompany=WSL043

--- a/launcher/portable-core.mjs
+++ b/launcher/portable-core.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
 import { mkdir, open, readFile, readdir, rename, rm, rmdir, writeFile } from 'node:fs/promises'
 import { zstdCompressSync, zstdDecompressSync } from 'node:zlib'
 import path from 'node:path'
@@ -85,16 +85,38 @@ function comparable(value, platform = process.platform) {
   return path.posix.resolve(source.replaceAll('\\', '/'))
 }
 
+function comparableAliases(value, platform = process.platform) {
+  const aliases = new Set([comparable(value, platform)])
+  if (platform !== 'win32' || !value) return aliases
+  try {
+    aliases.add(comparable(realpathSync.native(String(value)), platform))
+  } catch {
+    // A missing path cannot have a filesystem alias; retain the normalized input.
+  }
+  return aliases
+}
+
+function sameComparablePath(left, right, platform = process.platform) {
+  if (!left || !right) return false
+  const leftAliases = comparableAliases(left, platform)
+  return [...comparableAliases(right, platform)].some((alias) => leftAliases.has(alias))
+}
+
+function commandIncludesComparablePath(commandLine, expected, platform = process.platform) {
+  if (!expected) return false
+  return [...comparableAliases(expected, platform)].some((alias) => commandLine.includes(alias))
+}
+
 export function isOwnedDshProcess(processInfo, layout, port) {
   if (!processInfo) return false
   const platform = layout.platform ?? process.platform
   const commandLine = platform === 'win32'
     ? String(processInfo.commandLine ?? '').replaceAll('/', '\\').toLowerCase()
     : String(processInfo.commandLine ?? '').replaceAll('\\', '/')
-  if (processInfo.executablePath && comparable(processInfo.executablePath, platform) !== comparable(layout.nodeExe, platform)) return false
-  return commandLine.includes(comparable(layout.nodeExe, platform))
-    && commandLine.includes(comparable(layout.hostBin, platform))
-    && commandLine.includes(comparable(layout.dshBin, platform))
+  if (processInfo.executablePath && !sameComparablePath(processInfo.executablePath, layout.nodeExe, platform)) return false
+  return commandIncludesComparablePath(commandLine, layout.nodeExe, platform)
+    && commandIncludesComparablePath(commandLine, layout.hostBin, platform)
+    && commandIncludesComparablePath(commandLine, layout.dshBin, platform)
     && commandLine.includes(`--port ${Number(port)}`)
 }
 
@@ -104,9 +126,9 @@ export function isOwnedLauncherProcess(processInfo, layout) {
   const commandLine = platform === 'win32'
     ? String(processInfo.commandLine ?? '').replaceAll('/', '\\').toLowerCase()
     : String(processInfo.commandLine ?? '').replaceAll('\\', '/')
-  if (processInfo.executablePath && comparable(processInfo.executablePath, platform) !== comparable(layout.nodeExe, platform)) return false
-  return commandLine.includes(comparable(layout.nodeExe, platform))
-    && commandLine.includes(comparable(layout.portableCli, platform))
+  if (processInfo.executablePath && !sameComparablePath(processInfo.executablePath, layout.nodeExe, platform)) return false
+  return commandIncludesComparablePath(commandLine, layout.nodeExe, platform)
+    && commandIncludesComparablePath(commandLine, layout.portableCli, platform)
 }
 
 export function queryWindowsProcess(pid) {

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -1,7 +1,10 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
@@ -12,14 +15,15 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Microsoft.Win32.SafeHandles;
 
 [assembly: System.Reflection.AssemblyTitle("DSH-Portable")]
 [assembly: System.Reflection.AssemblyDescription("Lightweight downloader for DSH-Portable")]
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.1.0.4")]
-[assembly: System.Reflection.AssemblyFileVersion("0.1.0.4")]
+[assembly: System.Reflection.AssemblyVersion("0.1.0.5")]
+[assembly: System.Reflection.AssemblyFileVersion("0.1.0.5")]
 
 namespace DshPortableBootstrap
 {
@@ -118,6 +122,20 @@ namespace DshPortableBootstrap
 
     internal sealed class BootstrapInstaller
     {
+        private const uint GenericWrite = 0x40000000;
+        private const uint FileShareRead = 0x00000001;
+        private const uint CreateAlways = 2;
+        private const uint FileAttributeNormal = 0x00000080;
+        private const uint FileAttributeDirectory = 0x00000010;
+        private const uint FileAttributeReadOnly = 0x00000001;
+        private const uint FileAttributeReparsePoint = 0x00000400;
+        private const uint InvalidFileAttributes = 0xffffffff;
+        private const int ErrorFileNotFound = 2;
+        private const int ErrorPathNotFound = 3;
+        private const int ErrorNoMoreFiles = 18;
+        private const int ErrorAlreadyExists = 183;
+        private static readonly IntPtr InvalidFindHandle = new IntPtr(-1);
+
         private readonly BootstrapOptions options;
         private readonly Action<string> reportStatus;
         private readonly Action<long, long> reportProgress;
@@ -168,8 +186,8 @@ namespace DshPortableBootstrap
                     throw new InvalidDataException("下载内容校验失败；没有修改目标目录。请重新运行下载器。");
 
                 reportStatus("正在准备可移动文件夹…");
-                Directory.CreateDirectory(stagingRoot);
-                ExtractWithWindowsTar(temporaryArchive, stagingRoot);
+                EnsureDirectory(stagingRoot);
+                ExtractZipArchive(temporaryArchive, stagingRoot);
                 string extracted = Path.Combine(stagingRoot, "DSH-Portable");
                 if (!IsCompletePortable(extracted))
                     throw new InvalidDataException("下载包缺少启动器或运行环境；没有修改目标目录。");
@@ -315,30 +333,153 @@ namespace DshPortableBootstrap
             }
         }
 
-        private static void ExtractWithWindowsTar(string archive, string destination)
+        private static void ExtractZipArchive(string archive, string destination)
         {
-            string tar = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "tar.exe");
-            if (!File.Exists(tar)) throw new PlatformNotSupportedException("Windows tar.exe 不可用，请改用离线完整包。");
-            ProcessStartInfo start = new ProcessStartInfo
+            using (FileStream archiveStream = File.OpenRead(archive))
+            using (ZipArchive zip = new ZipArchive(archiveStream, ZipArchiveMode.Read, false))
             {
-                FileName = tar,
-                Arguments = "-x -f " + Quote(archive) + " -C " + Quote(destination),
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardError = true,
-            };
-            using (Process process = Process.Start(start))
-            {
-                string error = process.StandardError.ReadToEnd();
-                process.WaitForExit();
-                if (process.ExitCode != 0) throw new InvalidDataException("无法解压下载包：" + error.Trim());
+                foreach (ZipArchiveEntry entry in zip.Entries)
+                {
+                    string relativePath = SafeEntryPath(entry.FullName);
+                    if (String.IsNullOrEmpty(relativePath)) continue;
+                    string target = destination.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                        + Path.DirectorySeparatorChar + relativePath;
+
+                    if (entry.FullName.EndsWith("/", StringComparison.Ordinal)
+                        || entry.FullName.EndsWith("\\", StringComparison.Ordinal))
+                    {
+                        EnsureDirectory(target);
+                        continue;
+                    }
+
+                    string parent = ParentDirectory(target);
+                    if (!String.IsNullOrEmpty(parent)) EnsureDirectory(parent);
+                    using (Stream input = entry.Open())
+                    using (FileStream output = CreateOutputFile(target))
+                    {
+                        input.CopyTo(output);
+                    }
+                }
             }
         }
 
-        private static string Quote(string value)
+        private static string SafeEntryPath(string value)
         {
-            return "\"" + value.Replace("\"", "\\\"") + "\"";
+            string normalized = (value ?? String.Empty).Replace('\\', '/');
+            if (normalized.StartsWith("/", StringComparison.Ordinal) || normalized.IndexOf('\0') >= 0)
+                throw new InvalidDataException("下载包包含不安全的路径；没有修改目标目录。");
+
+            string safe = String.Empty;
+            foreach (string segment in normalized.Split('/'))
+            {
+                if (segment.Length == 0 || segment == ".") continue;
+                if (segment == ".." || segment.IndexOf(':') >= 0)
+                    throw new InvalidDataException("下载包包含不安全的路径；没有修改目标目录。");
+                safe = safe.Length == 0 ? segment : safe + Path.DirectorySeparatorChar + segment;
+            }
+            return safe;
         }
+
+        private static void EnsureDirectory(string value)
+        {
+            string fullPath = IsAbsolutePath(value) ? value : Path.GetFullPath(value);
+            string extendedPath = ToExtendedPath(fullPath);
+            uint attributes = GetFileAttributesW(extendedPath);
+            if (attributes != InvalidFileAttributes)
+            {
+                if ((attributes & FileAttributeDirectory) != 0) return;
+                throw new IOException("目标路径中存在同名文件：" + fullPath);
+            }
+
+            string parent = ParentDirectory(fullPath);
+            if (!String.IsNullOrEmpty(parent) && !String.Equals(parent, fullPath, StringComparison.OrdinalIgnoreCase))
+                EnsureDirectory(parent);
+
+            if (CreateDirectoryW(extendedPath, IntPtr.Zero)) return;
+            int error = Marshal.GetLastWin32Error();
+            if (error == ErrorAlreadyExists && (GetFileAttributesW(extendedPath) & FileAttributeDirectory) != 0) return;
+            throw new IOException("无法创建目录：" + fullPath, new Win32Exception(error));
+        }
+
+        private static FileStream CreateOutputFile(string value)
+        {
+            string fullPath = IsAbsolutePath(value) ? value : Path.GetFullPath(value);
+            SafeFileHandle handle = CreateFileW(
+                ToExtendedPath(fullPath),
+                GenericWrite,
+                FileShareRead,
+                IntPtr.Zero,
+                CreateAlways,
+                FileAttributeNormal,
+                IntPtr.Zero);
+            if (handle.IsInvalid)
+            {
+                int error = Marshal.GetLastWin32Error();
+                handle.Dispose();
+                throw new IOException("无法写入下载包中的文件：" + fullPath, new Win32Exception(error));
+            }
+            return new FileStream(handle, FileAccess.Write, 1024 * 128, false);
+        }
+
+        private static string ParentDirectory(string value)
+        {
+            if (String.IsNullOrEmpty(value)) return null;
+            string trimmed = value.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            int rootLength = RootLength(value);
+            if (rootLength > 0 && trimmed.Length <= rootLength) return null;
+
+            int slash = Math.Max(trimmed.LastIndexOf(Path.DirectorySeparatorChar), trimmed.LastIndexOf(Path.AltDirectorySeparatorChar));
+            if (slash < 0) return null;
+            if (rootLength > 0 && slash < rootLength) return value.Substring(0, rootLength);
+            return trimmed.Substring(0, slash);
+        }
+
+        private static bool IsAbsolutePath(string value)
+        {
+            if (String.IsNullOrEmpty(value)) return false;
+            if (value.StartsWith("\\\\", StringComparison.Ordinal)) return true;
+            return value.Length >= 3 && Char.IsLetter(value[0]) && value[1] == ':'
+                && (value[2] == Path.DirectorySeparatorChar || value[2] == Path.AltDirectorySeparatorChar);
+        }
+
+        private static int RootLength(string value)
+        {
+            if (String.IsNullOrEmpty(value)) return 0;
+            if (value.Length >= 3 && Char.IsLetter(value[0]) && value[1] == ':'
+                && (value[2] == Path.DirectorySeparatorChar || value[2] == Path.AltDirectorySeparatorChar))
+                return 3;
+            if (!value.StartsWith("\\\\", StringComparison.Ordinal)) return 0;
+
+            int serverEnd = value.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, 2);
+            if (serverEnd < 0) return value.Length;
+            int shareEnd = value.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, serverEnd + 1);
+            return shareEnd < 0 ? value.Length : shareEnd + 1;
+        }
+
+        private static string ToExtendedPath(string value)
+        {
+            string fullPath = IsAbsolutePath(value) ? value : Path.GetFullPath(value);
+            if (fullPath.StartsWith("\\\\?\\", StringComparison.Ordinal)) return fullPath;
+            if (fullPath.StartsWith("\\\\", StringComparison.Ordinal)) return "\\\\?\\UNC\\" + fullPath.Substring(2);
+            return "\\\\?\\" + fullPath;
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CreateDirectoryW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CreateDirectoryW(string path, IntPtr securityAttributes);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "GetFileAttributesW")]
+        private static extern uint GetFileAttributesW(string path);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CreateFileW")]
+        private static extern SafeFileHandle CreateFileW(
+            string filename,
+            uint desiredAccess,
+            uint shareMode,
+            IntPtr securityAttributes,
+            uint creationDisposition,
+            uint flagsAndAttributes,
+            IntPtr templateFile);
 
         private static string FriendlyMessage(Exception error)
         {
@@ -355,8 +496,125 @@ namespace DshPortableBootstrap
 
         private static void TryDeleteDirectory(string directory)
         {
-            try { if (Directory.Exists(directory)) Directory.Delete(directory, true); } catch { }
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, true);
+                    return;
+                }
+            }
+            catch { }
+
+            try { DeleteDirectoryTreeExtended(ToExtendedPath(directory)); } catch { }
         }
+
+        private static void DeleteDirectoryTreeExtended(string extendedDirectory)
+        {
+            string directory = extendedDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            uint directoryAttributes = GetFileAttributesW(directory);
+            if (directoryAttributes == InvalidFileAttributes)
+            {
+                int missingError = Marshal.GetLastWin32Error();
+                if (missingError == ErrorFileNotFound || missingError == ErrorPathNotFound) return;
+                throw new Win32Exception(missingError);
+            }
+
+            Win32FindData data;
+            IntPtr findHandle = FindFirstFileW(directory + "\\*", out data);
+            if (findHandle != InvalidFindHandle)
+            {
+                try
+                {
+                    while (true)
+                    {
+                        string name = data.FileName;
+                        if (!String.Equals(name, ".", StringComparison.Ordinal)
+                            && !String.Equals(name, "..", StringComparison.Ordinal))
+                        {
+                            string child = directory + "\\" + name;
+                            bool isDirectory = (data.FileAttributes & FileAttributeDirectory) != 0;
+                            bool isReparsePoint = (data.FileAttributes & FileAttributeReparsePoint) != 0;
+                            if (isDirectory && !isReparsePoint)
+                            {
+                                DeleteDirectoryTreeExtended(child);
+                            }
+                            else if (isDirectory)
+                            {
+                                if (!RemoveDirectoryW(child)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                            }
+                            else
+                            {
+                                if ((data.FileAttributes & FileAttributeReadOnly) != 0)
+                                    SetFileAttributesW(child, FileAttributeNormal);
+                                if (!DeleteFileW(child)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                            }
+                        }
+
+                        if (FindNextFileW(findHandle, out data)) continue;
+                        int nextError = Marshal.GetLastWin32Error();
+                        if (nextError != ErrorNoMoreFiles) throw new Win32Exception(nextError);
+                        break;
+                    }
+                }
+                finally
+                {
+                    FindClose(findHandle);
+                }
+            }
+            else
+            {
+                int findError = Marshal.GetLastWin32Error();
+                if (findError != ErrorFileNotFound) throw new Win32Exception(findError);
+            }
+
+            if (!RemoveDirectoryW(directory))
+            {
+                int removeError = Marshal.GetLastWin32Error();
+                if (removeError != ErrorFileNotFound && removeError != ErrorPathNotFound)
+                    throw new Win32Exception(removeError);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct Win32FindData
+        {
+            internal uint FileAttributes;
+            internal System.Runtime.InteropServices.ComTypes.FILETIME CreationTime;
+            internal System.Runtime.InteropServices.ComTypes.FILETIME LastAccessTime;
+            internal System.Runtime.InteropServices.ComTypes.FILETIME LastWriteTime;
+            internal uint FileSizeHigh;
+            internal uint FileSizeLow;
+            internal uint Reserved0;
+            internal uint Reserved1;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            internal string FileName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)]
+            internal string AlternateFileName;
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "FindFirstFileW")]
+        private static extern IntPtr FindFirstFileW(string filename, out Win32FindData data);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "FindNextFileW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool FindNextFileW(IntPtr findHandle, out Win32FindData data);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool FindClose(IntPtr findHandle);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "DeleteFileW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DeleteFileW(string filename);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "RemoveDirectoryW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool RemoveDirectoryW(string path);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "SetFileAttributesW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetFileAttributesW(string filename, uint attributes);
     }
 
     internal sealed class BootstrapWindow : Form

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -12,8 +12,8 @@ using System.Windows.Forms;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.1.0.4")]
-[assembly: AssemblyFileVersion("0.1.0.4")]
+[assembly: AssemblyVersion("0.1.0.5")]
+[assembly: AssemblyFileVersion("0.1.0.5")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.1.0-rc.6-portable.4",
+  "version": "0.1.0-rc.6-portable.5",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -213,7 +213,7 @@ try {
         "/win32manifest:$ProjectRoot\launcher\windows\DSH-Portable.manifest",
         '/reference:System.dll', '/reference:System.Core.dll', '/reference:System.Drawing.dll',
         '/reference:System.Windows.Forms.dll', '/reference:System.Net.Http.dll',
-        '/reference:System.Runtime.Serialization.dll',
+        '/reference:System.Runtime.Serialization.dll', '/reference:System.IO.Compression.dll',
         "/out:$BootstrapCandidate",
         (Join-Path $ProjectRoot 'launcher\windows\DSH-Bootstrap.cs')
     )

--- a/scripts/smoke-windows-bootstrap.mjs
+++ b/scripts/smoke-windows-bootstrap.mjs
@@ -26,6 +26,7 @@ assert.equal(
   sourcePayload.sha256,
   'manifest payload digest does not match the built ZIP',
 )
+console.log('[bootstrap-smoke] built payload verified')
 
 let manifestBody = null
 const server = createServer((request, response) => {
@@ -59,6 +60,7 @@ const resultFile = path.join(root, 'result.json')
 
 try {
   await mkdir(parent, { recursive: true })
+  console.log('[bootstrap-smoke] installing through the lightweight launcher')
   await execFileAsync(bootstrap, [
     '--manifest', `${origin}/portable-manifest.json`,
     '--destination', destination,
@@ -76,7 +78,9 @@ try {
     'the product bootstrap left a staging directory behind',
   )
   assert.ok((await stat(path.join(destination, 'DeepSeek-Herness.exe'))).isFile())
+  console.log('[bootstrap-smoke] Unicode and long-path installation passed')
 
+  console.log('[bootstrap-smoke] checking offline reuse')
   await execFileAsync(bootstrap, [
     '--manifest', 'http://127.0.0.1:1/unreachable.json',
     '--destination', destination,
@@ -86,11 +90,14 @@ try {
   ], { timeout: 60 * 1000, windowsHide: true })
   const reused = JSON.parse(await readFile(resultFile, 'utf8'))
   assert.equal(reused.status, 'ready')
+  console.log('[bootstrap-smoke] offline reuse passed')
 
+  console.log('[bootstrap-smoke] running and moving the installed product')
   await execFileAsync(process.execPath, [path.join(projectRoot, 'scripts', 'smoke-portable.mjs'), destination], {
     timeout: 10 * 60 * 1000,
     windowsHide: true,
   })
+  console.log('[bootstrap-smoke] product runtime smoke passed')
 
   console.log(JSON.stringify({
     status: 'passed',
@@ -100,5 +107,9 @@ try {
   }))
 } finally {
   await new Promise((resolve) => server.close(resolve))
-  await rm(root, { recursive: true, force: true, maxRetries: 40, retryDelay: 100 })
+  if (process.env.CI) {
+    console.log('[bootstrap-smoke] temporary product tree is owned by the ephemeral CI runner')
+  } else {
+    await rm(root, { recursive: true, force: true, maxRetries: 40, retryDelay: 100 })
+  }
 }

--- a/scripts/smoke-windows-bootstrap.mjs
+++ b/scripts/smoke-windows-bootstrap.mjs
@@ -100,5 +100,5 @@ try {
   }))
 } finally {
   await new Promise((resolve) => server.close(resolve))
-  await rm(root, { recursive: true, force: true })
+  await rm(root, { recursive: true, force: true, maxRetries: 40, retryDelay: 100 })
 }

--- a/scripts/smoke-windows-bootstrap.mjs
+++ b/scripts/smoke-windows-bootstrap.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { createReadStream } from 'node:fs'
+import { mkdtemp, mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const projectRoot = path.resolve(import.meta.dirname, '..')
+const artifacts = path.resolve(process.argv[2] || path.join(projectRoot, 'artifacts'))
+const bootstrap = path.join(artifacts, 'DSH-Portable-windows-x64.exe')
+const sourceManifest = JSON.parse(await readFile(path.join(artifacts, 'portable-manifest.json'), 'utf8'))
+const sourcePayload = sourceManifest?.payloads?.windowsX64
+
+assert.equal(process.platform, 'win32', 'the lightweight bootstrap smoke test requires Windows')
+assert.ok(sourcePayload?.filename, 'portable-manifest.json is missing the Windows payload')
+
+const payload = path.join(artifacts, sourcePayload.filename)
+const payloadBytes = await readFile(payload)
+assert.equal(payloadBytes.length, sourcePayload.bytes, 'manifest payload size does not match the built ZIP')
+assert.equal(
+  createHash('sha256').update(payloadBytes).digest('hex'),
+  sourcePayload.sha256,
+  'manifest payload digest does not match the built ZIP',
+)
+
+let manifestBody = null
+const server = createServer((request, response) => {
+  if (request.url === '/portable-manifest.json') {
+    response.writeHead(200, { 'content-type': 'application/json', 'content-length': manifestBody.length })
+    response.end(manifestBody)
+    return
+  }
+  if (request.url === '/payload.zip') {
+    response.writeHead(200, { 'content-type': 'application/zip', 'content-length': payloadBytes.length })
+    createReadStream(payload).pipe(response)
+    return
+  }
+  response.writeHead(404).end()
+})
+
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+const origin = `http://127.0.0.1:${server.address().port}`
+manifestBody = Buffer.from(JSON.stringify({
+  ...sourceManifest,
+  payloads: {
+    ...sourceManifest.payloads,
+    windowsX64: { ...sourcePayload, url: `${origin}/payload.zip` },
+  },
+}), 'utf8')
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-bootstrap-product-'))
+const parent = path.join(root, '验证 中文 空格')
+const destination = path.join(parent, 'DSH-Portable')
+const resultFile = path.join(root, 'result.json')
+
+try {
+  await mkdir(parent, { recursive: true })
+  await execFileAsync(bootstrap, [
+    '--manifest', `${origin}/portable-manifest.json`,
+    '--destination', destination,
+    '--allow-http',
+    '--no-launch',
+    '--result', resultFile,
+  ], { timeout: 10 * 60 * 1000, windowsHide: true })
+
+  const installed = JSON.parse(await readFile(resultFile, 'utf8'))
+  assert.equal(installed.status, 'installed')
+  assert.equal(installed.version, sourceManifest.version)
+  assert.deepEqual(
+    (await readdir(parent)).filter((name) => name.startsWith('.dsh-portable-install-')),
+    [],
+    'the product bootstrap left a staging directory behind',
+  )
+  assert.ok((await stat(path.join(destination, 'DeepSeek-Herness.exe'))).isFile())
+
+  await execFileAsync(bootstrap, [
+    '--manifest', 'http://127.0.0.1:1/unreachable.json',
+    '--destination', destination,
+    '--allow-http',
+    '--no-launch',
+    '--result', resultFile,
+  ], { timeout: 60 * 1000, windowsHide: true })
+  const reused = JSON.parse(await readFile(resultFile, 'utf8'))
+  assert.equal(reused.status, 'ready')
+
+  await execFileAsync(process.execPath, [path.join(projectRoot, 'scripts', 'smoke-portable.mjs'), destination], {
+    timeout: 10 * 60 * 1000,
+    windowsHide: true,
+  })
+
+  console.log(JSON.stringify({
+    status: 'passed',
+    version: sourceManifest.version,
+    bootstrapBytes: (await stat(bootstrap)).size,
+    payloadBytes: payloadBytes.length,
+  }))
+} finally {
+  await new Promise((resolve) => server.close(resolve))
+  await rm(root, { recursive: true, force: true })
+}

--- a/tests/bootstrap-contract.test.mjs
+++ b/tests/bootstrap-contract.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 import { execFile } from 'node:child_process'
 import { createServer } from 'node:http'
-import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -23,20 +23,41 @@ async function compileBootstrap(output) {
     '/reference:System.dll', '/reference:System.Core.dll',
     '/reference:System.Drawing.dll', '/reference:System.Windows.Forms.dll',
     '/reference:System.Net.Http.dll', '/reference:System.Runtime.Serialization.dll',
+    '/reference:System.IO.Compression.dll',
     `/out:${output}`,
     source,
   ])
 }
 
-async function makeFixture(root) {
+async function execBootstrap(executable, args, resultFile) {
+  try {
+    return await execFileAsync(executable, args)
+  } catch (error) {
+    const result = await readFile(resultFile, 'utf8').catch(() => '')
+    if (result) error.message += `\nBootstrap result: ${result}`
+    throw error
+  }
+}
+
+async function makeFixture(root, { omitRuntime = false } = {}) {
   const packageRoot = path.join(root, 'payload', 'DSH-Portable')
+  const longRelative = path.join(
+    'app',
+    'node_modules',
+    `package-${'a'.repeat(72)}`,
+    'dist',
+    `feature-${'b'.repeat(72)}`,
+    'runtime.json',
+  )
   await mkdir(path.join(packageRoot, 'runtime', 'node'), { recursive: true })
   await mkdir(path.join(packageRoot, 'app'), { recursive: true })
   await mkdir(path.join(packageRoot, 'data'), { recursive: true })
   await mkdir(path.join(packageRoot, 'workspace'), { recursive: true })
   await writeFile(path.join(packageRoot, 'DeepSeek-Herness.exe'), 'fixture launcher')
-  await writeFile(path.join(packageRoot, 'runtime', 'node', 'node.exe'), 'fixture node')
+  if (!omitRuntime) await writeFile(path.join(packageRoot, 'runtime', 'node', 'node.exe'), 'fixture node')
   await writeFile(path.join(packageRoot, 'app', 'package.json'), '{"name":"fixture"}\n')
+  await mkdir(path.dirname(path.join(packageRoot, longRelative)), { recursive: true })
+  await writeFile(path.join(packageRoot, longRelative), '{"longPath":true}\n')
   await writeFile(path.join(packageRoot, 'data', 'README.txt'), 'portable data')
   const archive = path.join(root, 'payload.zip')
   await execFileAsync('tar.exe', ['-a', '-c', '-f', archive, '-C', path.join(root, 'payload'), 'DSH-Portable'])
@@ -44,6 +65,7 @@ async function makeFixture(root) {
   return {
     archive,
     bytes,
+    longRelative,
     sha256: createHash('sha256').update(bytes).digest('hex'),
   }
 }
@@ -107,33 +129,39 @@ test('bootstrap installs atomically, verifies the payload, and reuses it offline
   try {
     const executable = path.join(root, 'bootstrap.exe')
     const resultFile = path.join(root, 'result.json')
-    const destination = path.join(root, 'chosen-parent', 'DSH-Portable')
+    const destination = path.join(root, 'chosen 父目录', 'DSH-Portable')
     const fixture = await makeFixture(root)
     await compileBootstrap(executable)
 
     await withFixtureServer(fixture, async ({ archiveRequests, manifestUrl }) => {
-      await execFileAsync(executable, [
+      await execBootstrap(executable, [
         '--manifest', manifestUrl,
         '--destination', destination,
         '--allow-http',
         '--no-launch',
         '--result', resultFile,
-      ])
+      ], resultFile)
       assert.equal(archiveRequests(), 1)
       const result = JSON.parse(await readFile(resultFile, 'utf8'))
       assert.equal(result.status, 'installed')
       assert.equal(result.version, 'test-portable')
       assert.equal(await readFile(path.join(destination, 'data', 'README.txt'), 'utf8'), 'portable data')
       assert.equal(await readFile(path.join(destination, 'app', 'package.json'), 'utf8'), '{"name":"fixture"}\n')
+      assert.equal(await readFile(path.join(destination, fixture.longRelative), 'utf8'), '{"longPath":true}\n')
+      assert.deepEqual(
+        (await readdir(path.dirname(destination))).filter((name) => name.startsWith('.dsh-portable-install-')),
+        [],
+        'successful installation must not leave its staging directory behind',
+      )
 
       await rm(fixture.archive, { force: true })
-      await execFileAsync(executable, [
+      await execBootstrap(executable, [
         '--manifest', 'http://127.0.0.1:1/unreachable.json',
         '--destination', destination,
         '--allow-http',
         '--no-launch',
         '--result', resultFile,
-      ])
+      ], resultFile)
       const reused = JSON.parse(await readFile(resultFile, 'utf8'))
       assert.equal(reused.status, 'ready')
       assert.equal(archiveRequests(), 1, 'an installed portable folder must not need the network')
@@ -164,6 +192,37 @@ test('bootstrap never commits a payload whose digest is wrong', { skip: process.
       const failed = JSON.parse(await readFile(resultFile, 'utf8'))
       assert.equal(failed.status, 'failed')
       await assert.rejects(stat(destination))
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('bootstrap removes a rejected long-path payload without leaving staging data', { skip: process.platform !== 'win32' }, async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-bootstrap-reject-'))
+  try {
+    const executable = path.join(root, 'bootstrap.exe')
+    const resultFile = path.join(root, 'result.json')
+    const destination = path.join(root, `parent-${'c'.repeat(150)}`, '中文 parent', 'DSH-Portable')
+    const fixture = await makeFixture(root, { omitRuntime: true })
+    await compileBootstrap(executable)
+
+    await withFixtureServer(fixture, async ({ manifestUrl }) => {
+      await assert.rejects(execBootstrap(executable, [
+        '--manifest', manifestUrl,
+        '--destination', destination,
+        '--allow-http',
+        '--no-launch',
+        '--result', resultFile,
+      ], resultFile))
+      const failed = JSON.parse(await readFile(resultFile, 'utf8'))
+      assert.equal(failed.status, 'failed')
+      await assert.rejects(stat(destination))
+      assert.deepEqual(
+        (await readdir(path.dirname(destination))).filter((name) => name.startsWith('.dsh-portable-install-')),
+        [],
+        'rejected payloads must not leave long-path staging data behind',
+      )
     })
   } finally {
     await rm(root, { recursive: true, force: true })

--- a/tests/portable-contract.test.mjs
+++ b/tests/portable-contract.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import { spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
+import { realpathSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rename, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -11,6 +12,7 @@ import {
   browserLaunchSpec,
   buildDshEnv,
   isOwnedDshProcess,
+  isOwnedLauncherProcess,
   layoutForRoot,
   migratePortableRoot,
   parseCli,
@@ -121,6 +123,39 @@ test('Windows process inspection preserves Unicode command-line paths', { skip: 
   const info = queryWindowsProcess(child.pid)
   assert.ok(info)
   assert.match(info.commandLine, new RegExp(marker))
+})
+
+test('Windows process ownership treats short and long path aliases as the same files', { skip: process.platform !== 'win32' }, () => {
+  const projectRoot = path.resolve(import.meta.dirname, '..')
+  const longPaths = {
+    nodeExe: realpathSync.native(process.execPath),
+    hostBin: realpathSync.native(path.join(projectRoot, 'launcher', 'portable-host.mjs')),
+    dshBin: realpathSync.native(path.join(projectRoot, 'package.json')),
+    portableCli: realpathSync.native(path.join(projectRoot, 'launcher', 'portable-cli.mjs')),
+  }
+  const shortPath = (filename) => execFileSync('cmd.exe', [
+    '/d', '/c', `for %I in ("${filename}") do @echo %~sI`,
+  ], { encoding: 'utf8', windowsHide: true, windowsVerbatimArguments: true }).trim()
+  const layout = {
+    platform: 'win32',
+    nodeExe: shortPath(longPaths.nodeExe),
+    hostBin: shortPath(longPaths.hostBin),
+    dshBin: shortPath(longPaths.dshBin),
+    portableCli: shortPath(longPaths.portableCli),
+  }
+  assert.ok(Object.keys(longPaths).some((name) => layout[name].toLowerCase() !== longPaths[name].toLowerCase()))
+  assert.equal(isOwnedDshProcess({
+    executablePath: longPaths.nodeExe,
+    commandLine: `"${longPaths.nodeExe}" "${longPaths.hostBin}" "${longPaths.dshBin}" web --port 31234`,
+  }, layout, 31234), true)
+  assert.equal(isOwnedLauncherProcess({
+    executablePath: longPaths.nodeExe,
+    commandLine: `"${longPaths.nodeExe}" "${longPaths.portableCli}" start`,
+  }, layout), true)
+  assert.equal(isOwnedLauncherProcess({
+    executablePath: longPaths.nodeExe,
+    commandLine: `"${longPaths.nodeExe}" "${longPaths.portableCli}" start`,
+  }, { ...layout, portableCli: '' }), false)
 })
 
 test('launcher reclaims a dead lock but never bypasses a live owned launcher', async () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -266,6 +266,7 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.match(bootstrapSmoke, /中文 空格/)
   assert.match(bootstrapSmoke, /\.dsh-portable-install-/)
   assert.match(bootstrapSmoke, /maxRetries:\s*40/)
+  assert.match(bootstrapSmoke, /process\.env\.CI/)
 })
 
 test('Node runtime lock covers Windows and both Mac CPU families', async () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -265,6 +265,7 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.match(bootstrapSmoke, /DSH-Portable-windows-x64\.exe/)
   assert.match(bootstrapSmoke, /中文 空格/)
   assert.match(bootstrapSmoke, /\.dsh-portable-install-/)
+  assert.match(bootstrapSmoke, /maxRetries:\s*40/)
 })
 
 test('Node runtime lock covers Windows and both Mac CPU families', async () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -86,6 +86,7 @@ test('desktop icons are derived from the pinned official DSH mark', async () => 
 
 test('Windows package exposes real GUI executables with matching icon and no path install', async () => {
   const source = await read('launcher/windows/DSH-Portable.cs')
+  const bootstrap = await read('launcher/windows/DSH-Bootstrap.cs')
   const manifest = await read('launcher/windows/DSH-Portable.manifest')
   const build = await read('scripts/build-windows.ps1')
 
@@ -112,6 +113,8 @@ test('Windows package exposes real GUI executables with matching icon and no pat
   assert.match(build, /DSH-Portable-windows-x64-offline\.zip/)
   assert.match(build, /DSH-Bootstrap\.cs/)
   assert.match(build, /portable-manifest\.json/)
+  assert.match(bootstrap, /ZipArchive/)
+  assert.doesNotMatch(bootstrap, /tar\.exe/i)
   assert.doesNotMatch(build, /community\.1|DeepSeek Harness\.cmd/)
 })
 
@@ -240,10 +243,12 @@ test('macOS DMG carries a self-contained app and keeps installed data outside it
 
 test('CI executes contracts and real package smoke tests on Windows and both Mac architectures', async () => {
   const workflow = await read('.github/workflows/ci.yml')
+  const bootstrapSmoke = await read('scripts/smoke-windows-bootstrap.mjs')
   for (const runner of ['windows-latest', 'macos-15', 'macos-15-intel']) assert.match(workflow, new RegExp(runner))
   assert.match(workflow, /build-windows\.ps1/)
   assert.match(workflow, /build-macos\.sh/)
   assert.match(workflow, /smoke-portable\.mjs/)
+  assert.match(workflow, /smoke-windows-bootstrap\.mjs/)
   assert.match(workflow, /tar\.exe -x -f artifacts\/DSH-Portable-windows-x64-offline\.zip/)
   assert.doesNotMatch(workflow, /Expand-Archive/)
   assert.match(workflow, /actions\/checkout@v6/)
@@ -257,6 +262,9 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.doesNotMatch(workflow, /choco install innosetup/)
   assert.match(workflow, /compression-level:\s*0/)
   assert.match(workflow, /if:\s*\$\{\{ always\(\) \}\}/)
+  assert.match(bootstrapSmoke, /DSH-Portable-windows-x64\.exe/)
+  assert.match(bootstrapSmoke, /中文 空格/)
+  assert.match(bootstrapSmoke, /\.dsh-portable-install-/)
 })
 
 test('Node runtime lock covers Windows and both Mac CPU families', async () => {


### PR DESCRIPTION
## What changed
- replace the lightweight Windows bootstrap's external `tar.exe` extraction with managed ZIP reading plus native Unicode/long-path file writes
- reject path traversal entries and clean long-path staging trees on both success and failure
- bump the package revision to `portable.5`
- add a real built-product bootstrap smoke test to Windows CI

## Root cause
The previous bootstrap delegated extraction to Windows `tar.exe`. In a Chinese/space-containing destination, the child process received a garbled working path. A first managed extraction attempt still used legacy .NET Framework path APIs, which fail on nested runtime paths beyond 260 characters.

## User impact
The small Windows launcher can now install the complete offline DSH runtime into Unicode and space-containing folders, handles long dependency paths, leaves no partial staging data, and can be reused offline after installation.

## Validation
- `node --test tests/*.test.mjs` (39 passed)
- real 76.6 MB product bootstrap download/extract/offline-reuse/move smoke in a Chinese + space path
- portable self-extractor run/move/stop smoke
- installer install/start/stop/uninstall smoke
- `git diff --check`