### PR TITLE
Refine native tray and downloads

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,7 +20,7 @@ body:
     id: version
     attributes:
       label: DSH-Portable 版本 / Version
-      placeholder: 例如 / e.g. 0.2.1
+      placeholder: 例如 / e.g. 0.2.2
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,9 @@ jobs:
           tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $Root
           if ($LASTEXITCODE -ne 0) { throw "Windows package extraction failed with exit code $LASTEXITCODE" }
           ./scripts/smoke-windows-desktop-host.ps1 -Root (Join-Path $Root 'DSH-Portable')
+          ./scripts/smoke-windows-native-tray.ps1 -Root (Join-Path $Root 'DSH-Portable')
           node scripts/smoke-windows-tray-bridge.mjs (Join-Path $Root 'DSH-Portable')
+          node scripts/smoke-windows-native-download.mjs (Join-Path $Root 'DSH-Portable')
 
   windows-bootstrap-smoke:
     name: Windows lightweight bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,14 @@ jobs:
           ./scripts/smoke-windows-desktop-host.ps1 -Root (Join-Path $Root 'DSH-Portable')
           ./scripts/smoke-windows-native-tray.ps1 -Root (Join-Path $Root 'DSH-Portable')
           node scripts/smoke-windows-tray-bridge.mjs (Join-Path $Root 'DSH-Portable')
-          node scripts/smoke-windows-native-download.mjs (Join-Path $Root 'DSH-Portable')
+          # WebView2 can keep the previous user-data browser process alive after
+          # its host exits. Verify downloads from a separately extracted product
+          # root so the debugging arguments cannot be swallowed by that process.
+          $DownloadRoot = Join-Path $env:RUNNER_TEMP 'dsh-native-download-host'
+          New-Item -ItemType Directory -Force -Path $DownloadRoot | Out-Null
+          tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $DownloadRoot
+          if ($LASTEXITCODE -ne 0) { throw "Windows download-smoke extraction failed with exit code $LASTEXITCODE" }
+          node scripts/smoke-windows-native-download.mjs (Join-Path $DownloadRoot 'DSH-Portable')
 
   windows-bootstrap-smoke:
     name: Windows lightweight bootstrap

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.2.1"
+  #define AppVersion "0.2.2"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.2.1.65534
+VersionInfoVersion=0.2.2.65534
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/installer/windows/DeepSeek-Herness.iss
+++ b/installer/windows/DeepSeek-Herness.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.2.1"
+  #define AppVersion "0.2.2"
 #endif
 
 [Setup]
@@ -36,7 +36,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.2.1.65534
+VersionInfoVersion=0.2.2.65534
 VersionInfoProductName=DeepSeek-Herness
 VersionInfoDescription=DeepSeek-Herness installer
 VersionInfoCompany=WSL043

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.2.1"
+version = "0.2.2"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info-installed.plist
+++ b/launcher/macos/Info-installed.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>0.2.2</string>
   <key>CFBundleVersion</key>
-	<string>2001999</string>
+	<string>2002999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/macos/Info-stop-installed.plist
+++ b/launcher/macos/Info-stop-installed.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>0.2.2</string>
   <key>CFBundleVersion</key>
-	<string>2001999</string>
+	<string>2002999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>0.2.2</string>
   <key>CFBundleVersion</key>
