### PR TITLE
Fix portable browser shutdown and parallelize release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - run: npm test
 
   windows-build:
-    name: Build Windows artifacts
+    name: Build Windows base artifacts
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
@@ -57,6 +57,46 @@ jobs:
           node-version: 24.19.0
           cache: npm
           cache-dependency-path: app/package-lock.json
+      - name: Build Windows portable base
+        shell: powershell
+        run: ./scripts/build-windows.ps1
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-x64-build
+          path: |
+            artifacts/DSH-Portable-windows-x64-offline.zip
+            artifacts/DSH-Portable-windows-x64-offline.zip.sha256
+            artifacts/DSH-Portable-windows-x64.exe
+            artifacts/DSH-Portable-windows-x64.exe.sha256
+            artifacts/portable-manifest.json
+            artifacts/DSH-Portable-update-windows-x64.zip
+            artifacts/DSH-Portable-update-windows-x64.zip.sha256
+            artifacts/portable-update-windows-x64.json
+          if-no-files-found: error
+          compression-level: 0
+
+  windows-inno-build:
+    name: Build Windows ${{ matrix.label }}
+    needs: windows-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - kind: portable
+            label: portable self-extractor
+            artifact: windows-x64-extractor
+            filename: DSH-Portable-windows-x64-offline.exe
+          - kind: installer
+            label: installer
+            artifact: windows-x64-installer
+            filename: DeepSeek-Herness-Setup.exe
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
       - name: Install pinned Inno Setup 7 compiler
         shell: powershell
         run: |
@@ -72,25 +112,15 @@ jobs:
           $Iscc = Join-Path $CompilerRoot 'ISCC.exe'
           if (-not (Test-Path -LiteralPath $Iscc)) { throw "ISCC.exe is missing: $Iscc" }
           "ISCC_PATH=$Iscc" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-      - name: Build Windows portable and installer packages
+      - name: Build ${{ matrix.label }} from the verified base archive
         shell: powershell
-        run: ./scripts/build-windows.ps1 -BuildInstaller -IsccPath $env:ISCC_PATH
+        run: ./scripts/build-windows-inno.ps1 -Kind '${{ matrix.kind }}' -Archive 'artifacts/DSH-Portable-windows-x64-offline.zip' -OutputDir 'artifacts' -IsccPath $env:ISCC_PATH
       - uses: actions/upload-artifact@v7
         with:
-          name: windows-x64-build
+          name: ${{ matrix.artifact }}
           path: |
-            artifacts/DSH-Portable-windows-x64-offline.zip
-            artifacts/DSH-Portable-windows-x64-offline.zip.sha256
-            artifacts/DSH-Portable-windows-x64.exe
-            artifacts/DSH-Portable-windows-x64.exe.sha256
-            artifacts/DSH-Portable-windows-x64-offline.exe
-            artifacts/DSH-Portable-windows-x64-offline.exe.sha256
-            artifacts/portable-manifest.json
-            artifacts/DSH-Portable-update-windows-x64.zip
-            artifacts/DSH-Portable-update-windows-x64.zip.sha256
-            artifacts/portable-update-windows-x64.json
-            artifacts/DeepSeek-Herness-Setup.exe
-            artifacts/DeepSeek-Herness-Setup.exe.sha256
+            artifacts/${{ matrix.filename }}
+            artifacts/${{ matrix.filename }}.sha256
           if-no-files-found: error
           compression-level: 0
 
@@ -177,28 +207,28 @@ jobs:
 
   windows-extractor-smoke:
     name: Windows self-extractor
-    needs: windows-build
+    needs: windows-inno-build
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
-          name: windows-x64-build
+          name: windows-x64-extractor
           path: artifacts
       - shell: powershell
         run: ./scripts/smoke-windows-portable-extractor.ps1
 
   windows-installer-smoke:
     name: Windows installer
-    needs: windows-build
+    needs: windows-inno-build
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
-          name: windows-x64-build
+          name: windows-x64-installer
           path: artifacts
       - shell: powershell
         run: ./scripts/smoke-windows-installer.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,54 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  windows-x64:
+  workflow-lint:
+    name: GitHub Actions syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate workflow semantics with actionlint
+        run: |
+          curl --fail --location --retry 3 --output actionlint.tar.gz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz' | sha256sum --check
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint
+
+  contracts:
+    name: Contracts (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            label: windows-x64
+          - runner: macos-15
+            label: macos-arm64
+          - runner: macos-15-intel
+            label: macos-x64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+      - run: npm test
+
+  windows-build:
+    name: Build Windows artifacts
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.19.0
           cache: npm
           cache-dependency-path: app/package-lock.json
-      - run: npm test
       - name: Install pinned Inno Setup 7 compiler
         shell: powershell
         run: |
@@ -38,31 +75,9 @@ jobs:
       - name: Build Windows portable and installer packages
         shell: powershell
         run: ./scripts/build-windows.ps1 -BuildInstaller -IsccPath $env:ISCC_PATH
-      - name: Verify Windows component update artifact
-        run: node scripts/verify-update-artifact.mjs artifacts/portable-update-windows-x64.json artifacts/DSH-Portable-update-windows-x64.zip
-      - name: Download, extract, move, and reuse the lightweight Windows bootstrap
-        run: node scripts/smoke-windows-bootstrap.mjs
-      - name: Extract and smoke test Windows package
-        shell: powershell
-        run: |
-          $Root = Join-Path $env:RUNNER_TEMP 'dsh-portable-smoke'
-          New-Item -ItemType Directory -Force -Path $Root | Out-Null
-          tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $Root
-          if ($LASTEXITCODE -ne 0) { throw "Windows package extraction failed with exit code $LASTEXITCODE" }
-          node scripts/smoke-update-artifact.mjs (Join-Path $Root 'DSH-Portable') artifacts/portable-update-windows-x64.json artifacts/DSH-Portable-update-windows-x64.zip
-          node scripts/smoke-portable.mjs (Join-Path $Root 'DSH-Portable')
-      - name: Extract, run, move, and stop Windows portable self-extractor
-        shell: powershell
-        timeout-minutes: 15
-        run: ./scripts/smoke-windows-portable-extractor.ps1
-      - name: Install, run, stop, and uninstall Windows setup
-        shell: powershell
-        timeout-minutes: 15
-        run: ./scripts/smoke-windows-installer.ps1
-      - uses: actions/upload-artifact@v6
-        if: ${{ always() }}
+      - uses: actions/upload-artifact@v7
         with:
-          name: DSH-Portable-windows-x64-all
+          name: windows-x64-build
           path: |
             artifacts/DSH-Portable-windows-x64-offline.zip
             artifacts/DSH-Portable-windows-x64-offline.zip.sha256
@@ -79,7 +94,117 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-  macos:
+  windows-update-smoke:
+    name: Windows component update
+    needs: windows-build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
+      - run: node scripts/verify-update-artifact.mjs artifacts/portable-update-windows-x64.json artifacts/DSH-Portable-update-windows-x64.zip
+      - name: Apply and roll back component update
+        shell: powershell
+        run: |
+          $Root = Join-Path $env:RUNNER_TEMP 'dsh-update-smoke'
+          New-Item -ItemType Directory -Force -Path $Root | Out-Null
+          tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $Root
+          if ($LASTEXITCODE -ne 0) { throw "Windows package extraction failed with exit code $LASTEXITCODE" }
+          node scripts/smoke-update-artifact.mjs (Join-Path $Root 'DSH-Portable') artifacts/portable-update-windows-x64.json artifacts/DSH-Portable-update-windows-x64.zip
+
+  windows-portable-smoke:
+    name: Windows movable ZIP
+    needs: windows-build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
+      - name: Extract, run, move, and stop portable ZIP
+        shell: powershell
+        run: |
+          $Root = Join-Path $env:RUNNER_TEMP 'dsh-portable-smoke'
+          New-Item -ItemType Directory -Force -Path $Root | Out-Null
+          tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $Root
+          if ($LASTEXITCODE -ne 0) { throw "Windows package extraction failed with exit code $LASTEXITCODE" }
+          node scripts/smoke-portable.mjs (Join-Path $Root 'DSH-Portable')
+
+  windows-browser-lifecycle:
+    name: Windows browser ownership and Stop EXE
+    needs: windows-build
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
+      - name: Start the real portable browser and close only its owned profile
+        shell: powershell
+        run: |
+          $Root = Join-Path $env:RUNNER_TEMP 'dsh-browser-lifecycle'
+          New-Item -ItemType Directory -Force -Path $Root | Out-Null
+          tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $Root
+          if ($LASTEXITCODE -ne 0) { throw "Windows package extraction failed with exit code $LASTEXITCODE" }
+          ./scripts/smoke-windows-browser-lifecycle.ps1 -Root (Join-Path $Root 'DSH-Portable')
+
+  windows-bootstrap-smoke:
+    name: Windows lightweight bootstrap
+    needs: windows-build
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
+      - run: node scripts/smoke-windows-bootstrap.mjs
+
+  windows-extractor-smoke:
+    name: Windows self-extractor
+    needs: windows-build
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
+      - shell: powershell
+        run: ./scripts/smoke-windows-portable-extractor.ps1
+
+  windows-installer-smoke:
+    name: Windows installer
+    needs: windows-build
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
+      - shell: powershell
+        run: ./scripts/smoke-windows-installer.ps1
+
+  macos-build:
+    name: Build macOS (${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:
@@ -90,30 +215,16 @@ jobs:
             arch: x64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.19.0
           cache: npm
           cache-dependency-path: app/package-lock.json
-      - run: npm test
-      - name: Build macOS portable package
-        run: bash scripts/build-macos.sh "${{ matrix.arch }}"
-      - name: Verify macOS component update artifact
-        run: node scripts/verify-update-artifact.mjs "artifacts/portable-update-macos-${{ matrix.arch }}.json" "artifacts/DSH-Portable-update-macos-${{ matrix.arch }}.zip"
-      - name: Extract and smoke test macOS package
-        run: |
-          ROOT="$RUNNER_TEMP/dsh-portable-smoke"
-          mkdir -p "$ROOT"
-          ditto -x -k "artifacts/DSH-Portable-macos-${{ matrix.arch }}.zip" "$ROOT"
-          node scripts/smoke-update-artifact.mjs "$ROOT/DSH-Portable" "artifacts/portable-update-macos-${{ matrix.arch }}.json" "artifacts/DSH-Portable-update-macos-${{ matrix.arch }}.zip"
-          node scripts/smoke-portable.mjs "$ROOT/DSH-Portable"
-      - name: Mount, install, run, stop, and remove macOS DMG
-        run: bash scripts/smoke-macos-dmg.sh "artifacts/DeepSeek-Herness-macos-${{ matrix.arch }}.dmg"
-      - uses: actions/upload-artifact@v6
-        if: ${{ always() }}
+      - run: bash scripts/build-macos.sh "${{ matrix.arch }}"
+      - uses: actions/upload-artifact@v7
         with:
-          name: DSH-Portable-macos-${{ matrix.arch }}-all
+          name: macos-${{ matrix.arch }}-build
           path: |
             artifacts/DSH-Portable-macos-${{ matrix.arch }}.zip
             artifacts/DSH-Portable-macos-${{ matrix.arch }}.zip.sha256
@@ -124,3 +235,79 @@ jobs:
             artifacts/DeepSeek-Herness-macos-${{ matrix.arch }}.dmg.sha256
           if-no-files-found: error
           compression-level: 0
+
+  macos-portable-smoke:
+    name: macOS portable (${{ matrix.arch }})
+    needs: macos-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-${{ matrix.arch }}-build
+          path: artifacts
+      - run: node scripts/verify-update-artifact.mjs "artifacts/portable-update-macos-${{ matrix.arch }}.json" "artifacts/DSH-Portable-update-macos-${{ matrix.arch }}.zip"
+      - name: Extract, update, run, move, and stop portable ZIP
+        run: |
+          ROOT="$RUNNER_TEMP/dsh-portable-smoke"
+          mkdir -p "$ROOT"
+          ditto -x -k "artifacts/DSH-Portable-macos-${{ matrix.arch }}.zip" "$ROOT"
+          node scripts/smoke-update-artifact.mjs "$ROOT/DSH-Portable" "artifacts/portable-update-macos-${{ matrix.arch }}.json" "artifacts/DSH-Portable-update-macos-${{ matrix.arch }}.zip"
+          node scripts/smoke-portable.mjs "$ROOT/DSH-Portable"
+
+  macos-browser-lifecycle:
+    name: macOS browser ownership and Stop (${{ matrix.arch }})
+    needs: macos-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-${{ matrix.arch }}-build
+          path: artifacts
+      - name: Start the real portable browser and close only its owned profile
+        run: |
+          ROOT="$RUNNER_TEMP/dsh-browser-lifecycle"
+          mkdir -p "$ROOT"
+          ditto -x -k "artifacts/DSH-Portable-macos-${{ matrix.arch }}.zip" "$ROOT"
+          bash scripts/smoke-macos-browser-lifecycle.sh "$ROOT/DSH-Portable"
+
+  macos-dmg-smoke:
+    name: macOS DMG (${{ matrix.arch }})
+    needs: macos-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-${{ matrix.arch }}-build
+          path: artifacts
+      - run: bash scripts/smoke-macos-dmg.sh "artifacts/DeepSeek-Herness-macos-${{ matrix.arch }}.dmg"

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -13,8 +13,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.19.0
       - id: upstream
@@ -23,7 +23,7 @@ jobs:
         run: node scripts/check-upstream.mjs
       - name: Open or refresh the upstream review issue
         if: steps.upstream.outputs.changed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = 'Review available DeepSeek Harness upstream update'

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.1.0-rc.6-portable.6"
+  #define AppVersion "0.1.0-rc.6-portable.7"
 #endif
 
 [Setup]
@@ -36,7 +36,7 @@ SolidCompression=yes
 WizardStyle=modern
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.1.0.6
+VersionInfoVersion=0.1.0.7
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/installer/windows/DeepSeek-Herness.iss
+++ b/installer/windows/DeepSeek-Herness.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.1.0-rc.6-portable.6"
+  #define AppVersion "0.1.0-rc.6-portable.7"
 #endif
 
 [Setup]
@@ -34,7 +34,7 @@ SolidCompression=yes
 WizardStyle=modern
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.1.0.6
+VersionInfoVersion=0.1.0.7
 VersionInfoProductName=DeepSeek-Herness
 VersionInfoDescription=DeepSeek-Herness installer
 VersionInfoCompany=WSL043

--- a/launcher/macos/Info-installed.plist
+++ b/launcher/macos/Info-installed.plist
@@ -19,7 +19,7 @@
   <key>CFBundleShortVersionString</key>
   <string>0.1.0-rc.6</string>
   <key>CFBundleVersion</key>
-  <string>6</string>
+  <string>7</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/macos/Info-stop-installed.plist
+++ b/launcher/macos/Info-stop-installed.plist
@@ -19,7 +19,7 @@
   <key>CFBundleShortVersionString</key>
   <string>0.1.0-rc.6</string>
   <key>CFBundleVersion</key>
-  <string>6</string>
+  <string>7</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -19,7 +19,7 @@
   <key>CFBundleShortVersionString</key>
   <string>0.1.0-rc.6</string>
   <key>CFBundleVersion</key>
-  <string>6</string>
+  <string>7</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/portable-cli.mjs
+++ b/launcher/portable-cli.mjs
@@ -32,6 +32,8 @@ import {
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const layout = layoutForRoot(root, process.platform, process.env.DSH_PORTABLE_STATE_ROOT || root)
+const BROWSER_GRACEFUL_SHUTDOWN_MS = 5000
+const BROWSER_FORCE_SHUTDOWN_MS = 15000
 
 function requireRuntime() {
   for (const filename of [layout.nodeExe, layout.dshBin, layout.hostBin]) {
@@ -207,7 +209,7 @@ async function stopPortableBrowser() {
       // A parent browser process may already have closed the rest of its tree.
     }
   }
-  let deadline = Date.now() + 5000
+  let deadline = Date.now() + BROWSER_GRACEFUL_SHUTDOWN_MS
   let remaining = ownedBrowserProcesses()
   while (remaining.length && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 100))
@@ -215,16 +217,22 @@ async function stopPortableBrowser() {
   }
   if (remaining.length) {
     forced = true
-    for (const item of browserProcessRoots(remaining)) {
-      try {
-        terminateBrowserProcess(item, true)
-      } catch {
-        // Re-query below before deciding whether shutdown failed.
+    deadline = Date.now() + BROWSER_FORCE_SHUTDOWN_MS
+    while (remaining.length && Date.now() < deadline) {
+      for (const item of browserProcessRoots(remaining)) {
+        try {
+          terminateBrowserProcess(item, true)
+        } catch {
+          // taskkill can report a tree failure while its parent is already
+          // exiting. A direct same-user PID termination handles the newly
+          // orphaned root; ownership is re-checked before every retry.
+          if (layout.platform === 'win32') {
+            try { process.kill(Number(item.pid), 'SIGTERM') } catch {}
+          }
+        }
       }
-    }
-    deadline = Date.now() + 5000
-    while ((remaining = ownedBrowserProcesses()).length && Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      remaining = ownedBrowserProcesses()
     }
   }
   remaining = ownedBrowserProcesses()

--- a/launcher/portable-cli.mjs
+++ b/launcher/portable-cli.mjs
@@ -15,9 +15,11 @@ import {
   buildDshEnv,
   ensurePortableDirectories,
   isOwnedDshProcess,
+  isOwnedPortableBrowserProcess,
   layoutForRoot,
   migratePortableRoot,
   parseCli,
+  queryBrowserProcesses,
   queryProcess,
   writeJsonAtomic,
 } from './portable-core.mjs'
@@ -40,6 +42,14 @@ function requireRuntime() {
 function readProcessState() {
   try {
     return JSON.parse(readFileSync(layout.processState, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function readBrowserState() {
+  try {
+    return JSON.parse(readFileSync(layout.browserState, 'utf8'))
   } catch {
     return null
   }
@@ -131,18 +141,96 @@ function findBrowser() {
   return candidates.find((candidate) => candidate && existsSync(candidate)) ?? null
 }
 
-function openBrowser(url) {
+async function openBrowser(url) {
   const executable = findBrowser()
   if (!executable) {
     const fallback = process.platform === 'darwin'
       ? { command: 'open', args: [url] }
       : { command: 'cmd.exe', args: ['/d', '/s', '/c', 'start', '', url] }
     spawn(fallback.command, fallback.args, { detached: true, stdio: 'ignore', windowsHide: true }).unref()
+    rmSync(layout.browserState, { force: true })
     return { portableProfile: false, executable: 'default-browser' }
   }
   const spec = browserLaunchSpec(executable, url, layout)
-  spawn(spec.command, spec.args, { detached: true, stdio: 'ignore', windowsHide: false }).unref()
-  return { portableProfile: true, executable }
+  const child = spawn(spec.command, spec.args, { detached: true, stdio: 'ignore', windowsHide: false })
+  await new Promise((resolve, reject) => {
+    child.once('spawn', resolve)
+    child.once('error', reject)
+  })
+  child.unref()
+  await writeJsonAtomic(layout.browserState, {
+    schemaVersion: 1,
+    pid: child.pid,
+    executable,
+    profile: layout.browserProfile,
+    url,
+    startedAt: new Date().toISOString(),
+  })
+  return { portableProfile: true, executable, pid: child.pid }
+}
+
+function ownedBrowserProcesses() {
+  return queryBrowserProcesses(layout.platform).filter((item) => (
+    isOwnedPortableBrowserProcess(item, layout)
+  ))
+}
+
+function browserProcessRoots(items) {
+  const owned = new Set(items.map((item) => Number(item.pid)))
+  const roots = items.filter((item) => !owned.has(Number(item.parentPid)))
+  return roots.length ? roots : items.slice(0, 1)
+}
+
+function terminateBrowserProcess(processInfo, force) {
+  const pid = Number(processInfo.pid)
+  if (layout.platform === 'win32') {
+    const args = ['/PID', String(pid), '/T']
+    if (force) args.push('/F')
+    execFileSync('taskkill.exe', args, { encoding: 'utf8', windowsHide: true })
+  } else {
+    const processGroupId = Number(processInfo.processGroupId)
+    const target = Number.isSafeInteger(processGroupId) && processGroupId > 0 && processGroupId === pid
+      ? -processGroupId
+      : pid
+    process.kill(target, force ? 'SIGKILL' : 'SIGTERM')
+  }
+}
+
+async function stopPortableBrowser() {
+  const recorded = Boolean(readBrowserState())
+  const initial = ownedBrowserProcesses()
+  let forced = false
+  for (const item of browserProcessRoots(initial)) {
+    try {
+      terminateBrowserProcess(item, false)
+    } catch {
+      // A parent browser process may already have closed the rest of its tree.
+    }
+  }
+  let deadline = Date.now() + 5000
+  let remaining = ownedBrowserProcesses()
+  while (remaining.length && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    remaining = ownedBrowserProcesses()
+  }
+  if (remaining.length) {
+    forced = true
+    for (const item of browserProcessRoots(remaining)) {
+      try {
+        terminateBrowserProcess(item, true)
+      } catch {
+        // Re-query below before deciding whether shutdown failed.
+      }
+    }
+    deadline = Date.now() + 5000
+    while ((remaining = ownedBrowserProcesses()).length && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+  }
+  remaining = ownedBrowserProcesses()
+  if (remaining.length) throw new Error(`Portable browser processes did not stop: ${remaining.map((item) => item.pid).join(', ')}`)
+  rmSync(layout.browserState, { force: true })
+  return { found: initial.length, stopped: initial.length, forced, recorded }
 }
 
 function logSize(filename) {
@@ -170,7 +258,7 @@ async function start(noBrowser) {
   const prior = readProcessState()
   if (ownedState(prior) && await httpReady(prior.port)) {
     const url = `http://127.0.0.1:${prior.port}`
-    const browser = noBrowser ? null : openBrowser(url)
+    const browser = noBrowser ? null : await openBrowser(url)
     return { status: 'already-running', pid: prior.pid, port: prior.port, url, browser, migration }
   }
   if (prior) {
@@ -234,15 +322,23 @@ async function start(noBrowser) {
   }
 
   const url = `http://127.0.0.1:${port}`
-  const browser = noBrowser ? null : openBrowser(url)
+  const browser = noBrowser ? null : await openBrowser(url)
   return { status: 'started', pid: child.pid, port, url, browser, migration }
 }
 
 async function stop() {
+  let browser = null
+  let browserError = null
+  try {
+    browser = await stopPortableBrowser()
+  } catch (error) {
+    browserError = error
+  }
   const state = readProcessState()
   if (!ownedState(state)) {
     rmSync(layout.processState, { force: true })
-    return { status: 'not-running' }
+    if (browserError) throw browserError
+    return { status: browser?.stopped ? 'stopped' : 'not-running', browser }
   }
   let gracefulRequested = false
   gracefulRequested = await requestGracefulShutdown(state)
@@ -263,7 +359,8 @@ async function stop() {
   if (ownedState(state)) throw new Error(`DSH process ${state.pid} did not stop.`)
   rmSync(layout.processState, { force: true })
   if (process.platform !== 'win32' && state.controlPipe) rmSync(state.controlPipe, { force: true })
-  return { status: 'stopped', pid: state.pid, port: state.port, graceful: gracefulRequested && !forced, forced }
+  if (browserError) throw browserError
+  return { status: 'stopped', pid: state.pid, port: state.port, graceful: gracefulRequested && !forced, forced, browser }
 }
 
 async function status() {
@@ -281,7 +378,7 @@ async function status() {
 async function openExisting() {
   const current = await status()
   if (current.status !== 'running') return start(false)
-  return { ...current, browser: openBrowser(current.url) }
+  return { ...current, browser: await openBrowser(current.url) }
 }
 
 async function checkUpdate(options) {
@@ -332,7 +429,7 @@ async function update(options) {
       },
     })
     const running = await status()
-    const browser = !options.noBrowser && running.status === 'running' ? openBrowser(running.url) : null
+    const browser = !options.noBrowser && running.status === 'running' ? await openBrowser(running.url) : null
     return { ...applied, running, browser }
   } catch (error) {
     await deferUpdate(layout).catch(() => {})

--- a/launcher/portable-core.mjs
+++ b/launcher/portable-core.mjs
@@ -20,6 +20,7 @@ export function layoutForRoot(root, platform = process.platform, stateRoot = roo
     root: portableRoot,
     appDir,
     browserProfile: paths.join(dataDir, 'browser'),
+    browserState: paths.join(stateDir, 'browser.json'),
     dataDir,
     dshBin: paths.join(appDir, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js'),
     dshHome: paths.join(dataDir, 'dsh-home'),
@@ -121,6 +122,60 @@ function commandIncludesComparablePath(commandLine, expected, platform = process
   return [...comparableAliases(expected, platform)].some((alias) => commandLine.includes(alias))
 }
 
+function commandHasExactPathArgument(commandLine, flag, expected, platform = process.platform) {
+  const source = platform === 'win32'
+    ? String(commandLine ?? '').replaceAll('/', '\\').toLowerCase()
+    : String(commandLine ?? '').replaceAll('\\', '/')
+  for (const alias of comparableAliases(expected, platform)) {
+    for (const prefix of [`${flag}=`, `"${flag}=`, `'${flag}=`]) {
+      for (const value of [alias, `"${alias}`, `'${alias}`]) {
+        const needle = `${prefix}${value}`
+        let index = source.indexOf(needle)
+        while (index >= 0) {
+          const next = source[index + needle.length]
+          if (!next || /[\s"']/.test(next)) return true
+          index = source.indexOf(needle, index + 1)
+        }
+      }
+    }
+  }
+  return false
+}
+
+function supportedBrowserExecutable(filename, platform = process.platform) {
+  if (!filename) return false
+  const paths = platform === 'win32' ? path.win32 : path.posix
+  const name = paths.basename(String(filename)).toLowerCase()
+  if (platform === 'win32') return name === 'chrome.exe' || name === 'msedge.exe'
+  return name === 'google chrome' || name === 'microsoft edge'
+}
+
+function supportedBrowserCommandLine(commandLine, platform = process.platform) {
+  if (platform === 'win32') return false
+  const source = String(commandLine ?? '').toLowerCase()
+  return source.includes('/google chrome.app/contents/macos/google chrome')
+    || source.includes('/microsoft edge.app/contents/macos/microsoft edge')
+}
+
+export function isOwnedPortableBrowserProcess(processInfo, layout, executable = '') {
+  if (!processInfo) return false
+  const platform = layout.platform ?? process.platform
+  const commandLine = String(processInfo.commandLine ?? '')
+  if (!commandHasExactPathArgument(commandLine, '--user-data-dir', layout.browserProfile, platform)) return false
+  if (executable) {
+    if (platform === 'win32' && processInfo.executablePath && !sameComparablePath(processInfo.executablePath, executable, platform)) return false
+    if ((platform !== 'win32' || !processInfo.executablePath) && !commandIncludesComparablePath(
+      platform === 'win32' ? commandLine.replaceAll('/', '\\').toLowerCase() : commandLine.replaceAll('\\', '/'),
+      executable,
+      platform,
+    )) return false
+    return supportedBrowserExecutable(executable, platform)
+  }
+  return supportedBrowserExecutable(processInfo.executablePath, platform)
+    || supportedBrowserExecutable(processInfo.processName, platform)
+    || supportedBrowserCommandLine(commandLine, platform)
+}
+
 export function isOwnedDshProcess(processInfo, layout, port) {
   if (!processInfo) return false
   const platform = layout.platform ?? process.platform
@@ -165,6 +220,55 @@ export function queryWindowsProcess(pid) {
   } catch {
     return null
   }
+}
+
+export function queryWindowsBrowserProcesses(adapters = {}) {
+  const script = [
+    '$utf8 = New-Object System.Text.UTF8Encoding($false)',
+    '[Console]::OutputEncoding = $utf8',
+    '$OutputEncoding = $utf8',
+    '$items = @(Get-CimInstance Win32_Process -Filter "Name = \'chrome.exe\' OR Name = \'msedge.exe\'" -ErrorAction SilentlyContinue | ForEach-Object {',
+    '  [pscustomobject]@{ pid=[int]$_.ProcessId; parentPid=[int]$_.ParentProcessId; processName=$_.Name; executablePath=$_.ExecutablePath; commandLine=$_.CommandLine }',
+    '})',
+    '$items | ConvertTo-Json -Compress',
+  ].join('; ')
+  try {
+    const execute = adapters.execute ?? execFileSync
+    const output = execute('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf8',
+      windowsHide: true,
+    }).trim()
+    const parsed = output ? JSON.parse(output) : []
+    return Array.isArray(parsed) ? parsed : [parsed]
+  } catch (error) {
+    throw new Error('Could not inspect browser processes on Windows.', { cause: error })
+  }
+}
+
+export function queryPosixBrowserProcesses(adapters = {}) {
+  try {
+    const execute = adapters.execute ?? execFileSync
+    const output = execute('ps', ['-ww', '-A', '-o', 'pid=,ppid=,pgid=,command='], { encoding: 'utf8' })
+    return output.split(/\r?\n/).map((line) => {
+      const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/)
+      if (!match) return null
+      const commandLine = match[4]
+      const executablePath = commandLine.match(/^(?:"([^"]+)"|'([^']+)'|(\S+))/)?.slice(1).find(Boolean) ?? ''
+      return {
+        pid: Number(match[1]),
+        parentPid: Number(match[2]),
+        processGroupId: Number(match[3]),
+        executablePath,
+        commandLine,
+      }
+    }).filter(Boolean)
+  } catch (error) {
+    throw new Error('Could not inspect browser processes on macOS.', { cause: error })
+  }
+}
+
+export function queryBrowserProcesses(platform = process.platform, adapters = {}) {
+  return platform === 'win32' ? queryWindowsBrowserProcesses(adapters) : queryPosixBrowserProcesses(adapters)
 }
 
 export function queryPosixProcess(pid) {

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -22,8 +22,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.1.0.6")]
-[assembly: System.Reflection.AssemblyFileVersion("0.1.0.6")]
+[assembly: System.Reflection.AssemblyVersion("0.1.0.7")]
+[assembly: System.Reflection.AssemblyFileVersion("0.1.0.7")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -13,8 +13,8 @@ using System.Windows.Forms;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.1.0.6")]
-[assembly: AssemblyFileVersion("0.1.0.6")]
+[assembly: AssemblyVersion("0.1.0.7")]
+[assembly: AssemblyFileVersion("0.1.0.7")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.1.0-rc.6-portable.6",
+  "version": "0.1.0-rc.6-portable.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -98,7 +98,7 @@ cat > "$STAGE/licenses/COMPONENTS.json" <<EOF
   "nodeVersion": "$NODE_VERSION",
   "nodeSha256": "$NODE_SHA256",
   "updaterSchema": 1,
-  "shellSchema": 1
+  "shellSchema": 2
 }
 EOF
 
@@ -148,7 +148,7 @@ cat > "$UPDATE_MANIFEST" <<EOF
   "portableVersion": "$PORTABLE_VERSION",
   "platform": "macos-$ARCH",
   "minimumUpdaterSchema": 1,
-  "requiredShellSchema": 1,
+  "requiredShellSchema": 2,
   "component": {
     "kind": "dsh-app",
     "dshVersion": "$DSH_VERSION",

--- a/scripts/build-windows-inno.ps1
+++ b/scripts/build-windows-inno.ps1
@@ -1,0 +1,124 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('portable', 'installer')]
+    [string]$Kind,
+    [Parameter(Mandatory = $true)]
+    [string]$Archive,
+    [string]$OutputDir,
+    [string]$IsccPath
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$ProjectRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$Archive = [System.IO.Path]::GetFullPath($Archive)
+if (-not $OutputDir) { $OutputDir = Join-Path $ProjectRoot 'artifacts' }
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+if (-not (Test-Path -LiteralPath $Archive -PathType Leaf)) { throw "Windows base archive is missing: $Archive" }
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+if (-not $IsccPath) {
+    $Command = Get-Command ISCC.exe -ErrorAction SilentlyContinue
+    if ($Command) { $IsccPath = $Command.Source }
+}
+if (-not $IsccPath) {
+    foreach ($Candidate in @(
+        (Join-Path $env:ProgramFiles 'Inno Setup 7\ISCC.exe'),
+        (Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 7\ISCC.exe')
+    )) {
+        if ($Candidate -and (Test-Path -LiteralPath $Candidate -PathType Leaf)) {
+            $IsccPath = $Candidate
+            break
+        }
+    }
+}
+if (-not $IsccPath -or -not (Test-Path -LiteralPath $IsccPath -PathType Leaf)) {
+    throw 'An Inno Setup 7 compiler (ISCC.exe) is required.'
+}
+$IsccVersion = [string]((& $IsccPath '--version' | Select-Object -First 1))
+$IsccVersionMatch = [regex]::Match($IsccVersion.Trim(), '^(?<major>\d+)\.')
+if ($LASTEXITCODE -ne 0 -or -not $IsccVersionMatch.Success -or [int]$IsccVersionMatch.Groups['major'].Value -lt 7) {
+    throw "Inno Setup 7 or newer is required; found '$IsccVersion'."
+}
+
+$PortableVersion = (Get-Content -Raw -LiteralPath (Join-Path $ProjectRoot 'package.json') | ConvertFrom-Json).version
+$BuildId = [Guid]::NewGuid().ToString('N')
+$TempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$WorkRoot = [System.IO.Path]::GetFullPath((Join-Path $TempRoot ("dsh-inno-$Kind-$BuildId")))
+if (-not $WorkRoot.StartsWith($TempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Unsafe installer staging directory: $WorkRoot"
+}
+$Stage = Join-Path $WorkRoot 'DSH-Portable'
+$CompilerOutput = Join-Path $WorkRoot 'output'
+$MappedDrive = $null
+$Mapped = $false
+
+try {
+    New-Item -ItemType Directory -Force -Path $WorkRoot, $CompilerOutput | Out-Null
+    & tar.exe -x -f $Archive -C $WorkRoot
+    if ($LASTEXITCODE -ne 0) { throw "Windows base archive extraction failed with exit code $LASTEXITCODE" }
+    if (-not (Test-Path -LiteralPath (Join-Path $Stage 'DeepSeek-Herness.exe') -PathType Leaf)) {
+        throw 'The Windows base archive does not contain a complete DSH-Portable stage.'
+    }
+
+    if ($Kind -eq 'installer') {
+        Copy-Item -Force -LiteralPath (Join-Path $ProjectRoot 'templates\INSTALLED-README.txt') -Destination (Join-Path $Stage 'README.txt')
+        [System.IO.File]::WriteAllText(
+            (Join-Path $Stage 'installed-mode.json'),
+            (([ordered]@{ stateRoot = '%LOCALAPPDATA%\DeepSeek-Herness'; schemaVersion = 1 } | ConvertTo-Json) + [Environment]::NewLine),
+            [System.Text.UTF8Encoding]::new($false)
+        )
+    }
+
+    foreach ($Letter in @('R', 'Q', 'P', 'O', 'N', 'M')) {
+        $CandidateDrive = "${Letter}:"
+        if (-not (Test-Path -LiteralPath ($CandidateDrive + '\'))) {
+            $MappedDrive = $CandidateDrive
+            break
+        }
+    }
+    if (-not $MappedDrive) { throw 'No unused drive letter is available for the installer build.' }
+    & subst.exe $MappedDrive $WorkRoot
+    if ($LASTEXITCODE -ne 0) { throw "Could not map the installer staging drive ($MappedDrive)." }
+    $Mapped = $true
+
+    $MappedRoot = $MappedDrive + '\'
+    $MappedStage = Join-Path $MappedRoot 'DSH-Portable'
+    $MappedOutput = Join-Path $MappedRoot 'output'
+    if ($Kind -eq 'portable') {
+        $SetupScript = Join-Path $ProjectRoot 'installer\windows\DSH-Portable.iss'
+        $OutputName = 'DSH-Portable-windows-x64-offline.exe'
+    } else {
+        $SetupScript = Join-Path $ProjectRoot 'installer\windows\DeepSeek-Herness.iss'
+        $OutputName = 'DeepSeek-Herness-Setup.exe'
+    }
+
+    $Arguments = @(
+        "/DStage=$MappedStage",
+        "/DOutputDir=$MappedOutput",
+        "/DProjectRoot=$ProjectRoot",
+        "/DAppVersion=$PortableVersion",
+        $SetupScript
+    )
+    & $IsccPath $Arguments
+    if ($LASTEXITCODE -ne 0) { throw "Inno Setup $Kind build failed with exit code $LASTEXITCODE" }
+
+    $Candidate = Join-Path $CompilerOutput $OutputName
+    if (-not (Test-Path -LiteralPath $Candidate -PathType Leaf)) { throw "Inno Setup did not produce $OutputName." }
+    $Destination = Join-Path $OutputDir $OutputName
+    Copy-Item -Force -LiteralPath $Candidate -Destination $Destination
+    $Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $Destination).Hash.ToLowerInvariant()
+    "$Hash  $OutputName" | Set-Content -LiteralPath ($Destination + '.sha256') -Encoding ascii -NoNewline
+
+    [pscustomobject]@{ Kind = $Kind; Artifact = $Destination; Sha256 = $Hash }
+} finally {
+    if ($Mapped) {
+        & subst.exe $MappedDrive /D
+        if ($LASTEXITCODE -ne 0) { Write-Warning "Could not release temporary installer drive $MappedDrive" }
+    }
+    if (Test-Path -LiteralPath $WorkRoot) {
+        Remove-Item -LiteralPath $WorkRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -125,7 +125,7 @@ try {
         nodeVersion = $Lock.node.version
         nodeSha256 = $Runtime.sha256
         updaterSchema = 1
-        shellSchema = 1
+        shellSchema = 2
     }
     [System.IO.File]::WriteAllText(
         (Join-Path $Stage 'licenses\COMPONENTS.json'),
@@ -208,7 +208,7 @@ try {
             portableVersion = $PortableVersion
             platform = 'windows-x64'
             minimumUpdaterSchema = 1
-            requiredShellSchema = 1
+            requiredShellSchema = 2
             component = [ordered]@{
                 kind = 'dsh-app'
                 dshVersion = $Lock.dsh.version

--- a/scripts/smoke-macos-browser-lifecycle.sh
+++ b/scripts/smoke-macos-browser-lifecycle.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "${1:?usage: smoke-macos-browser-lifecycle.sh <extracted-DSH-Portable-root>}" && pwd)"
+NODE="$ROOT/runtime/node/bin/node"
+CLI="$ROOT/launcher/portable-cli.mjs"
+START="$ROOT/DSH-Portable.app/Contents/MacOS/DSH-Portable"
+STOP="$ROOT/Stop DSH-Portable.command"
+PROFILE="$ROOT/data/browser"
+DECOY_PROFILE="$ROOT/data/browser-decoy"
+BROWSER_STATE="$ROOT/data/runtime/browser.json"
+HOST_STATE="$ROOT/data/runtime/process.json"
+
+for file in "$NODE" "$CLI" "$START" "$STOP"; do
+  [[ -e "$file" ]] || { echo "Missing package entry: $file" >&2; exit 1; }
+done
+
+CHROME='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+EDGE='/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
+if [[ -x "$CHROME" ]]; then
+  BROWSER="$CHROME"
+elif [[ -x "$EDGE" ]]; then
+  BROWSER="$EDGE"
+else
+  echo 'Chrome or Edge is required for the browser lifecycle smoke.' >&2
+  exit 1
+fi
+
+owned_pids() {
+  "$NODE" --input-type=module - "$ROOT" <<'NODE'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+const root = process.argv[2]
+const { isOwnedPortableBrowserProcess, layoutForRoot, queryPosixBrowserProcesses } = await import(
+  pathToFileURL(path.join(root, 'launcher', 'portable-core.mjs')).href
+)
+const layout = layoutForRoot(root, 'darwin')
+for (const item of queryPosixBrowserProcesses()) {
+  if (isOwnedPortableBrowserProcess(item, layout)) console.log(item.pid)
+}
+NODE
+}
+
+profile_pids() {
+  local profile="$1"
+  ps -ww -A -o pid=,command= | awk -v needle="--user-data-dir=$profile" 'index($0, needle) { print $1 }'
+}
+
+wait_for_owned_browser() {
+  local deadline=$((SECONDS + 20))
+  while (( SECONDS < deadline )); do
+    if [[ -n "$(owned_pids)" ]]; then return 0; fi
+    sleep 0.2
+  done
+  return 1
+}
+
+kill_profile() {
+  local profile="$1"
+  local pid
+  while read -r pid; do
+    [[ -n "$pid" ]] && kill -TERM "$pid" 2>/dev/null || true
+  done < <(profile_pids "$profile")
+}
+
+cleanup() {
+  "$NODE" "$CLI" stop --json >/dev/null 2>&1 || true
+  kill_profile "$DECOY_PROFILE"
+  kill_profile "$PROFILE"
+}
+trap cleanup EXIT
+
+mkdir -p "$ROOT/data/dsh-home" "$ROOT/workspace"
+printf 'browser-lifecycle-data\n' > "$ROOT/data/dsh-home/browser-lifecycle-sentinel.txt"
+printf 'browser-lifecycle-workspace\n' > "$ROOT/workspace/browser-lifecycle-sentinel.txt"
+DATA_HASH="$(shasum -a 256 "$ROOT/data/dsh-home/browser-lifecycle-sentinel.txt" | awk '{print $1}')"
+WORKSPACE_HASH="$(shasum -a 256 "$ROOT/workspace/browser-lifecycle-sentinel.txt" | awk '{print $1}')"
+
+"$START"
+wait_for_owned_browser || { echo 'The portable browser did not start with its owned profile.' >&2; exit 1; }
+[[ -f "$BROWSER_STATE" ]] || { echo 'The portable browser state was not recorded.' >&2; exit 1; }
+OWNED_OBSERVED="$(owned_pids | wc -l | tr -d ' ')"
+
+"$BROWSER" --headless=new --disable-gpu --no-first-run --user-data-dir="$DECOY_PROFILE" about:blank >/dev/null 2>&1 &
+DECOY_PID=$!
+sleep 1
+kill -0 "$DECOY_PID" 2>/dev/null || { echo 'The unrelated browser profile did not stay alive.' >&2; exit 1; }
+
+# Simulate an older package that left its browser alive without browser.json.
+rm -f "$BROWSER_STATE"
+"$STOP"
+
+[[ -z "$(owned_pids)" ]] || { echo 'Portable browser processes remained after Stop.' >&2; exit 1; }
+kill -0 "$DECOY_PID" 2>/dev/null || { echo 'Stop terminated an unrelated browser profile.' >&2; exit 1; }
+STATUS="$($NODE "$CLI" status --json)"
+printf '%s' "$STATUS" | "$NODE" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{if(JSON.parse(s).status!=="stopped")process.exit(1)})'
+[[ ! -e "$HOST_STATE" ]] || { echo 'Host process state remained after Stop.' >&2; exit 1; }
+[[ ! -e "$BROWSER_STATE" ]] || { echo 'Browser process state remained after Stop.' >&2; exit 1; }
+[[ "$(shasum -a 256 "$ROOT/data/dsh-home/browser-lifecycle-sentinel.txt" | awk '{print $1}')" == "$DATA_HASH" ]]
+[[ "$(shasum -a 256 "$ROOT/workspace/browser-lifecycle-sentinel.txt" | awk '{print $1}')" == "$WORKSPACE_HASH" ]]
+
+printf '{"platform":"darwin","browserProcessesObserved":%s,"status":"passed"}\n' "$OWNED_OBSERVED"

--- a/scripts/smoke-windows-browser-lifecycle.ps1
+++ b/scripts/smoke-windows-browser-lifecycle.ps1
@@ -52,7 +52,16 @@ function Invoke-Launcher {
         [string[]]$Arguments = @(),
         [int]$TimeoutMilliseconds = 90000
     )
-    $Process = Start-Process -FilePath $FilePath -ArgumentList $Arguments -WorkingDirectory $Root -WindowStyle Hidden -PassThru
+    $StartParameters = @{
+        FilePath = $FilePath
+        WorkingDirectory = $Root
+        WindowStyle = 'Hidden'
+        PassThru = $true
+    }
+    # Windows PowerShell 5.1 rejects an explicitly empty -ArgumentList even
+    # though PowerShell 7 accepts the same call.
+    if ($Arguments.Count -gt 0) { $StartParameters.ArgumentList = $Arguments }
+    $Process = Start-Process @StartParameters
     if (-not $Process.WaitForExit($TimeoutMilliseconds)) {
         & taskkill.exe /PID $Process.Id /T /F 2>&1 | ForEach-Object { Write-Host $_ }
         $Process.WaitForExit(10000) | Out-Null
@@ -72,14 +81,14 @@ try {
     if ((Get-PortableBrowserProcesses).Count -ne 0) { throw 'browser lifecycle smoke started with an owned browser already running' }
 
     Invoke-Launcher -FilePath $StartExe -Arguments @('start', '--json')
+    $BrowserState = Join-Path $Root 'data\runtime\browser.json'
     $Deadline = [DateTime]::UtcNow.AddSeconds(45)
     do {
         $OwnedBrowsers = @(Get-PortableBrowserProcesses)
-        if ($OwnedBrowsers.Count -gt 0) { break }
+        if ($OwnedBrowsers.Count -gt 0 -and (Test-Path -LiteralPath $BrowserState)) { break }
         Start-Sleep -Milliseconds 250
     } while ([DateTime]::UtcNow -lt $Deadline)
     if ($OwnedBrowsers.Count -eq 0) { throw 'DeepSeek-Herness.exe did not launch a browser with the portable profile' }
-    $BrowserState = Join-Path $Root 'data\runtime\browser.json'
     if (-not (Test-Path -LiteralPath $BrowserState)) { throw 'portable browser ownership state was not recorded' }
 
     $BrowserExecutable = $OwnedBrowsers[0].ExecutablePath

--- a/scripts/smoke-windows-browser-lifecycle.ps1
+++ b/scripts/smoke-windows-browser-lifecycle.ps1
@@ -1,0 +1,138 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Root
+)
+
+$ErrorActionPreference = 'Stop'
+$Root = [System.IO.Path]::GetFullPath($Root)
+$StartExe = Join-Path $Root 'DeepSeek-Herness.exe'
+$StopExe = Join-Path $Root 'Stop DeepSeek-Herness.exe'
+$PortableNode = Join-Path $Root 'runtime\node\node.exe'
+$PortableCli = Join-Path $Root 'launcher\portable-cli.mjs'
+$BrowserProfile = Join-Path $Root 'data\browser'
+$DecoyProfile = Join-Path $Root 'data\browser-decoy'
+$WorkspaceMarker = Join-Path $Root 'workspace\browser-lifecycle-smoke.txt'
+$HomeMarker = Join-Path $Root 'data\dsh-home\browser-lifecycle-smoke.txt'
+
+foreach ($File in @($StartExe, $StopExe, $PortableNode, $PortableCli)) {
+    if (-not (Test-Path -LiteralPath $File)) { throw "Portable file is missing: $File" }
+}
+
+function Get-BrowserProcessesForProfile {
+    param([Parameter(Mandatory = $true)] [string]$Profile)
+    $EscapedProfile = [regex]::Escape($Profile.Replace('/', '\'))
+    $Pattern = '(?i)--user-data-dir="?{0}(?:"|\s|$)' -f $EscapedProfile
+    @(
+        Get-CimInstance Win32_Process -Filter "Name = 'chrome.exe' OR Name = 'msedge.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -and $_.CommandLine.Replace('/', '\') -match $Pattern }
+    )
+}
+
+function Get-PortableBrowserProcesses { @(Get-BrowserProcessesForProfile -Profile $BrowserProfile) }
+
+function Stop-BrowserProfileFixture {
+    param([Parameter(Mandatory = $true)] [string]$Profile)
+    for ($Attempt = 0; $Attempt -lt 3; $Attempt++) {
+        $Processes = @(Get-BrowserProcessesForProfile -Profile $Profile)
+        if ($Processes.Count -eq 0) { return }
+        $Ids = @{}; foreach ($Process in $Processes) { $Ids[[int]$Process.ProcessId] = $true }
+        $Roots = @($Processes | Where-Object { -not $Ids.ContainsKey([int]$_.ParentProcessId) })
+        if ($Roots.Count -eq 0) { $Roots = @($Processes[0]) }
+        foreach ($Process in $Roots) {
+            & taskkill.exe /PID $Process.ProcessId /T /F 2>$null | Out-Null
+        }
+        Start-Sleep -Milliseconds 250
+    }
+}
+
+function Invoke-Launcher {
+    param(
+        [Parameter(Mandatory = $true)] [string]$FilePath,
+        [string[]]$Arguments = @(),
+        [int]$TimeoutMilliseconds = 90000
+    )
+    $Process = Start-Process -FilePath $FilePath -ArgumentList $Arguments -WorkingDirectory $Root -WindowStyle Hidden -PassThru
+    if (-not $Process.WaitForExit($TimeoutMilliseconds)) {
+        & taskkill.exe /PID $Process.Id /T /F 2>&1 | ForEach-Object { Write-Host $_ }
+        $Process.WaitForExit(10000) | Out-Null
+        throw "$([System.IO.Path]::GetFileName($FilePath)) timed out."
+    }
+    $Process.Refresh()
+    if ($Process.ExitCode -ne 0) { throw "$([System.IO.Path]::GetFileName($FilePath)) exited with code $($Process.ExitCode)." }
+}
+
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $WorkspaceMarker), (Split-Path -Parent $HomeMarker) | Out-Null
+[System.IO.File]::WriteAllText($WorkspaceMarker, 'workspace survives browser shutdown', [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText($HomeMarker, 'home survives browser shutdown', [System.Text.UTF8Encoding]::new($false))
+$WorkspaceDigest = (Get-FileHash -Algorithm SHA256 -LiteralPath $WorkspaceMarker).Hash
+$HomeDigest = (Get-FileHash -Algorithm SHA256 -LiteralPath $HomeMarker).Hash
+
+try {
+    if ((Get-PortableBrowserProcesses).Count -ne 0) { throw 'browser lifecycle smoke started with an owned browser already running' }
+
+    Invoke-Launcher -FilePath $StartExe -Arguments @('start', '--json')
+    $Deadline = [DateTime]::UtcNow.AddSeconds(45)
+    do {
+        $OwnedBrowsers = @(Get-PortableBrowserProcesses)
+        if ($OwnedBrowsers.Count -gt 0) { break }
+        Start-Sleep -Milliseconds 250
+    } while ([DateTime]::UtcNow -lt $Deadline)
+    if ($OwnedBrowsers.Count -eq 0) { throw 'DeepSeek-Herness.exe did not launch a browser with the portable profile' }
+    $BrowserState = Join-Path $Root 'data\runtime\browser.json'
+    if (-not (Test-Path -LiteralPath $BrowserState)) { throw 'portable browser ownership state was not recorded' }
+
+    $BrowserExecutable = $OwnedBrowsers[0].ExecutablePath
+    $DecoyArguments = @('--headless=new', 'about:blank', "--user-data-dir=`"$DecoyProfile`"", '--no-first-run')
+    Start-Process -FilePath $BrowserExecutable -ArgumentList $DecoyArguments -WorkingDirectory $Root -WindowStyle Hidden | Out-Null
+    $Deadline = [DateTime]::UtcNow.AddSeconds(20)
+    do {
+        $DecoyBrowsers = @(Get-BrowserProcessesForProfile -Profile $DecoyProfile)
+        if ($DecoyBrowsers.Count -gt 0) { break }
+        Start-Sleep -Milliseconds 250
+    } while ([DateTime]::UtcNow -lt $Deadline)
+    if ($DecoyBrowsers.Count -eq 0) { throw 'could not start the unrelated browser-profile safety fixture' }
+
+    # Simulate an already-open browser inherited from a pre-fix package. The
+    # Stop launcher must recover ownership from the exact profile path even
+    # when no browser.json record is available.
+    Remove-Item -LiteralPath $BrowserState -Force
+
+    $StatusJson = & $PortableNode $PortableCli status --json
+    if ($LASTEXITCODE -ne 0) { throw 'portable status command failed after start' }
+    $Status = $StatusJson | ConvertFrom-Json
+    if ($Status.status -ne 'running') { throw "portable host is not running after start: $($Status.status)" }
+
+    Invoke-Launcher -FilePath $StopExe
+    $Deadline = [DateTime]::UtcNow.AddSeconds(15)
+    do {
+        $RemainingBrowsers = @(Get-PortableBrowserProcesses)
+        if ($RemainingBrowsers.Count -eq 0) { break }
+        Start-Sleep -Milliseconds 250
+    } while ([DateTime]::UtcNow -lt $Deadline)
+    if ($RemainingBrowsers.Count -ne 0) {
+        throw "Stop DeepSeek-Herness.exe left portable browser processes running: $($RemainingBrowsers.ProcessId -join ', ')"
+    }
+    if (@(Get-BrowserProcessesForProfile -Profile $DecoyProfile).Count -eq 0) {
+        throw 'Stop DeepSeek-Herness.exe terminated an unrelated browser profile'
+    }
+
+    $StoppedJson = & $PortableNode $PortableCli status --json
+    if ($LASTEXITCODE -ne 0) { throw 'portable status command failed after stop' }
+    $Stopped = $StoppedJson | ConvertFrom-Json
+    if ($Stopped.status -ne 'stopped') { throw "portable host is still active after stop: $($Stopped.status)" }
+    if (Test-Path -LiteralPath (Join-Path $Root 'data\runtime\process.json')) { throw 'host process state remained after stop' }
+    if (Test-Path -LiteralPath (Join-Path $Root 'data\runtime\browser.json')) { throw 'browser process state remained after stop' }
+    if ((Get-FileHash -Algorithm SHA256 -LiteralPath $WorkspaceMarker).Hash -ne $WorkspaceDigest) { throw 'workspace data changed during browser shutdown' }
+    if ((Get-FileHash -Algorithm SHA256 -LiteralPath $HomeMarker).Hash -ne $HomeDigest) { throw 'DSH_HOME data changed during browser shutdown' }
+
+    [pscustomobject]@{
+        Root = $Root
+        BrowserProcessesObserved = $OwnedBrowsers.Count
+        Status = 'passed'
+    }
+} finally {
+    & $PortableNode $PortableCli stop --json 2>$null | Out-Null
+    Stop-BrowserProfileFixture -Profile $BrowserProfile
+    Stop-BrowserProfileFixture -Profile $DecoyProfile
+}

--- a/scripts/smoke-windows-browser-lifecycle.ps1
+++ b/scripts/smoke-windows-browser-lifecycle.ps1
@@ -132,7 +132,13 @@ try {
         Status = 'passed'
     }
 } finally {
-    & $PortableNode $PortableCli stop --json 2>$null | Out-Null
-    Stop-BrowserProfileFixture -Profile $BrowserProfile
-    Stop-BrowserProfileFixture -Profile $DecoyProfile
+    $PreviousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        & $PortableNode $PortableCli stop --json *> $null
+        Stop-BrowserProfileFixture -Profile $BrowserProfile
+        Stop-BrowserProfileFixture -Profile $DecoyProfile
+    } finally {
+        $ErrorActionPreference = $PreviousErrorActionPreference
+    }
 }

--- a/scripts/verify-update-artifact.mjs
+++ b/scripts/verify-update-artifact.mjs
@@ -39,7 +39,12 @@ async function main() {
 
   const manifest = JSON.parse(await readFile(manifestFile, 'utf8'))
   if (manifest.schemaVersion !== 1 || !manifest.portableVersion || !manifest.platform) fail('Update manifest is incomplete.')
-  if (manifest.minimumUpdaterSchema !== 1 || manifest.requiredShellSchema !== 1) fail('Update compatibility metadata is incomplete.')
+  const minimumUpdaterSchema = Number(manifest.minimumUpdaterSchema)
+  const requiredShellSchema = Number(manifest.requiredShellSchema)
+  if (!Number.isSafeInteger(minimumUpdaterSchema) || minimumUpdaterSchema < 1
+    || !Number.isSafeInteger(requiredShellSchema) || requiredShellSchema < 1) {
+    fail('Update compatibility metadata is incomplete.')
+  }
   const component = manifest.component
   if (!component || component.kind !== 'dsh-app' || !component.requiredNodeVersion) fail('Update component metadata is incomplete.')
 

--- a/templates/RELEASE-NOTES.md
+++ b/templates/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 > 打包官方 DeepSeek Harness 预览版（`@deepseek-ai/dsh 0.1.0-rc.6`）。DSH-Portable 是独立社区分发项目。
 
+本次更新修复了停止入口只关闭后台服务、却留下便携浏览器运行的问题。Windows 的
+`Stop DeepSeek-Herness.exe` 与 macOS 的 `Stop DSH-Portable.command` 现在会同时关闭
+本文件夹专属的浏览器窗口，且不会影响其他 Chrome 或 Edge 窗口。
+
 ## Windows x64（推荐）
 
 [**下载轻量启动器**](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe)
@@ -39,8 +43,8 @@ macOS 包采用临时签名，没有经过 Apple 公证。首次启动可能需�
 保留会话、设置、凭据和工作区；只有运行环境发生兼容性变化时才提示下载完整包。
 新版无法正常启动时会自动恢复更新前的版本。
 
-旧版本还没有这项更新能力，需要手动下载本版本一次；安装本版本后，后续兼容更新
-即可由启动器完成。
+本次更新包含便携启动器修复，已有版本会提示下载一次完整包；安装本版本后，
+后续兼容更新仍可由启动器只下载变化的 DSH 应用组件。
 
 轻量启动器会自动验证首次下载；普通用户不需要手动处理校验文件。离线完整包
 包含官方、未修改的 DSH 运行时、固定版本 Node.js、原生模块和所需许可证。

--- a/tests/portable-contract.test.mjs
+++ b/tests/portable-contract.test.mjs
@@ -11,12 +11,15 @@ import {
   acquireLaunchLock,
   browserLaunchSpec,
   buildDshEnv,
+  isOwnedPortableBrowserProcess,
   isOwnedDshProcess,
   isOwnedLauncherProcess,
   layoutForRoot,
   migratePortableRoot,
   parseCli,
   projectKey,
+  queryPosixBrowserProcesses,
+  queryWindowsBrowserProcesses,
   queryWindowsProcess,
 } from '../launcher/portable-core.mjs'
 
@@ -32,6 +35,7 @@ test('all durable application paths stay under the movable root', () => {
   }
   assert.equal(layout.dshHome, path.win32.join(usbRoot, 'data', 'dsh-home'))
   assert.equal(layout.browserProfile, path.win32.join(usbRoot, 'data', 'browser'))
+  assert.equal(layout.browserState, path.win32.join(usbRoot, 'data', 'runtime', 'browser.json'))
   assert.equal(layout.workspace, path.win32.join(usbRoot, 'workspace'))
 })
 
@@ -75,6 +79,69 @@ test('browser app profile moves with the portable folder', () => {
   assert.ok(spec.args.includes('--app=http://127.0.0.1:3080'))
   assert.ok(spec.args.includes(`--user-data-dir=${layout.browserProfile}`))
   assert.ok(spec.args.includes('--no-first-run'))
+})
+
+test('browser ownership requires both a supported executable and the exact portable profile', () => {
+  const layout = layoutForRoot(usbRoot, 'win32')
+  const executable = path.win32.join('C:\\Program Files', 'Google', 'Chrome', 'Application', 'chrome.exe')
+  const owned = {
+    pid: 4100,
+    executablePath: executable,
+    commandLine: `"${executable}" --app=http://127.0.0.1:3080 "--user-data-dir=${layout.browserProfile}" --no-first-run`,
+  }
+  assert.equal(isOwnedPortableBrowserProcess(owned, layout, executable), true)
+  assert.equal(isOwnedPortableBrowserProcess({
+    ...owned,
+    commandLine: `"${executable}" --app=http://127.0.0.1:3080 "--user-data-dir=${layout.browserProfile}-other"`,
+  }, layout, executable), false)
+  assert.equal(isOwnedPortableBrowserProcess({
+    ...owned,
+    executablePath: 'C:\\Windows\\System32\\notepad.exe',
+  }, layout, executable), false)
+  assert.equal(isOwnedPortableBrowserProcess({
+    ...owned,
+    executablePath: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+    commandLine: `pwsh.exe -Command "inspect ${layout.browserProfile}"`,
+  }, layout), false)
+  assert.equal(isOwnedPortableBrowserProcess({
+    ...owned,
+    executablePath: '',
+    processName: 'chrome.exe',
+  }, layout), true)
+  assert.equal(isOwnedPortableBrowserProcess({
+    ...owned,
+    executablePath: '',
+    processName: 'pwsh.exe',
+  }, layout), false)
+})
+
+test('macOS browser ownership accepts the unquoted application command reported by ps', () => {
+  const layout = layoutForRoot('/Volumes/Portable Disk/DSH-Portable', 'darwin')
+  const executable = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+  const commandLine = `${executable} --app=http://127.0.0.1:3080 --user-data-dir=${layout.browserProfile}`
+  assert.equal(isOwnedPortableBrowserProcess({
+    pid: 4200,
+    executablePath: '/Applications/Google',
+    commandLine,
+  }, layout, executable), true)
+  assert.equal(isOwnedPortableBrowserProcess({
+    pid: 4201,
+    executablePath: '/Applications/Google',
+    commandLine: commandLine.replace(layout.browserProfile, `${layout.browserProfile}-other`),
+  }, layout, executable), false)
+})
+
+test('macOS browser inspection records process groups for safe tree shutdown', () => {
+  const rows = queryPosixBrowserProcesses({
+    execute() {
+      return ' 4200  1 4200 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/owned\n'
+        + ' 4201 4200 4200 /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Helper --type=renderer\n'
+    },
+  })
+  assert.deepEqual(rows.map(({ pid, parentPid, processGroupId }) => ({ pid, parentPid, processGroupId })), [
+    { pid: 4200, parentPid: 1, processGroupId: 4200 },
+    { pid: 4201, parentPid: 4200, processGroupId: 4200 },
+  ])
 })
 
 test('CLI defaults to start and supports bounded automation flags', () => {
@@ -143,6 +210,12 @@ test('Windows process inspection preserves Unicode command-line paths', { skip: 
   const info = queryWindowsProcess(child.pid)
   assert.ok(info)
   assert.match(info.commandLine, new RegExp(marker))
+})
+
+test('browser process inspection fails closed when the operating-system query fails', () => {
+  assert.throws(() => queryWindowsBrowserProcesses({
+    execute() { throw new Error('CIM unavailable') },
+  }), /could not inspect browser processes/i)
 })
 
 test('Windows process ownership treats short and long path aliases as the same files', { skip: process.platform !== 'win32' }, () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -11,7 +11,7 @@ const exists = async (name) => access(path.join(root, name)).then(() => true, ()
 test('the public product identity is DSH-Portable everywhere users see it', async () => {
   const manifest = JSON.parse(await read('package.json'))
   assert.equal(manifest.name, 'dsh-portable')
-  assert.match(manifest.version, /^0\.1\.0-rc\.6-portable\.\d+$/)
+  assert.equal(manifest.version, '0.1.0-rc.6-portable.7')
 
   const chineseReadme = await read('README.md')
   const englishReadme = await read('README.en.md')
@@ -71,7 +71,7 @@ test('update guidance describes the component update path without exposing inter
   assert.match(userReadme, /只下载.+DSH.+组件/s)
   assert.match(userReadme, /English[\s\S]+downloads only\s+the changed DSH application component/i)
   assert.match(releaseNotes, /启动时检查更新/)
-  assert.match(releaseNotes, /旧版本.+手动下载本版本一次.+后续.+启动器/s)
+  assert.match(releaseNotes, /本次更新.+完整包.+后续.+DSH 应用组件/s)
   assert.doesNotMatch(`${chinese}\n${english}\n${userReadme}\n${releaseNotes}`, /update-core|updaterSchema|shellSchema|journal/i)
 })
 
@@ -149,6 +149,9 @@ test('Windows package exposes real GUI executables with matching icon and no pat
   assert.match(build, /portable-update-windows-x64\.json/)
   assert.match(build, /updaterSchema/)
   assert.match(build, /shellSchema/)
+  assert.match(build, /shellSchema\s*=\s*2/)
+  assert.match(build, /requiredShellSchema\s*=\s*2/)
+  assert.match(source, /AssemblyFileVersion\("0\.1\.0\.7"\)/)
   assert.match(bootstrap, /ZipArchive/)
   assert.doesNotMatch(bootstrap, /tar\.exe/i)
   assert.doesNotMatch(build, /community\.1|DeepSeek Harness\.cmd/)
@@ -265,6 +268,9 @@ test('macOS package is a movable signed app shell for both supported architectur
   assert.match(build, /DSH-Portable-macos-\$ARCH\.zip/)
   assert.match(build, /DSH-Portable-update-macos-\$ARCH\.zip/)
   assert.match(build, /portable-update-macos-\$ARCH\.json/)
+  assert.match(build, /"shellSchema": 2/)
+  assert.match(build, /"requiredShellSchema": 2/)
+  assert.match(plist, /<key>CFBundleVersion<\/key>\s*<string>7<\/string>/s)
   assert.match(app, /check-update/)
   assert.match(app, /defer-update/)
   assert.doesNotMatch(app, /\$\(\$NODE\b/)
@@ -291,6 +297,9 @@ test('macOS DMG carries a self-contained app and keeps installed data outside it
 
 test('CI executes contracts and real package smoke tests on Windows and both Mac architectures', async () => {
   const workflow = await read('.github/workflows/ci.yml')
+  const upstreamWorkflow = await read('.github/workflows/upstream-watch.yml')
+  const browserLifecycleSmoke = await read('scripts/smoke-windows-browser-lifecycle.ps1')
+  const macBrowserLifecycleSmoke = await read('scripts/smoke-macos-browser-lifecycle.sh')
   const bootstrapSmoke = await read('scripts/smoke-windows-bootstrap.mjs')
   const updateSmoke = await read('scripts/smoke-update-artifact.mjs')
   for (const runner of ['windows-latest', 'macos-15', 'macos-15-intel']) assert.match(workflow, new RegExp(runner))
@@ -300,9 +309,14 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.match(workflow, /smoke-windows-bootstrap\.mjs/)
   assert.match(workflow, /tar\.exe -x -f artifacts\/DSH-Portable-windows-x64-offline\.zip/)
   assert.doesNotMatch(workflow, /Expand-Archive/)
-  assert.match(workflow, /actions\/checkout@v6/)
-  assert.match(workflow, /actions\/setup-node@v6/)
-  assert.match(workflow, /actions\/upload-artifact@v6/)
+  assert.match(workflow, /actions\/checkout@v7/)
+  assert.match(workflow, /actions\/setup-node@v7/)
+  assert.match(workflow, /actions\/upload-artifact@v7/)
+  assert.match(workflow, /actions\/download-artifact@v8/)
+  assert.match(upstreamWorkflow, /actions\/checkout@v7/)
+  assert.match(upstreamWorkflow, /actions\/setup-node@v7/)
+  assert.match(upstreamWorkflow, /actions\/github-script@v9/)
+  assert.doesNotMatch(`${workflow}\n${upstreamWorkflow}`, /actions\/(?:checkout|setup-node|upload-artifact|download-artifact|github-script)@v[1-6]\b/)
   assert.match(workflow, /innosetup-7\.1\.0-x64\.exe/)
   assert.match(workflow, /0362a383ed217d4c4239b5933866dd96d3eb2102737da92f80f6057a4b40df2f/)
   assert.match(workflow, /Get-FileHash[\s\S]+SHA256/)
@@ -310,7 +324,6 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.match(workflow, /-IsccPath \$env:ISCC_PATH/)
   assert.doesNotMatch(workflow, /choco install innosetup/)
   assert.match(workflow, /compression-level:\s*0/)
-  assert.match(workflow, /if:\s*\$\{\{ always\(\) \}\}/)
   assert.match(bootstrapSmoke, /DSH-Portable-windows-x64\.exe/)
   assert.match(bootstrapSmoke, /中文 空格/)
   assert.match(bootstrapSmoke, /\.dsh-portable-install-/)
@@ -326,6 +339,39 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
     workflow.indexOf('node scripts/smoke-update-artifact.mjs') < workflow.indexOf('node scripts/smoke-portable.mjs'),
     'the update smoke must run before the movable-root smoke renames the package',
   )
+  for (const job of [
+    'workflow-lint:',
+    'contracts:',
+    'windows-build:',
+    'windows-portable-smoke:',
+    'windows-browser-lifecycle:',
+    'windows-extractor-smoke:',
+    'windows-installer-smoke:',
+    'macos-build:',
+    'macos-portable-smoke:',
+    'macos-browser-lifecycle:',
+    'macos-dmg-smoke:',
+  ]) assert.match(workflow, new RegExp(`^  ${job.replace(':', '\\:')}`, 'm'))
+  assert.match(workflow, /actionlint_1\.7\.12_linux_amd64\.tar\.gz/)
+  assert.match(workflow, /8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8/)
+  assert.match(workflow, /\.\/actionlint/)
+  assert.match(workflow, /windows-browser-lifecycle:[\s\S]+needs:\s*windows-build/)
+  assert.match(workflow, /smoke-windows-browser-lifecycle\.ps1/)
+  assert.match(browserLifecycleSmoke, /DeepSeek-Herness\.exe/)
+  assert.match(browserLifecycleSmoke, /Stop DeepSeek-Herness\.exe/)
+  assert.match(browserLifecycleSmoke, /data\\browser/)
+  assert.match(browserLifecycleSmoke, /Get-CimInstance Win32_Process/)
+  assert.match(browserLifecycleSmoke, /browser-decoy/)
+  assert.match(browserLifecycleSmoke, /terminated an unrelated browser profile/)
+  assert.doesNotMatch(browserLifecycleSmoke, /--no-browser/)
+  assert.match(workflow, /macos-browser-lifecycle:[\s\S]+needs:\s*macos-build/)
+  assert.match(workflow, /smoke-macos-browser-lifecycle\.sh/)
+  assert.match(macBrowserLifecycleSmoke, /DSH-Portable\.app\/Contents\/MacOS\/DSH-Portable/)
+  assert.match(macBrowserLifecycleSmoke, /Stop DSH-Portable\.command/)
+  assert.match(macBrowserLifecycleSmoke, /data\/browser/)
+  assert.match(macBrowserLifecycleSmoke, /browser-decoy/)
+  assert.match(macBrowserLifecycleSmoke, /terminated an unrelated browser profile/)
+  assert.doesNotMatch(macBrowserLifecycleSmoke, /DSH_PORTABLE_NO_BROWSER|--no-browser/)
 })
 
 test('Node runtime lock covers Windows and both Mac CPU families', async () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -159,6 +159,8 @@ test('Windows package exposes real GUI executables with matching icon and no pat
   const cli = await read('launcher/portable-cli.mjs')
   assert.match(cli, /rollbackPendingAppUpdate\(layout,\s*\{[\s\S]+beforeRestore:[\s\S]+ownedState\(current\)[\s\S]+await stop\(\)/)
   assert.match(cli, /catch \(error\) \{[\s\S]+await deferUpdate\(layout\)\.catch/)
+  assert.match(cli, /BROWSER_FORCE_SHUTDOWN_MS\s*=\s*15000/)
+  assert.match(cli, /terminateBrowserProcess\(item, true\)[\s\S]+process\.kill\(Number\(item\.pid\)/)
 })
 
 test('Windows setup is a per-user offline installer with durable data outside the app', async () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -245,7 +245,7 @@ test('Windows portable self-extractor stays offline, movable, and registration-f
   assert.match(workflow, /smoke-windows-portable-extractor\.ps1/)
   assert.match(workflow, /artifacts\/DSH-Portable-windows-x64\.exe/)
   assert.match(workflow, /artifacts\/DSH-Portable-windows-x64\.exe\.sha256/)
-  assert.match(workflow, /artifacts\/DSH-Portable-windows-x64-offline\.exe/)
+  assert.match(workflow, /filename:\s*DSH-Portable-windows-x64-offline\.exe/)
   assert.match(workflow, /artifacts\/portable-manifest\.json/)
   assert.match(workflow, /artifacts\/DSH-Portable-update-windows-x64\.zip/)
   assert.match(workflow, /artifacts\/portable-update-windows-x64\.json/)
@@ -345,6 +345,7 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
     'workflow-lint:',
     'contracts:',
     'windows-build:',
+    'windows-inno-build:',
     'windows-portable-smoke:',
     'windows-browser-lifecycle:',
     'windows-extractor-smoke:',
@@ -359,12 +360,21 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.match(workflow, /\.\/actionlint/)
   assert.match(workflow, /windows-browser-lifecycle:[\s\S]+needs:\s*windows-build/)
   assert.match(workflow, /smoke-windows-browser-lifecycle\.ps1/)
+  const windowsBaseJob = workflow.match(/\n  windows-build:[\s\S]+?(?=\n  [a-z][\w-]+:)/)?.[0] || ''
+  const windowsInnoJob = workflow.match(/\n  windows-inno-build:[\s\S]+?(?=\n  [a-z][\w-]+:)/)?.[0] || ''
+  assert.doesNotMatch(windowsBaseJob, /BuildInstaller|ISCC|Inno Setup/)
+  assert.match(windowsInnoJob, /needs:\s*windows-build/)
+  assert.match(windowsInnoJob, /strategy:[\s\S]+matrix:[\s\S]+kind:\s*portable[\s\S]+kind:\s*installer/)
+  assert.match(windowsInnoJob, /build-windows-inno\.ps1/)
+  assert.match(workflow, /windows-extractor-smoke:[\s\S]+needs:\s*windows-inno-build[\s\S]+name:\s*windows-x64-extractor/)
+  assert.match(workflow, /windows-installer-smoke:[\s\S]+needs:\s*windows-inno-build[\s\S]+name:\s*windows-x64-installer/)
   assert.match(browserLifecycleSmoke, /DeepSeek-Herness\.exe/)
   assert.match(browserLifecycleSmoke, /Stop DeepSeek-Herness\.exe/)
   assert.match(browserLifecycleSmoke, /data\\browser/)
   assert.match(browserLifecycleSmoke, /Get-CimInstance Win32_Process/)
   assert.match(browserLifecycleSmoke, /browser-decoy/)
   assert.match(browserLifecycleSmoke, /terminated an unrelated browser profile/)
+  assert.match(browserLifecycleSmoke, /if \(\$Arguments\.Count -gt 0\)/)
   assert.doesNotMatch(browserLifecycleSmoke, /--no-browser/)
   assert.match(workflow, /macos-browser-lifecycle:[\s\S]+needs:\s*macos-build/)
   assert.match(workflow, /smoke-macos-browser-lifecycle\.sh/)

--- a/tests/update-artifact-verifier.test.mjs
+++ b/tests/update-artifact-verifier.test.mjs
@@ -10,7 +10,7 @@ import { promisify } from 'node:util'
 const execFileAsync = promisify(execFile)
 const projectRoot = path.resolve(import.meta.dirname, '..')
 
-async function buildFixture(root, { componentsOverrides = {} } = {}) {
+async function buildFixture(root, { componentsOverrides = {}, requiredShellSchema = 1 } = {}) {
   const source = path.join(root, 'source')
   const archive = path.join(root, 'DSH-Portable-update-windows-x64.zip')
   await mkdir(path.join(source, 'app', 'node_modules', '@deepseek-ai', 'dsh', 'lib'), { recursive: true })
@@ -32,7 +32,7 @@ async function buildFixture(root, { componentsOverrides = {} } = {}) {
     platform: 'windows-x64',
     nodeVersion: '24.19.0',
     updaterSchema: 1,
-    shellSchema: 1,
+    shellSchema: requiredShellSchema,
     ...componentsOverrides,
   })}\n`)
   await writeFile(path.join(source, 'licenses', 'DeepSeek-Harness-LICENSE.txt'), 'license\n')
@@ -46,7 +46,7 @@ async function buildFixture(root, { componentsOverrides = {} } = {}) {
     portableVersion: metadata.portableVersion,
     platform: 'windows-x64',
     minimumUpdaterSchema: 1,
-    requiredShellSchema: 1,
+    requiredShellSchema,
     component: {
       kind: metadata.kind,
       dshVersion: metadata.dshVersion,
@@ -90,6 +90,21 @@ test('release update verifier proves the exact component archive matches its man
       mismatched.manifest,
       mismatched.archive,
     ]), /metadata/i)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('release update verifier accepts a newer positive shell compatibility boundary', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-update-shell-schema-'))
+  try {
+    const fixture = await buildFixture(root, { requiredShellSchema: 2 })
+    const result = await execFileAsync(process.execPath, [
+      path.join(projectRoot, 'scripts', 'verify-update-artifact.mjs'),
+      fixture.manifest,
+      fixture.archive,
+    ])
+    assert.equal(JSON.parse(result.stdout).status, 'verified')
   } finally {
     await rm(root, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- close only the Chrome or Edge process tree owned by this portable folder when using the Windows or macOS Stop entry
- recover browser processes left by older packages even when their browser state file is missing
- split package builds from parallel update, movable-folder, browser, installer, extractor, and DMG smoke jobs
- add real browser lifecycle gates on Windows and both macOS architectures, plus workflow linting
- publish the shell compatibility boundary as portable.7 so existing packages request one complete-package update

## Local verification
- 63 Node contract tests passed
- actionlint 1.7.12 passed for both workflows
- final Windows ZIP update artifact verified
- real Windows start/browser/Stop test passed while an unrelated browser profile stayed alive
- component update + injected rollback passed
- movable-folder, Unicode/long-path, offline reuse, and lightweight bootstrap smokes passed