-	<string>2001999</string>
+	<string>2002999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -22,8 +22,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.2.1.65534")]
-[assembly: System.Reflection.AssemblyFileVersion("0.2.1.65534")]
+[assembly: System.Reflection.AssemblyVersion("0.2.2.65534")]
+[assembly: System.Reflection.AssemblyFileVersion("0.2.2.65534")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -7,8 +7,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.2.1.65534")]
-[assembly: AssemblyFileVersion("0.2.1.65534")]
+[assembly: AssemblyVersion("0.2.2.65534")]
+[assembly: AssemblyFileVersion("0.2.2.65534")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -20,8 +20,8 @@ using Microsoft.Web.WebView2.WinForms;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.2.1.65534")]
-[assembly: AssemblyFileVersion("0.2.1.65534")]
+[assembly: AssemblyVersion("0.2.2.65534")]
+[assembly: AssemblyFileVersion("0.2.2.65534")]
 
 namespace DshPortable
 {
@@ -88,6 +88,140 @@ namespace DshPortable
         public override Color MenuItemPressedGradientEnd { get { return Selected; } }
         public override Color SeparatorDark { get { return Border; } }
         public override Color SeparatorLight { get { return Surface; } }
+    }
+
+    internal sealed class DownloadProgressWindow : Form
+    {
+        private readonly CoreWebView2DownloadOperation operation;
+        private readonly bool chinese;
+        private readonly Label status;
+        private readonly Label details;
+        private readonly ProgressBar progress;
+        private readonly Button cancel;
+        private readonly Button reveal;
+        private readonly Button open;
+        private bool terminal;
+
+        internal DownloadProgressWindow(CoreWebView2DownloadOperation download, bool isChinese)
+        {
+            operation = download;
+            chinese = isChinese;
+            Text = T("下载", "Download");
+            ShowInTaskbar = false;
+            StartPosition = FormStartPosition.CenterParent;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            ClientSize = new Size(500, 170);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            Padding = new Padding(20);
+            Font = new Font("Segoe UI", 9.5F, FontStyle.Regular, GraphicsUnit.Point);
+            AccessibleName = T("下载进度", "Download progress");
+
+            status = new Label { Location = new Point(20, 18), Size = new Size(460, 28), AutoEllipsis = true, Font = new Font("Segoe UI Semibold", 10F, FontStyle.Bold) };
+            details = new Label { Location = new Point(20, 50), Size = new Size(460, 24), AutoEllipsis = true, ForeColor = Color.FromArgb(92, 94, 99) };
+            progress = new ProgressBar { Location = new Point(20, 82), Size = new Size(460, 7), Style = ProgressBarStyle.Marquee, MarqueeAnimationSpeed = 20 };
+            cancel = new Button { Location = new Point(364, 112), Size = new Size(116, 34), Text = T("取消下载", "Cancel download"), AccessibleName = T("取消下载", "Cancel download") };
+            reveal = new Button { Location = new Point(244, 112), Size = new Size(112, 34), Text = T("打开文件夹", "Show in folder"), AccessibleName = T("打开文件夹", "Show in folder"), Visible = false };
+            open = new Button { Location = new Point(124, 112), Size = new Size(112, 34), Text = T("打开文件", "Open file"), AccessibleName = T("打开文件", "Open file"), Visible = false };
+            cancel.Click += delegate { if (!terminal) operation.Cancel(); else Close(); };
+            reveal.Click += delegate { RevealFile(operation.ResultFilePath); };
+            open.Click += delegate { OpenFile(operation.ResultFilePath); };
+            Controls.Add(status);
+            Controls.Add(details);
+            Controls.Add(progress);
+            Controls.Add(cancel);
+            Controls.Add(reveal);
+            Controls.Add(open);
+            operation.BytesReceivedChanged += OnDownloadChanged;
+            operation.EstimatedEndTimeChanged += OnDownloadChanged;
+            operation.StateChanged += OnDownloadChanged;
+            FormClosed += delegate
+            {
+                operation.BytesReceivedChanged -= OnDownloadChanged;
+                operation.EstimatedEndTimeChanged -= OnDownloadChanged;
+                operation.StateChanged -= OnDownloadChanged;
+            };
+            UpdateState();
+        }
+
+        private string T(string zh, string en) { return chinese ? zh : en; }
+
+        private void OnDownloadChanged(object sender, object eventArgs)
+        {
+            if (IsDisposed) return;
+            if (InvokeRequired) { BeginInvoke((MethodInvoker)UpdateState); return; }
+            UpdateState();
+        }
+
+        private void UpdateState()
+        {
+            if (IsDisposed) return;
+            string filename = Path.GetFileName(operation.ResultFilePath);
+            CoreWebView2DownloadState state = operation.State;
+            terminal = state != CoreWebView2DownloadState.InProgress;
+            if (state == CoreWebView2DownloadState.Completed)
+            {
+                status.Text = T("下载完成", "Download complete") + " · " + filename;
+                details.Text = operation.ResultFilePath;
+                progress.Style = ProgressBarStyle.Continuous;
+                progress.Value = 100;
+                open.Visible = true;
+                reveal.Visible = true;
+                cancel.Text = T("关闭", "Close");
+                return;
+            }
+            if (state == CoreWebView2DownloadState.Interrupted)
+            {
+                status.Text = T("下载未完成", "Download did not finish") + " · " + filename;
+                details.Text = operation.InterruptReason.ToString();
+                progress.Style = ProgressBarStyle.Continuous;
+                progress.Value = 0;
+                cancel.Text = T("关闭", "Close");
+                return;
+            }
+
+            status.Text = T("正在下载", "Downloading") + " · " + filename;
+            ulong? total = operation.TotalBytesToReceive;
+            long received = operation.BytesReceived;
+            if (total.HasValue && total.Value > 0)
+            {
+                progress.Style = ProgressBarStyle.Continuous;
+                progress.Value = (int)Math.Max(0, Math.Min(100, (received * 100L) / (long)Math.Min(total.Value, (ulong)long.MaxValue)));
+                details.Text = FormatBytes(received) + " / " + FormatBytes((long)Math.Min(total.Value, (ulong)long.MaxValue));
+            }
+            else
+            {
+                progress.Style = ProgressBarStyle.Marquee;
+                details.Text = FormatBytes(received);
+            }
+        }
+
+        private static string FormatBytes(long value)
+        {
+            double bytes = Math.Max(0, value);
+            if (bytes >= 1024 * 1024 * 1024) return (bytes / (1024 * 1024 * 1024)).ToString("0.0") + " GB";
+            if (bytes >= 1024 * 1024) return (bytes / (1024 * 1024)).ToString("0.0") + " MB";
+            if (bytes >= 1024) return (bytes / 1024).ToString("0.0") + " KB";
+            return bytes.ToString("0") + " B";
+        }
+
+        private static void OpenFile(string filename)
+        {
+            if (String.IsNullOrWhiteSpace(filename) || !File.Exists(filename)) return;
+            Process.Start(new ProcessStartInfo(filename) { UseShellExecute = true });
+        }
+
+        private static void RevealFile(string filename)
+        {
+            if (String.IsNullOrWhiteSpace(filename)) return;
+            Process.Start(new ProcessStartInfo("explorer.exe", "/select," + Quote(filename)) { UseShellExecute = true });
+        }
+
+        private static string Quote(string value)
+        {
+            return "\"" + value.Replace("\"", "\\\"") + "\"";
+        }
     }
 
     internal sealed class LauncherWindow : Form
@@ -160,6 +294,10 @@ namespace DshPortable
             launcherArgs = ResolveArguments(args);
             nonInteractive = Array.Exists(launcherArgs, item =>
                 string.Equals(item, "--json", StringComparison.OrdinalIgnoreCase));
+            bool testHidden = String.Equals(
+                Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_HIDDEN"),
+                "1",
+                StringComparison.Ordinal);
             desktopStart = !nonInteractive && IsStartCommand(launcherArgs);
 
             Text = "DeepSeek-Herness";
@@ -168,8 +306,8 @@ namespace DshPortable
             FormBorderStyle = FormBorderStyle.FixedSingle;
             MaximizeBox = false;
             MinimizeBox = desktopStart;
-            ShowInTaskbar = !nonInteractive;
-            if (nonInteractive) Opacity = 0;
+            ShowInTaskbar = !nonInteractive && !testHidden;
+            if (nonInteractive || testHidden) Opacity = 0;
             ClientSize = desktopStart ? new Size(560, 220) : new Size(440, 160);
             MinimumSize = Size.Empty;
             BackColor = SystemColors.Window;
@@ -350,7 +488,10 @@ namespace DshPortable
                 ContextMenuStrip = trayMenu,
                 Visible = false,
             };
-            trayIcon.DoubleClick += delegate { RestoreFromTray(); };
+            trayIcon.MouseClick += delegate(object sender, MouseEventArgs eventArgs)
+            {
+                if (eventArgs.Button == MouseButtons.Left) RestoreFromTray();
+            };
 
             webView = new WebView2 { Dock = DockStyle.Fill, Visible = false };
             Controls.Add(webView);
@@ -434,7 +575,9 @@ namespace DshPortable
         private static string MenuTitle(string value)
         {
             string text = String.IsNullOrWhiteSpace(value) ? L("未命名会话", "Untitled session") : value.Trim();
-            if (text.Length > 52) text = text.Substring(0, 51) + "…";
+            const int limit = 35;
+            int[] starts = StringInfo.ParseCombiningCharacters(text);
+            if (starts.Length > limit) text = text.Substring(0, starts[limit]).TrimEnd() + "…";
             return text.Replace("&", "&&");
         }
 
@@ -442,7 +585,11 @@ namespace DshPortable
         {
             if (!String.IsNullOrEmpty(session.pendingInteraction)) return L("待回复", "Needs input");
             if (session.running) return L("运行中", "Running");
-            return String.IsNullOrWhiteSpace(session.agentPreset) ? "" : session.agentPreset.Trim();
+            string preset = String.IsNullOrWhiteSpace(session.agentPreset) ? "" : session.agentPreset.Trim();
+            if (preset.Equals("coding", StringComparison.OrdinalIgnoreCase)) return L("编码", "Coding");
+            if (preset.Equals("plan", StringComparison.OrdinalIgnoreCase)) return L("计划", "Plan");
+            if (preset.Equals("review", StringComparison.OrdinalIgnoreCase)) return L("复核", "Review");
+            return preset;
         }
 
         private ToolStripMenuItem CreateSessionMenuItem(TrayBridgeSession session)
@@ -1261,11 +1408,13 @@ namespace DshPortable
             }
 
             applicationUri = new Uri(url);
-            webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
+            webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+            webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
             webView.CoreWebView2.Settings.AreDevToolsEnabled = false;
             webView.CoreWebView2.WebMessageReceived += OnWebMessageReceived;
             webView.CoreWebView2.NewWindowRequested += OnNewWindowRequested;
             webView.CoreWebView2.NavigationStarting += OnNavigationStarting;
+            webView.CoreWebView2.DownloadStarting += OnDownloadStarting;
             TaskCompletionSource<CoreWebView2NavigationCompletedEventArgs> navigation =
                 new TaskCompletionSource<CoreWebView2NavigationCompletedEventArgs>();
             EventHandler<CoreWebView2NavigationCompletedEventArgs> navigationCompleted = delegate(object sender, CoreWebView2NavigationCompletedEventArgs eventArgs)
@@ -1312,6 +1461,74 @@ namespace DshPortable
             eventArgs.Cancel = true;
             OpenExternalUrl(eventArgs.Uri);
         }
+
+        private void OnDownloadStarting(object sender, CoreWebView2DownloadStartingEventArgs eventArgs)
+        {
+            eventArgs.Handled = true;
+            string suggested = Path.GetFileName(eventArgs.ResultFilePath);
+            if (String.IsNullOrWhiteSpace(suggested)) suggested = L("下载文件", "download");
+            string downloads = GetDefaultDownloadFolder();
+            string testDirectory = Environment.GetEnvironmentVariable("DSH_PORTABLE_DOWNLOAD_DIRECTORY");
+            if (!String.IsNullOrWhiteSpace(testDirectory))
+            {
+                string resolved = Path.GetFullPath(testDirectory);
+                if (!Directory.Exists(resolved)) throw new DirectoryNotFoundException(resolved);
+                eventArgs.ResultFilePath = Path.Combine(resolved, suggested);
+            }
+            else using (SaveFileDialog dialog = new SaveFileDialog
+            {
+                AddExtension = true,
+                CheckPathExists = true,
+                FileName = suggested,
+                Filter = L("所有文件 (*.*)|*.*", "All files (*.*)|*.*"),
+                InitialDirectory = Directory.Exists(downloads) ? downloads : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                OverwritePrompt = true,
+                RestoreDirectory = true,
+                Title = L("保存下载文件", "Save download"),
+            })
+            {
+                if (dialog.ShowDialog(this) != DialogResult.OK)
+                {
+                    eventArgs.Cancel = true;
+                    return;
+                }
+                eventArgs.ResultFilePath = dialog.FileName;
+            }
+
+            if (String.Equals(Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_HIDDEN"), "1", StringComparison.Ordinal)) return;
+
+            DownloadProgressWindow window = new DownloadProgressWindow(
+                eventArgs.DownloadOperation,
+                uiLanguage.Equals("zh", StringComparison.OrdinalIgnoreCase));
+            BeginInvoke((MethodInvoker)delegate
+            {
+                if (Visible) window.Show(this);
+                else window.Show();
+            });
+        }
+
+        private static string GetDefaultDownloadFolder()
+        {
+            Guid downloadsFolder = new Guid("374DE290-123F-4565-9164-39C4925E467B");
+            IntPtr path = IntPtr.Zero;
+            try
+            {
+                if (SHGetKnownFolderPath(ref downloadsFolder, 0, IntPtr.Zero, out path) == 0 && path != IntPtr.Zero)
+                {
+                    string value = Marshal.PtrToStringUni(path);
+                    if (!String.IsNullOrWhiteSpace(value)) return value;
+                }
+            }
+            catch { }
+            finally
+            {
+                if (path != IntPtr.Zero) Marshal.FreeCoTaskMem(path);
+            }
+            return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+        private static extern int SHGetKnownFolderPath(ref Guid folderId, uint flags, IntPtr token, out IntPtr path);
 
         private static void OpenExternalUrl(string url)
         {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -1396,6 +1396,13 @@ namespace DshPortable
                 {
                     Language = UiLanguageTag,
                 };
+                string testBrowserArguments = Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_WEBVIEW2_ARGUMENTS");
+                if (String.Equals(Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_HIDDEN"), "1", StringComparison.Ordinal)
+                    && !String.IsNullOrWhiteSpace(testBrowserArguments)
+                    && Regex.IsMatch(testBrowserArguments, "^--remote-debugging-port=[0-9]{1,5}$"))
+                {
+                    options.AdditionalBrowserArguments = testBrowserArguments;
+                }
                 CoreWebView2Environment environment = await CoreWebView2Environment.CreateAsync(null, userData, options);
                 await webView.EnsureCoreWebView2Async(environment);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/scripts/smoke-windows-native-download.mjs
+++ b/scripts/smoke-windows-native-download.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import { execFile, spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const root = path.resolve(process.argv[2] || '')
+if (!process.argv[2]) throw new Error('usage: node smoke-windows-native-download.mjs <DSH-Portable root>')
+if (process.platform !== 'win32') throw new Error('the native WebView2 download smoke is Windows-only')
+
+const executable = path.join(root, 'DeepSeek-Herness.exe')
+const portableNode = path.join(root, 'runtime', 'node', 'node.exe')
+const portableCli = path.join(root, 'launcher', 'portable-cli.mjs')
+for (const filename of [executable, portableNode, portableCli]) {
+  if (!existsSync(filename)) throw new Error(`portable file is missing: ${filename}`)
+}
+
+async function reserveLoopbackPort() {
+  const server = createServer()
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+  if (!port) throw new Error('could not reserve a WebView2 DevTools port')
+  return port
+}
+
+async function waitForPage(port, launcher, timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs
+  let latest = ''
+  while (Date.now() < deadline) {
+    if (launcher.exitCode !== null) throw new Error(`desktop host exited before WebView2 became ready: ${launcher.exitCode}`)
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`)
+      latest = await response.text()
+      if (response.ok) {
+        const targets = JSON.parse(latest)
+        const page = targets.find(target => target.type === 'page' && /^http:\/\/127\.0\.0\.1:\d+/.test(target.url || ''))
+        if (page?.webSocketDebuggerUrl) return page
+      }
+    } catch { /* WebView2 is still starting */ }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`timed out waiting for the embedded DSH page; latest=${latest.slice(-1000)}`)
+}
+
+class CdpClient {
+  constructor(url) {
+    this.socket = new WebSocket(url)
+    this.nextId = 1
+    this.pending = new Map()
+  }
+
+  async open() {
+    await new Promise((resolve, reject) => {
+      this.socket.addEventListener('open', resolve, { once: true })
+      this.socket.addEventListener('error', reject, { once: true })
+    })
+    this.socket.addEventListener('message', event => {
+      const message = JSON.parse(event.data)
+      if (!message.id) return
+      const pending = this.pending.get(message.id)
+      if (!pending) return
+      this.pending.delete(message.id)
+      if (message.error) pending.reject(new Error(`${message.error.code}: ${message.error.message}`))
+      else pending.resolve(message.result)
+    })
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      this.socket.send(JSON.stringify({ id, method, params }))
+    })
+  }
+
+  close() { this.socket.close() }
+}
+
+async function evaluate(client, expression) {
+  const result = await client.send('Runtime.evaluate', { expression, awaitPromise: true, returnByValue: true })
+  if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || result.exceptionDetails.text)
+  return result.result?.value
+}
+
+async function portable(args) {
+  return execFileAsync(portableNode, [portableCli, ...args], {
+    cwd: root,
+    env: { ...process.env, DSH_PORTABLE_SKIP_UPDATE_CHECK: '1' },
+    timeout: 90000,
+    windowsHide: true,
+  })
+}
+
+let launcher = null
+let client = null
+let downloadRoot = ''
+try {
+  await portable(['stop', '--no-browser', '--json']).catch(() => {})
+  downloadRoot = await mkdtemp(path.join(os.tmpdir(), 'dsh-native-download-'))
+  const debugPort = await reserveLoopbackPort()
+  launcher = spawn(executable, [], {
+    cwd: root,
+    env: {
+      ...process.env,
+      DSH_PORTABLE_SKIP_UPDATE_CHECK: '1',
+      DSH_PORTABLE_TEST_HIDDEN: '1',
+      DSH_PORTABLE_DOWNLOAD_DIRECTORY: downloadRoot,
+      WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS: `--remote-debugging-port=${debugPort}`,
+    },
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+
+  const page = await waitForPage(debugPort, launcher)
+  client = new CdpClient(page.webSocketDebuggerUrl)
+  await client.open()
+  await client.send('Runtime.enable')
+  const filename = 'dsh-native-download-smoke.txt'
+  const body = 'DSH native WebView2 download passed.'
+  await evaluate(client, `(() => {
+    const blob = new Blob([${JSON.stringify(body)}], { type: 'text/plain;charset=utf-8' })
+    const anchor = document.createElement('a')
+    anchor.href = URL.createObjectURL(blob)
+    anchor.download = ${JSON.stringify(filename)}
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    return true
+  })()`)
+
+  const downloaded = path.join(downloadRoot, filename)
+  const deadline = Date.now() + 30000
+  while (!existsSync(downloaded) && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 100))
+  assert.equal(await readFile(downloaded, 'utf8'), body)
+  process.stdout.write(`${JSON.stringify({ status: 'passed', host: 'WebView2', filename, bytes: Buffer.byteLength(body) })}\n`)
+} finally {
+  client?.close()
+  await portable(['stop', '--no-browser', '--json']).catch(() => {})
+  if (launcher?.pid) {
+    try { await execFileAsync('taskkill.exe', ['/PID', String(launcher.pid), '/T', '/F'], { windowsHide: true }) } catch { /* already stopped */ }
+  }
+  if (downloadRoot) {
+    const tempRoot = path.resolve(os.tmpdir()) + path.sep
+    const resolved = path.resolve(downloadRoot)
+    if (!resolved.startsWith(tempRoot) || !path.basename(resolved).startsWith('dsh-native-download-')) {
+      throw new Error(`refusing to remove unexpected download root: ${resolved}`)
+    }
+    await rm(resolved, { recursive: true, force: true })
+  }
+}

--- a/scripts/smoke-windows-native-download.mjs
+++ b/scripts/smoke-windows-native-download.mjs
@@ -114,7 +114,7 @@ try {
       DSH_PORTABLE_SKIP_UPDATE_CHECK: '1',
       DSH_PORTABLE_TEST_HIDDEN: '1',
       DSH_PORTABLE_DOWNLOAD_DIRECTORY: downloadRoot,
-      WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS: `--remote-debugging-port=${debugPort}`,
+      DSH_PORTABLE_TEST_WEBVIEW2_ARGUMENTS: `--remote-debugging-port=${debugPort}`,
     },
     stdio: 'ignore',
     windowsHide: true,

--- a/scripts/smoke-windows-native-tray.ps1
+++ b/scripts/smoke-windows-native-tray.ps1
@@ -59,9 +59,18 @@ try {
         throw "Tray title truncation must preserve exactly 35 complete text elements"
     }
 
+    $ZhRecent = -join ([char[]]@(0x6700, 0x8FD1))
+    $ZhRunning = -join ([char[]]@(0x8FD0, 0x884C, 0x4E2D))
+    $ZhWaiting = -join ([char[]]@(0x5F85, 0x56DE, 0x590D))
+    $ZhReview = -join ([char[]]@(0x590D, 0x6838))
+    $ZhMore = -join ([char[]]@(0x66F4, 0x591A))
+    $ZhNew = -join ([char[]]@(0x65B0, 0x4F1A, 0x8BDD))
+    $ZhFeedback = -join ([char[]]@(0x53CD, 0x9988, 0x95EE, 0x9898))
+    $ZhExit = (-join ([char[]]@(0x9000, 0x51FA))) + ' DeepSeek Harness'
+
     foreach ($Case in @(
         @{ Locale = 'en'; Theme = 'light'; Recent = 'Recent'; Running = 'Running'; Waiting = 'Needs input'; Review = 'Review'; More = 'More'; New = 'New session'; Feedback = 'Report a problem'; Exit = 'Exit DeepSeek Harness' },
-        @{ Locale = 'zh'; Theme = 'dark'; Recent = '最近'; Running = '运行中'; Waiting = '待回复'; Review = '复核'; More = '更多'; New = '新会话'; Feedback = '反馈问题'; Exit = '退出 DeepSeek Harness' }
+        @{ Locale = 'zh'; Theme = 'dark'; Recent = $ZhRecent; Running = $ZhRunning; Waiting = $ZhWaiting; Review = $ZhReview; More = $ZhMore; New = $ZhNew; Feedback = $ZhFeedback; Exit = $ZhExit }
     )) {
         Set-Property $StateType $State 'locale' $Case.Locale
         Set-Property $StateType $State 'theme' $Case.Theme

--- a/scripts/smoke-windows-native-tray.ps1
+++ b/scripts/smoke-windows-native-tray.ps1
@@ -1,0 +1,94 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Root
+)
+
+$ErrorActionPreference = 'Stop'
+$ResolvedRoot = (Resolve-Path -LiteralPath $Root).Path
+$Launcher = Join-Path $ResolvedRoot 'DeepSeek-Herness.exe'
+if (-not (Test-Path -LiteralPath $Launcher -PathType Leaf)) {
+    throw "DeepSeek-Herness.exe is missing: $Launcher"
+}
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$Assembly = [Reflection.Assembly]::LoadFrom($Launcher)
+$AllFields = [Reflection.BindingFlags]'Instance,Static,Public,NonPublic'
+$InstanceMembers = [Reflection.BindingFlags]'Instance,NonPublic'
+$WindowType = $Assembly.GetType('DshPortable.LauncherWindow', $true)
+$StateType = $Assembly.GetType('DshPortable.TrayBridgeState', $true)
+$SessionType = $Assembly.GetType('DshPortable.TrayBridgeSession', $true)
+$Constructor = $WindowType.GetConstructor($InstanceMembers, $null, [Type[]]@([string[]]), $null)
+$ConstructorArgs = New-Object 'System.Object[]' 1
+$ConstructorArgs[0] = [string[]]@('--desktop')
+$Window = $Constructor.Invoke($ConstructorArgs)
+
+function Set-Property([Type]$Type, [object]$Target, [string]$Name, [object]$Value) {
+    $Type.GetProperty($Name).SetValue($Target, $Value, $null)
+}
+
+function Add-Session([object]$List, [string]$Id, [string]$Title, [string]$Preset, [bool]$Running, [string]$Pending) {
+    $Session = [Activator]::CreateInstance($SessionType, $true)
+    Set-Property $SessionType $Session 'id' $Id
+    Set-Property $SessionType $Session 'title' $Title
+    Set-Property $SessionType $Session 'agentPreset' $Preset
+    Set-Property $SessionType $Session 'running' $Running
+    Set-Property $SessionType $Session 'pendingInteraction' $Pending
+    $List.Add($Session)
+}
+
+try {
+    $State = [Activator]::CreateInstance($StateType, $true)
+    Set-Property $StateType $State 'type' 'dsh-portable/state'
+    Set-Property $StateType $State 'schemaVersion' 1
+    Set-Property $StateType $State 'currentSessionId' 'session-1'
+    $ListType = [Collections.Generic.List``1].MakeGenericType($SessionType)
+    $Sessions = [Activator]::CreateInstance($ListType)
+    Add-Session $Sessions 'session-1' 'Implement native downloads' 'coding' $true ''
+    Add-Session $Sessions 'session-2' 'Review a waiting task' 'plan' $false 'approval'
+    Add-Session $Sessions 'session-3' 'Verify the Linux package' 'review' $false ''
+    Add-Session $Sessions 'session-4' 'Prepare release notes' '' $false ''
+    Set-Property $StateType $State 'sessions' $Sessions
+
+    $WindowType.GetField('trayState', $AllFields).SetValue($Window, $State)
+    $WindowType.GetField('trayBridgeReady', $AllFields).SetValue($Window, $true)
+
+    $LongTitle = [string]::Concat((1..36 | ForEach-Object { "e$([char]0x0301)" }))
+    $ShortenedTitle = [string]$WindowType.GetMethod('MenuTitle', $AllFields).Invoke($null, @($LongTitle))
+    if ([Globalization.StringInfo]::ParseCombiningCharacters($ShortenedTitle.TrimEnd([char]0x2026)).Length -ne 35 -or -not $ShortenedTitle.EndsWith([char]0x2026)) {
+        throw "Tray title truncation must preserve exactly 35 complete text elements"
+    }
+
+    foreach ($Case in @(
+        @{ Locale = 'en'; Theme = 'light'; Recent = 'Recent'; Running = 'Running'; Waiting = 'Needs input'; Review = 'Review'; More = 'More'; New = 'New session'; Feedback = 'Report a problem'; Exit = 'Exit DeepSeek Harness' },
+        @{ Locale = 'zh'; Theme = 'dark'; Recent = '最近'; Running = '运行中'; Waiting = '待回复'; Review = '复核'; More = '更多'; New = '新会话'; Feedback = '反馈问题'; Exit = '退出 DeepSeek Harness' }
+    )) {
+        Set-Property $StateType $State 'locale' $Case.Locale
+        Set-Property $StateType $State 'theme' $Case.Theme
+        $WindowType.GetField('uiLanguage', $AllFields).SetValue($null, $Case.Locale)
+        $WindowType.GetField('trayTheme', $AllFields).SetValue($Window, $Case.Theme)
+        $WindowType.GetMethod('RebuildTrayMenu', $InstanceMembers).Invoke($Window, $null) | Out-Null
+        $Menu = [Windows.Forms.ContextMenuStrip]$WindowType.GetField('trayMenu', $AllFields).GetValue($Window)
+
+        if ($Menu.Items[0].Text -ne $Case.Recent -or $Menu.Items[0].Enabled) { throw "Invalid recent section for $($Case.Locale)" }
+        if ($Menu.Items[1].ShortcutKeyDisplayString -ne $Case.Running) { throw "Running hint is missing for $($Case.Locale)" }
+        if ($Menu.Items[2].ShortcutKeyDisplayString -ne $Case.Waiting) { throw "Waiting hint is missing for $($Case.Locale)" }
+        if ($Menu.Items[3].ShortcutKeyDisplayString -ne $Case.Review) { throw "Review hint is missing for $($Case.Locale)" }
+        if ($Menu.Items[4].Text -ne $Case.More -or $Menu.Items[4].DropDownItems[0].Text -ne 'Prepare release notes') { throw "Bounded More menu is invalid for $($Case.Locale)" }
+        if ($Menu.Items[5].Text -ne $Case.New) { throw "New-session action is missing for $($Case.Locale)" }
+        if ($Menu.Items[7].Text -ne $Case.Feedback) { throw "Feedback action is missing for $($Case.Locale)" }
+        if ($Menu.Items[9].Text -ne $Case.Exit) { throw "Exit action is missing for $($Case.Locale)" }
+
+        $Size = $Menu.GetPreferredSize([Drawing.Size]::Empty)
+        if ($Size.Width -lt 240 -or $Size.Height -lt 180) { throw "Tray menu layout is unexpectedly small: $Size" }
+        $Menu.Size = $Size
+        $Bitmap = New-Object Drawing.Bitmap($Size.Width, $Size.Height)
+        try { $Menu.DrawToBitmap($Bitmap, [Drawing.Rectangle]::new(0, 0, $Size.Width, $Size.Height)) }
+        finally { $Bitmap.Dispose() }
+    }
+
+    Write-Host 'Windows native tray smoke passed: real compiled menu, bounded sessions, locale, theme, and task actions.'
+}
+finally {
+    $Window.Dispose()
+}

--- a/templates/RELEASE-NOTES.md
+++ b/templates/RELEASE-NOTES.md
@@ -1,13 +1,14 @@
 > 打包官方 DeepSeek Harness 预览版（`@deepseek-ai/dsh 0.1.0-rc.6`）。DSH-Portable 是独立社区分发项目。
 
-0.2.1 把更新信息和桌面托盘收成一套更清楚的产品体验：
+0.2.2 让 Windows 桌面壳更接近原生应用：
 
-- 更新窗口分别显示 **DSH-Portable** 与 **内置官方 DSH** 的当前和目标版本；本次内置
-  官方 DSH 仍为 `0.1.0-rc.6`。
-- 下载显示真实百分比与已下载大小，并继续显示验证、安装和重新打开阶段。
-- Windows 托盘跟随 DSH 的中文/英文与明暗外观；最近会话、新会话、更多操作和退出采用
-  一致的层级，仍通过官方会话接口打开内容。
-- 关闭启动时检查更新后不再主动提醒，手动检查保留；运行中的任务不会被自动更新中断。
+- 托盘改为系统原生任务菜单：最近 3 个会话直接可达，状态显示在右侧，其余会话进入
+  “更多”；左键回到主窗口，打开与新建仍使用官方会话接口。
+- 网页式右键菜单和浏览器状态栏不再出现在桌面窗口中。
+- 导出会话等文件下载改由桌面壳接管：选择保存位置后显示真实进度，可取消、打开文件或
+  打开所在文件夹。
+- 托盘继续跟随 DSH 的中文/英文与明暗外观；本次内置官方 DSH 仍为 `0.1.0-rc.6`。
+- 仍可在托盘“更多”中关闭“启动时检查更新”；手动检查始终保留。
 
 普通更新只替换 DSH 应用组件并保留用户数据。
 
@@ -43,16 +44,17 @@
 > Packages the official DeepSeek Harness preview (`@deepseek-ai/dsh 0.1.0-rc.6`).
 > DSH-Portable is an independent community distribution.
 
-0.2.1 makes updates and the desktop tray feel like one coherent product:
+0.2.2 makes the Windows desktop shell behave more like a native application:
 
-- The update window separates the **DSH-Portable** version from the **bundled official DSH** version.
-  The bundled official DSH remains `0.1.0-rc.6` in this release.
-- Downloads show the real percentage and transferred size, followed by verification, installation,
-  and reopen stages.
-- The Windows tray follows the DSH language and light/dark appearance. Recent sessions, New Session,
-  More, and Exit use a consistent hierarchy while session actions still use the official runtime API.
-- Disabling startup checks suppresses automatic prompts while manual checks stay available. Running
-  tasks are never interrupted automatically.
+- The tray is now a native task menu: the three most recent sessions stay one click away, their state
+  appears on the right, and the remaining sessions move into More. Session actions still use the
+  official runtime API.
+- Web-style context menus and the browser status bar no longer appear in the desktop window.
+- Session exports and other downloads are owned by the desktop shell, with a save location, real
+  progress, cancel, open-file, and show-in-folder actions.
+- The tray continues to follow DSH language and light/dark appearance. The bundled official DSH
+  remains `0.1.0-rc.6` in this release.
+- You can still turn off **Check for updates at startup** from More; manual checks remain available.
 
 If an older launcher crosses a compatibility boundary, it downloads one complete package and updates
 in place while preserving `data`, `workspace`, sessions, credentials, and plugins. Finished products

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -101,9 +101,10 @@ test('macOS GUI is a native WKWebView app rather than a Chrome app-mode launcher
 })
 
 test('CI release gate verifies native desktop ownership, lifecycle, and application identity', async () => {
-  const [workflow, windowsSmoke, macSmoke] = await Promise.all([
+  const [workflow, windowsSmoke, traySmoke, macSmoke] = await Promise.all([
     read('.github/workflows/ci.yml'),
     read('scripts/smoke-windows-desktop-host.ps1'),
+    read('scripts/smoke-windows-native-tray.ps1'),
     read('scripts/smoke-macos-desktop-host.sh'),
   ])
 
@@ -111,6 +112,7 @@ test('CI release gate verifies native desktop ownership, lifecycle, and applicat
   assert.match(workflow, /smoke-windows-desktop-host\.ps1/)
   assert.match(workflow, /smoke-windows-native-tray\.ps1/)
   assert.match(workflow, /smoke-windows-native-download\.mjs/)
+  assert.doesNotMatch(traySmoke, /[^\x00-\x7F]/, 'Windows PowerShell 5.1 smoke scripts must remain encoding-safe without a BOM')
   assert.match(workflow, /macos-desktop-host:/)
   assert.match(workflow, /smoke-macos-desktop-host\.sh/)
   assert.doesNotMatch(workflow, /browser ownership and Stop|windows-browser-lifecycle:|macos-browser-lifecycle:/)

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -112,6 +112,8 @@ test('CI release gate verifies native desktop ownership, lifecycle, and applicat
   assert.match(workflow, /smoke-windows-desktop-host\.ps1/)
   assert.match(workflow, /smoke-windows-native-tray\.ps1/)
   assert.match(workflow, /smoke-windows-native-download\.mjs/)
+  assert.match(workflow, /\$DownloadRoot = Join-Path \$env:RUNNER_TEMP 'dsh-native-download-host'/)
+  assert.match(workflow, /smoke-windows-native-download\.mjs \(Join-Path \$DownloadRoot 'DSH-Portable'\)/)
   assert.doesNotMatch(traySmoke, /[^\x00-\x7F]/, 'Windows PowerShell 5.1 smoke scripts must remain encoding-safe without a BOM')
   assert.match(workflow, /macos-desktop-host:/)
   assert.match(workflow, /smoke-macos-desktop-host\.sh/)

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -46,6 +46,45 @@ test('Windows GUI is a native WebView2 host with its own stable taskbar identity
   assert.doesNotMatch(build, /Copy-Item\s+\$LauncherExe\s+\(Join-Path\s+\$Stage\s+'Stop DeepSeek-Herness\.exe'\)/)
 })
 
+test('Windows owns browser chrome and file downloads instead of exposing Edge UI', async () => {
+  const host = await read('launcher/windows/DSH-Portable.cs')
+
+  assert.match(host, /AreDefaultContextMenusEnabled\s*=\s*false/)
+  assert.match(host, /IsStatusBarEnabled\s*=\s*false/)
+  assert.match(host, /DownloadStarting\s*\+=\s*OnDownloadStarting/)
+  assert.match(host, /CoreWebView2DownloadStartingEventArgs/)
+  assert.match(host, /eventArgs\.Handled\s*=\s*true/)
+  assert.match(host, /SaveFileDialog/)
+  assert.match(host, /CoreWebView2DownloadOperation/)
+  assert.match(host, /BytesReceivedChanged/)
+  assert.match(host, /StateChanged/)
+  assert.match(host, /打开文件夹|Show in folder/)
+  assert.match(host, /取消下载|Cancel download/)
+  assert.match(host, /DSH_PORTABLE_DOWNLOAD_DIRECTORY/)
+  assert.match(host, /DSH_PORTABLE_TEST_HIDDEN/)
+})
+
+test('Windows tray follows the Codex native bounded task-menu hierarchy', async () => {
+  const host = await read('launcher/windows/DSH-Portable.cs')
+
+  assert.doesNotMatch(host, /class\s+TrayTaskCenter\s*:\s*Form/)
+  assert.match(host, /ContextMenuStrip\s*=\s*trayMenu/)
+  assert.match(host, /trayIcon\.MouseClick\s*\+=/)
+  assert.match(host, /sessions\.Take\(3\)/)
+  assert.match(host, /sessions\.Skip\(3\)\.Take\(7\)/)
+  assert.match(host, /CreateSectionHeader\("最近",\s*"Recent"\)/)
+  assert.match(host, /ShortcutKeyDisplayString\s*=\s*SessionHint/)
+  assert.match(host, /StringInfo\.ParseCombiningCharacters/)
+  assert.match(host, /const\s+int\s+limit\s*=\s*35/)
+  assert.match(host, /Equals\("coding"[\s\S]*L\("编码",\s*"Coding"\)/)
+  assert.match(host, /Equals\("plan"[\s\S]*L\("计划",\s*"Plan"\)/)
+  assert.match(host, /Equals\("review"[\s\S]*L\("复核",\s*"Review"\)/)
+  assert.match(host, /ToolStripMenuItem\s+more\s*=\s*new ToolStripMenuItem\(L\("更多",\s*"More"\)\)/)
+  assert.match(host, /新会话|New session/)
+  assert.match(host, /反馈问题|Report a problem/)
+  assert.match(host, /退出 DeepSeek Harness|Exit DeepSeek Harness/)
+})
+
 test('macOS GUI is a native WKWebView app rather than a Chrome app-mode launcher', async () => {
   const [host, build] = await Promise.all([
     read('launcher/macos/DeepSeek-Herness.swift'),
@@ -70,6 +109,8 @@ test('CI release gate verifies native desktop ownership, lifecycle, and applicat
 
   assert.match(workflow, /windows-desktop-host:/)
   assert.match(workflow, /smoke-windows-desktop-host\.ps1/)
+  assert.match(workflow, /smoke-windows-native-tray\.ps1/)
+  assert.match(workflow, /smoke-windows-native-download\.mjs/)
   assert.match(workflow, /macos-desktop-host:/)
   assert.match(workflow, /smoke-macos-desktop-host\.sh/)
   assert.doesNotMatch(workflow, /browser ownership and Stop|windows-browser-lifecycle:|macos-browser-lifecycle:/)

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -62,6 +62,8 @@ test('Windows owns browser chrome and file downloads instead of exposing Edge UI
   assert.match(host, /取消下载|Cancel download/)
   assert.match(host, /DSH_PORTABLE_DOWNLOAD_DIRECTORY/)
   assert.match(host, /DSH_PORTABLE_TEST_HIDDEN/)
+  assert.match(host, /DSH_PORTABLE_TEST_WEBVIEW2_ARGUMENTS/)
+  assert.match(host, /options\.AdditionalBrowserArguments\s*=\s*testBrowserArguments/)
 })
 
 test('Windows tray follows the Codex native bounded task-menu hierarchy', async () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -5,9 +5,12 @@ import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 import { inflateSync } from 'node:zlib'
 
+import { classifyProductVersion } from '../scripts/version-policy.mjs'
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const read = (name) => readFile(path.join(root, name), 'utf8')
 const exists = async (name) => access(path.join(root, name)).then(() => true, () => false)
+const regexEscape = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 function pngCornerAlphas(png) {
   assert.equal(png.subarray(0, 8).toString('hex'), '89504e470d0a1a0a')
@@ -77,7 +80,7 @@ function icoPngFrames(ico) {
 test('the public product identity is DSH-Portable everywhere users see it', async () => {
   const manifest = JSON.parse(await read('package.json'))
   assert.equal(manifest.name, 'dsh-portable')
-  assert.equal(manifest.version, '0.2.1')
+  assert.equal(classifyProductVersion(manifest.version).channel, 'stable')
 
   const chineseReadme = await read('README.md')
   const englishReadme = await read('README.en.md')
@@ -276,6 +279,7 @@ test('Windows package exposes real GUI executables with matching icon and no pat
   const bootstrap = await read('launcher/windows/DSH-Bootstrap.cs')
   const manifest = await read('launcher/windows/DSH-Portable.manifest')
   const build = await read('scripts/build-windows.ps1')
+  const policy = classifyProductVersion(JSON.parse(await read('package.json')).version)
 
   assert.match(source, /Application\.ExecutablePath/)
   assert.match(source, /portable-cli\.mjs/)
@@ -333,7 +337,7 @@ test('Windows package exposes real GUI executables with matching icon and no pat
   assert.match(build, /shellSchema/)
   assert.match(build, /shellSchema\s*=\s*10/)
   assert.match(build, /requiredShellSchema\s*=\s*10/)
-  assert.match(source, /AssemblyFileVersion\("0\.2\.1\.65534"\)/)
+  assert.match(source, new RegExp(`AssemblyFileVersion\\("${regexEscape(policy.windowsVersion)}"\\)`))
   assert.match(bootstrap, /ZipArchive/)
   assert.match(bootstrap, /progressPercentLabel/)
   assert.match(bootstrap, /FormatBytes/)
@@ -497,6 +501,7 @@ test('macOS package is a movable signed app shell for both supported architectur
   const app = await read('launcher/macos/DeepSeek-Herness.swift')
   const stop = await read('launcher/macos/Stop DSH-Portable.command')
   const build = await read('scripts/build-macos.sh')
+  const policy = classifyProductVersion(JSON.parse(await read('package.json')).version)
 
   assert.match(plist, /<string>DSH-Portable<\/string>/)
   assert.match(plist, /<string>io\.github\.wsl043\.dsh-portable<\/string>/)
@@ -515,7 +520,7 @@ test('macOS package is a movable signed app shell for both supported architectur
   assert.match(build, /portable-update-macos-\$ARCH\.json/)
   assert.match(build, /"shellSchema": 10/)
   assert.match(build, /"requiredShellSchema": 10/)
-  assert.match(plist, /<key>CFBundleVersion<\/key>\s*<string>2001999<\/string>/s)
+  assert.match(plist, new RegExp(`<key>CFBundleVersion<\\/key>\\s*<string>${regexEscape(policy.macBuildVersion)}<\\/string>`, 's'))
   assert.match(app, /check-update/)
   assert.match(app, /Check for Updates|检查更新/)
   assert.match(app, /Check for updates at startup|启动时检查更新/)

--- a/tests/version-policy.test.mjs
+++ b/tests/version-policy.test.mjs
@@ -8,6 +8,7 @@ import { classifyProductVersion } from '../scripts/version-policy.mjs'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const read = (name) => readFile(path.join(root, name), 'utf8')
+const regexEscape = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 test('stable and release-candidate versions have unambiguous GitHub channels', () => {
   assert.deepEqual(classifyProductVersion('0.2.0'), {
@@ -33,7 +34,8 @@ test('stable and release-candidate versions have unambiguous GitHub channels', (
 
 test('all finished-product manifests use the same stable product version', async () => {
   const manifest = JSON.parse(await read('package.json'))
-  assert.equal(manifest.version, '0.2.1')
+  const policy = classifyProductVersion(manifest.version)
+  assert.equal(policy.channel, 'stable')
 
   const sources = await Promise.all([
     read('installer/windows/DSH-Portable.iss'),
@@ -48,8 +50,9 @@ test('all finished-product manifests use the same stable product version', async
     read('launcher/macos/Info-installed.plist'),
     read('launcher/macos/Info-stop-installed.plist'),
   ])
-  for (const source of sources) assert.match(source, /0\.2\.1/)
-  assert.doesNotMatch(sources.join('\n'), /0\.2\.1-rc\./)
+  const productVersion = new RegExp(regexEscape(policy.version))
+  for (const source of sources) assert.match(source, productVersion)
+  assert.doesNotMatch(sources.join('\n'), new RegExp(`${regexEscape(policy.version)}-rc\\.`))
 })
 
 test('publishing derives prerelease state from the product version instead of user input', async () => {


### PR DESCRIPTION
## Summary
- replace the custom tray surface with a bounded native task menu backed by official DSH session actions
- suppress browser chrome and handle downloads in the Windows desktop shell
- add real compiled tray and embedded WebView2 download gates
- advance the product to stable 0.2.2 across Windows, macOS, and Linux manifests

## Verification
- 108/108 repository tests
- isolated Windows 0.2.2 package build
- native desktop host smoke
- native tray menu smoke (zh/en, light/dark, Unicode titles)
- official tray bridge smoke
- embedded WebView2 download smoke