### PR TITLE
Update bundled DSH to rc.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,8 +403,7 @@ jobs:
           components: rustfmt
       - name: Install pinned Linux desktop build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/install-linux-packages.sh \
             build-essential curl file fuse libayatana-appindicator3-dev libfuse2 \
             libgtk-3-dev librsvg2-dev libssl-dev libwebkit2gtk-4.1-dev patchelf \
             unzip xauth xvfb xdotool zip
@@ -445,9 +444,7 @@ jobs:
           name: linux-${{ matrix.arch }}-build
           path: artifacts
       - name: Install Linux runtime smoke dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libayatana-appindicator3-1 libwebkit2gtk-4.1-0 unzip xauth xvfb
+        run: bash scripts/install-linux-packages.sh libayatana-appindicator3-1 libwebkit2gtk-4.1-0 unzip xauth xvfb
       - run: node scripts/verify-update-artifact.mjs "artifacts/portable-update-linux-${{ matrix.arch }}.json" "artifacts/DSH-Portable-update-linux-${{ matrix.arch }}.zip"
       - name: Extract, update, run, move, and stop
         run: |
@@ -476,9 +473,7 @@ jobs:
           name: linux-${{ matrix.arch }}-build
           path: artifacts
       - name: Install one-click package smoke dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.1-0 xauth xvfb
+        run: bash scripts/install-linux-packages.sh libwebkit2gtk-4.1-0 xauth xvfb
       - name: Add, list, compose, remove, and move with no system Node or pnpm
         run: |
           ROOT="$RUNNER_TEMP/dsh-linux-plugins"
@@ -512,8 +507,7 @@ jobs:
           path: artifacts
       - name: Install native Linux desktop smoke dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/install-linux-packages.sh \
             libayatana-appindicator3-1 libwebkit2gtk-4.1-0 xauth xvfb xdotool
       - name: Verify native window, lifecycle, and self-contained AppImage payload
         run: |

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,18 +1,23 @@
 {
   "name": "deepseek-harness-portable-runtime",
-  "version": "0.1.0-rc.6",
+  "version": "0.1.0-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-portable-runtime",
-      "version": "0.1.0-rc.6",
+      "version": "0.1.0-rc.7",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh": "0.1.0-rc.6",
+        "@deepseek-ai/dsh": "0.1.0-rc.7",
         "@wsl043/dsh-portable-desktop-bridge": "file:../desktop-bridge",
         "pnpm": "11.7.0"
       }
+    },
+    "../desktop-bridge": {
+      "name": "@wsl043/dsh-portable-desktop-bridge",
+      "version": "0.2.4",
+      "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.91.1",
@@ -109,13 +114,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
-      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
-        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
         "@aws/lambda-invoke-store": "^0.3.0",
         "@smithy/core": "^3.31.1",
         "@smithy/signature-v4": "^5.6.12",
@@ -128,13 +133,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
-      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -144,13 +149,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
-      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -162,13 +167,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
-      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -176,20 +181,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
-      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/credential-provider-env": "^3.972.68",
-        "@aws-sdk/credential-provider-http": "^3.972.70",
-        "@aws-sdk/credential-provider-login": "^3.972.75",
-        "@aws-sdk/credential-provider-process": "^3.972.68",
-        "@aws-sdk/credential-provider-sso": "^3.973.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -200,14 +205,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.75",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
-      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -217,18 +222,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.79",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
-      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.68",
-        "@aws-sdk/credential-provider-http": "^3.972.70",
-        "@aws-sdk/credential-provider-ini": "^3.973.13",
-        "@aws-sdk/credential-provider-process": "^3.972.68",
-        "@aws-sdk/credential-provider-sso": "^3.973.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -239,13 +244,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
-      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -255,15 +260,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
-      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/token-providers": "3.1108.0",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -273,14 +278,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
-      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -290,14 +295,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.74",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
-      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -307,12 +312,12 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.32.tgz",
-      "integrity": "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.33.tgz",
+      "integrity": "sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -322,12 +327,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.27.tgz",
-      "integrity": "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.28.tgz",
+      "integrity": "sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -337,13 +342,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.50.tgz",
-      "integrity": "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.51.tgz",
+      "integrity": "sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/signature-v4": "^5.6.12",
@@ -355,14 +360,14 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
-      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -374,13 +379,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
-      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -388,12 +393,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
-      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -420,9 +425,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
-      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -433,9 +438,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
-      "integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -445,9 +450,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
-      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -602,9 +607,9 @@
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.0-rc.6.tgz",
-      "integrity": "sha512-brpZfED7ieRa2PQ5tUxMhHrM1pb2CmKFVM/f6yMULBDMicahk+Z2OsHgTwTDnoiZm23Ftu9rQz0NN4pflaoJcg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.0-rc.7.tgz",
+      "integrity": "sha512-ZceDCJ8FAywih+USW/OMk9jEhunlvJBGEz4kqrhau23hPzbciOazZrywH0nBRsaalSeAJ1JGBmjtw4OSjToStw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
@@ -612,59 +617,59 @@
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-base": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-headless": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-mcp-client": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-persona": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-schedule": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-terminal-bash": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-time-context": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tmux-context": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-ask-user": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-cordis": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-web-app": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-base": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-headless": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-persona": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-schedule": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-time-context": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-web-app": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.7",
         "commander": "^15.0.0",
         "js-yaml": "^4.2.0",
         "node-addon-require-builtin": "^0.1.4"
@@ -674,80 +679,80 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.6.tgz",
-      "integrity": "sha512-vtqq2pWTrzn0dKfj5kREZRpP82AwtGjGx9V1lYnKvF+Uc/a8zyWbSvjDE7V1d3YQAQJzs2cWO31hURWDekDXIA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.7.tgz",
+      "integrity": "sha512-AqBQavJYgbCUUYBHP7OGCaw8WN5082NXYQOoOfNRO72bub3E+/nWkl8b4B7BAJdFfyLo9ce+Kgb1BCHSJU/JLg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.0-rc.6.tgz",
-      "integrity": "sha512-5Fl15p5mHVMlp69Ea0qeS81ej1Bt9vSJtCed+gjvzkKzv5y3VbJQ8PPBV34F1rTSyhTtjj5Q7TuDugQI5ZpjfA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.0-rc.7.tgz",
+      "integrity": "sha512-zHtD4FAqxzidyNiyx1bpvLHdOTTsKnmjlHRqDS1KegIMSTNFmmp1B2bHdAUXp/OH7fPDmv+1ZXzDoJhBNUY9jA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.0-rc.6.tgz",
-      "integrity": "sha512-RCd3UWJI7b3X6EUnxnqwOFiMWh1PzRRg9GrVt4G0tVNDIxeYX+RF2FTbOrslIOkOCZxG3BlI2M/bZ6yQmB4Vwg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.0-rc.7.tgz",
+      "integrity": "sha512-laLz5ee7tKqVzrj15ztHuOnJLxDiGlqFOm6mEJUjJPWWD9Yzj1Iq+6WHZZ3Hw66vrNzYKqEN0TBofWF3DA7OzQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-loop": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.0-rc.6.tgz",
-      "integrity": "sha512-yShuKIMW360H14L4y13j3gz3Ix1s/3lwEEpfJW4hnFAE09h9Z4yJA7UfTQmQdzMRMnuj4uWFPw0e0BbapnkFuw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.0-rc.7.tgz",
+      "integrity": "sha512-98jV+6XnkZ93g4C1BJ/hCcC8k4GVhH+oNrkhLFvc6aOQz6o+9kdV8IrgEVr0qRcAfHKlCMfiV4BIDz4eBBoziw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.0-rc.6.tgz",
-      "integrity": "sha512-LtDz0TYE7YNhJOhMDZ8s45xQG57bWF4F1SN3tjYDosaBdINIRTxJ0O80BC+KeliqFDw071ZNOzTUEelwEAIx7w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.0-rc.7.tgz",
+      "integrity": "sha512-T/VcMV7lrXCFmRKrtoMTAz5DAdUmku6hz95wbikRvRc0WizIwQ3R04ke9KIeDiQcxK8xkE8cx+IYqEWa9C5gPg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -757,89 +762,89 @@
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Ysg45g0qnteB6w7krUBRXQ6SFbc8L+laPZTS2y15FFTLueruJaANBLIgnorEtj2bIJYF2Lq0fKH5v0wPNNrlXw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.0-rc.7.tgz",
+      "integrity": "sha512-RAtrfRyLZ/ob9lW5/fKeU7T4LYPTXYP7qCmu2i7ZBqwHseMdYHk0U1Ti8z2kr2NF4LIzHNUXIwaE9s7za5cwuA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.0-rc.6.tgz",
-      "integrity": "sha512-+K/+tQzuDlmvKhoudB7qVMJMNF/p1+GTRQkkPA3JHIQM5yHj7AUYY8oMLROTvUivs8XWtkNyEP1/c6nPwrHazQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.0-rc.7.tgz",
+      "integrity": "sha512-g39W2HSWum6ghJG3src3rLVR8mnCsc0xCBSRpef1Fxgsjjn1LS2KNstKThXQtn7lYQZM/DNE7uiaOmsLxayeJQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.0-rc.6.tgz",
-      "integrity": "sha512-pmdQXBEJpUtr87jIfTyzyPWKGbUghzJno/nZpBWfhk+ZTjGwj0jKpyA5GhhS/tzzo67f5IdmEjcxddoDr3o3Kw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.0-rc.7.tgz",
+      "integrity": "sha512-tcoOuHMSqYqCtMxLjWBHKN+glS56XaUo3ImphvDvUkB84FyU3btHNJbYeAt2oXoWbHfOedcIRWpfNN4tSmhPwQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.0-rc.6.tgz",
-      "integrity": "sha512-yYsHgPr5ZiLk+i2RTREdMj8Gin7J8jG2qnTehZmLpCONGbJv2+grPPRuH7OwcQd+HguXL0ay/rlg6L1O1t8xDg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.0-rc.7.tgz",
+      "integrity": "sha512-dsP69u0avHRcJTPzngudqCm73UaTxNvGi/557DNPi3cOSoIh1SyPzPgk8W8rQQEFTL07rkwt8KfdQoMU5ga1fg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-app-boot": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.0-rc.6.tgz",
-      "integrity": "sha512-97Xb2wB0cuFMmbvW7/95pfMTyXwUNQxW/ROx19OdjS6PgHQNA28ZADZ19FgZmofguxzWuDD0lJPc1SWkSGLYcg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.0-rc.7.tgz",
+      "integrity": "sha512-3qgv994YzNGrlDcOyarL4vqNky3ttmYsUhDsMgGdefALK6gpL7ZCWF+9m0ehZjGY0Rb4VcBdieJYOY2EgpWb0w==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"
@@ -850,10 +855,10 @@
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-hmr": {
@@ -862,31 +867,31 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Ot/2aygDzWuN4ypUkDJA6MpSlGbcvzzKnWAms0lg+2WUtPZr7O0cGb83K3TEO2NoAu0LJfVxlbo8Eya3tDaFtw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.0-rc.7.tgz",
+      "integrity": "sha512-LxRx6K8FJ8bXZHiNhH6Rvj+jh/ZIpolmsmi138XrvMUGvbOBWE6QLbdzcgTgwrYZm5GP2kqqLe/3gQlgtt2bXA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.6.tgz",
-      "integrity": "sha512-3P6N17NQ8jqSQGzeCs+svCIqArU8oq0YmgEAo+axN9aVuUDferWU4DLRSX59UGpmyldX4LQn81toA+c+DqMcHg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.7.tgz",
+      "integrity": "sha512-rsR/xVNOGIig8gXxhrKnkd6YD7aYliGtA/e7b4DlPawMpLhsItAh0HQ832n8LJn1aGZxKf68y9PRgzfljsveOQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-vnLDgnFU2Nxxyjrdh1rRhUYhENE2ZMocfXoeWZd4qioCmjibO/GZxqB7HxJhmFzrldSkKI4VnOglPG8lttKW+Q==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-7i2Fuj811MFeqrUYnpEG3VBoShZEjQ7zNXdLOa1W5hZ4TWV+tUjX7pJoN88U1LOgEOWMc9uzSPqGA5/aKBYgdQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -894,104 +899,104 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-base": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.0-rc.6.tgz",
-      "integrity": "sha512-SR0V0Lq4Bm2ir7k2OaiINZZWFSDt1n4dS8J6IlIabYhoIF46baEQY2awZ9/InOWCe+dIpQob0/3y3yZOHqjnpw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.0-rc.7.tgz",
+      "integrity": "sha512-lpAMUO3PdxZwLnCQOdOZ/fu7eI27Ckz3Ec9MB9QYL4u34yatndCliTrGaFBDoNHoWt3V4gojzszRFrEx+Vce/g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-loop": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-attachment-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-bash-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-credentials-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-fs-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings-file": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill-badge": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-spill-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-spill-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-loader": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings-file": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-spill-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-web": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.7"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-YAc5W9uR7sN1Rrobp6fQlCaOdHqCWatTktV68UsoDuOJs5eM3nWEUUUVN8jdZCIDZhktT5hqbhe3+DzOX3Xg1w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-fsw2Ex5ExyX4A62P1+fodbnUG4PXOSyHAM4YtaLg2kcPcElLwatYNPG3gEuulxwbpWDlx/OWvbjHThnJUuzaoA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -999,62 +1004,62 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.0-rc.6.tgz",
-      "integrity": "sha512-TNLRriAjpEUrJplrI0BmZtAtntIkV5usYiKylJGPlGUfWWnJkLR0zL9gioyXW3kncHBVSnb+YTuf+7FnDVeVHQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.0-rc.7.tgz",
+      "integrity": "sha512-xX+XhqPeRaOqMPDNk8dPboHza2pP13hTIMt+ztvd8WpD0t35idrNrcsXEYs+CtKiFWn6I05WB1BeAimWkLDOcg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-bash-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-bash-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.6.tgz",
-      "integrity": "sha512-E8j9Nby24qP4rfrdcfc7bpt1CHpGT3tYmycOJJkEOH4ptIdT1m2ro9nmnSd5CWYukTr64A77vjm2WGqHRI92UA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.7.tgz",
+      "integrity": "sha512-P7+w0fN40yXXQkV360p6jQi63pcl68OOWebNGN5gf8w8sguvni2mA1cU8RLZzDkRNFSZD+BCw3D4uWYM+hhh7A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.0-rc.6.tgz",
-      "integrity": "sha512-ZHqZXmmdcxzw7HKwrSJDlU3/GVulvX/yAc1xHu7hw+cXWws2QK7ahQMpfdiywnxAVYadhFnsvLLkEPp38mOREg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.0-rc.7.tgz",
+      "integrity": "sha512-JZWDKCbwKHOUcm7+JadKA3aJCSEB34XfPycCtPgdWfABIiHMaSpnmSVy/8Jed4hw6hxhnR6A3rnvW02Xr2yqwA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "ws": "^8.21.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-hmr": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.0-rc.6.tgz",
-      "integrity": "sha512-DKm5ePNGDRCBVoyb42vBtE34M+FaIwgNwmJLu7xvOCj/XNlmgCBTakHCoKN9oBZLAPurC+D0skPEcGRHGqzBGw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.0-rc.7.tgz",
+      "integrity": "sha512-uJVHLMgmf19JI7UCqrC8jipf/5oaM539RPJ5sNv+BJCbt9Ik6VqaKbu4uiF+gz8i8EqbXV3D9criL1IiCS+pdg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -1062,405 +1067,405 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-locale": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.0-rc.6.tgz",
-      "integrity": "sha512-IoSLGxfHgcoaNzIlQ7YRTHRTy/MQCvvusrPCwlT30Xc9lpQe6Yo/LiRLDXlm9zbhN6imf/AoQZIfO+T3VGqneg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.0-rc.7.tgz",
+      "integrity": "sha512-1onX79wXJfAzdwIJPUI9jEVYeVQJfWwyQvyL/OmGrnkCs8srJHIXBdYtsUC7ILlR13y5nOY4j6bifBOAoGRn6w==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-modules": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.0-rc.6.tgz",
-      "integrity": "sha512-DFeXjfbfrU2LvVziHsqBsfvnYVuqXTpvNybwBDJqGBNR4VjPVUbvCUrH8pzFRkv0bQO6Vq6dLKUR0Q2ZUYdTwg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.0-rc.7.tgz",
+      "integrity": "sha512-hczFl0TRH5sLt/dS0+TMCtQvfDoeLw/r88L6n3rXfY6Q1e4Yddg6RAv4kGsUoMoLYgWi7qPwD6HcUGgyKkDPHg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-runtime": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.0-rc.6.tgz",
-      "integrity": "sha512-qprJMsVPLK2CyJmmCHwECJZlbM7XNG5yKr2Zf/yKYRyz0+QNJfHlIt+4C32tkjFFIq+Dx3gU5YaUQaLXxsR4/w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Ish2uFML2FibTpzo7QyVSt29jf/iG4j9BFQ41ychVMPRR3trJGM3h8CMuam3oKWlvB8OXVXFd6gO929w6PI0Ew==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
         "immer": "^10.1.1",
         "react": "^18.2.0",
         "zustand": "~4.4.7"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-schema-form": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-schema-form/-/dsh-client-schema-form-0.1.0-rc.6.tgz",
-      "integrity": "sha512-2kFkweuNJlcnYRTy6rXx1gWoWNapFCDOvcYs7Kkir8n3JwQVB6xwTkQxVuZDBTD4jrdIpKTeetx4ghig49joTw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-schema-form/-/dsh-client-schema-form-0.1.0-rc.7.tgz",
+      "integrity": "sha512-acGeXjGl2lMqCO+jY1z9/FKbIiskk7FZO266OSBOwHJQP6yBd5MBnrvtPJUB3glP6xsQK8neFLLtRwVgRJ+GqQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.0-rc.6.tgz",
-      "integrity": "sha512-kJeQdVrUZ0skjyWIAwf+YKZE4VgUXT/7HGQvRVWSWRRlQ0X3dlWUgJnDDzcWBt+cn0cfR5/CANPrPiYEveBxdw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.0-rc.7.tgz",
+      "integrity": "sha512-85GLGfg3iEISMhHxn9ZePkB/mtXIJdWkpvSHCm9bZizK8KiyRfA/OjDpKfk5kvG16xKNV0KQo65HOf0JdwtyXQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.0-rc.6.tgz",
-      "integrity": "sha512-/cnnH48758EQxJB/p3qPaAgFmQuxNgu29pGzSd4jH2W9dM29lNkLLZ15mrpS6IIDndx0bEzW/nLJ4x6/iowHnQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.0-rc.7.tgz",
+      "integrity": "sha512-IRA778yZpOaoJEkODlfydd6yuASf7hF229s64IY5zaY+22K7D+X1cmDo8D13UylxQXFPAomTlHtQtQpCtghKXw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
         "clsx": "^2.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-commands": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.0-rc.6.tgz",
-      "integrity": "sha512-he9tgQtm/yy4qJRzob37rTqfb+FTY1YWzvHjDwfAWzsHH0R8vO2r0L/WHX8ZFpdGzzcPAIGuwEjkDa5Q05PI0A==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.0-rc.7.tgz",
+      "integrity": "sha512-gLuzEmgVhEIjVeLlmIAdKX/SEEFavnVOD0mQPlHIMqFAX/80yzYfRD7CMxXc0amOj7uBcw7qsSa4WzFvaWso3w==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.0-rc.6.tgz",
-      "integrity": "sha512-pKDKZYTRvO9pBTyHvVOtPDuTzNfCHwy7GmeIaRLjyCORLPM3uv0BuMc1qIHVI6LcK54l+cRGIuSSGah3bO/0vw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.0-rc.7.tgz",
+      "integrity": "sha512-CyjFjP+oRJQ4ydX8WVrKUeloQnAJRA/fN6RRY6NAHldFC9pd1l8YogmTcR1JuCIlqzMnLRyYlGODQBYz8WOjmA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.0-rc.6.tgz",
-      "integrity": "sha512-gYCef2obc7UMKOjneFvU8pTK2FehGNI9rqvZW9i1CUZ5pSJjAzJ14C4noIMPQxCrhj37QehrxyAC6Z+XzKYEYg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.0-rc.7.tgz",
+      "integrity": "sha512-8OwbFdMHRIE7L2PvoIGwSOkhUYsznr9u773K3s64DMxp4oLLl3ZzHc2hfaOfQTTmyE7ItpDJm8Von42LsJBKaw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.0-rc.6.tgz",
-      "integrity": "sha512-zs5pa0ug9gFf2+X3UHTLCOcspKAzWnroNyh8BG1gZtcDIZtpabjyG/+Yfpm98Pxl0j0VBnpU0MUOqI5LGrHsHw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.0-rc.7.tgz",
+      "integrity": "sha512-uVN7TXKrGQMACKToSTPxOIeDlebQgi2OMiKBaKrYcI7jBsCRief3CTLziZ6Kups2h2s72Eo6gu/0eueccwLYew==",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.0-rc.6.tgz",
-      "integrity": "sha512-laXJjWRMPYaJaG5TuHB7H98Ahtg1Umxp6tH78WXVULATToJ5BLZ/7fPedc/rSlYwRQFFDpsmK0nNxsAVGY1RnQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.0-rc.7.tgz",
+      "integrity": "sha512-5lj27c68wWqroyIOXmFPGUDFQxICDYEcYAJSuV5ZbnHXyN2cBTTDTW4zJPwisY5GhKfiJXjhS0YZqLi54/Xn+Q==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.0-rc.6.tgz",
-      "integrity": "sha512-R2tdM0cLwMo9lJSl/tTmPi+jlilvVeVzBn3vZWeRDyvNzj3fwgw9nSy1/7FcwlOuopr9vCAyf3rRDZrnySYixw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.0-rc.7.tgz",
+      "integrity": "sha512-SZ9NuuIDrBjHJsEcnqwhbiCZknjkyNd0ZBHDl453p2WHkfA8zwDMUJRdAMWd0sC95WH2Yu4rMzkAVYjZwCBjVw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-goal": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Ixbqu74dbqjkwtVdvCAZWvUfjOsc4N5wAQvNKXR1eB5O+d6j0K3jeGb2rGeo1vCoZGCZVuawy5PWTKuIr2ZiRg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.0-rc.7.tgz",
+      "integrity": "sha512-zZEAbaA6ZCMw2ZDGMWFm+nBXnBBRfI8StRtx33GoFcJHlMIP5mJfuSm2gcFHdO+3aeAmuTf5G++DdWwLRLZv9A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.0-rc.6.tgz",
-      "integrity": "sha512-lp6psRmPzkvz5JiVhV2tIovzVq7oo0LKbQcL77Rlcw1ZmHoZMCzQYResbMa+un9ycM8io/am2VKbTOaqrWjgOA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Sfn4YlS6dKm/ojGRyZL5oq34+GSeyirzGkmqhtoX7hpjHAhBVmugz2jku2ijYEjjFtD6YKYdWwvQxHdRaHFZ+w==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.0-rc.6.tgz",
-      "integrity": "sha512-pNJfFOyTyTG7XRysArUacNNw57J1bSoATozsffu5MA5gEnBDz4ZAE8uvlJjnbwD75xYBsfNoDABOWySY/rH/QA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.0-rc.7.tgz",
+      "integrity": "sha512-q8WvaB1gxj4OBPCLC/luDLQ7TRY2iwuhOZKrwG1MbXhSmfd14RiyKHG1p/5HIxwTJZfqnxuN69NzdAZY6cjU8g==",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-layout": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.0-rc.6.tgz",
-      "integrity": "sha512-JpQ5rzySpK7molQBfMqrcBCGDWYQngqZmFuFqhcxecIc2n5mBYVP0F5UbGITgxo+D7sDOy78RA1PWqZ/5b/g0g==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.0-rc.7.tgz",
+      "integrity": "sha512-4z5xkH/O8GT6ve1IX15WTel236fJwSuRZusMKJ9qIxdslZZ1h+wMbtgX3tCqg7mTtMznRDspCpC1b1QSAt4nTg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.0-rc.6.tgz",
-      "integrity": "sha512-CQqh/Uix3z5crbTb8lowJVltLRP39NfoRNoJ6J7gu9FaaX6qA8Cf5x4W3+hMnN2e7el6v3pVSpm+MicGypkeZg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.0-rc.7.tgz",
+      "integrity": "sha512-B8y2+tu1xorpHmwo8KWsLFZwa4P0uFCI32H1SwYyQjBjoTbSb+TOfPA3i6na988XMiF8NCcxynTFzHRv/77AJw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.0-rc.6.tgz",
-      "integrity": "sha512-adjndhpBq++KGOmA8aK12xTBYvTu1UnY8BCW6smOQa93VVPuMWqstDw7MFZ6mrFQoF3tHwNxoSo+tYWS20o+mg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Gr5goo9dEGCR/CqpeJgO1mGO1ZqoX4tpuAMuZoq3wmLwaeK8qOMMhHGTxGOI9NbBD1snvbUzOJP/LUoNrS61YQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "clsx": "^2.1.1",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.0-rc.6.tgz",
-      "integrity": "sha512-6Im98frB6nfM82HWOtAxGmN1lJHZnkwTJNcK9oX6piA+vyQ3LPXAmXq9dmTh/qMeIVgFkE+IljjuQ6hP0Wu8hQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.0-rc.7.tgz",
+      "integrity": "sha512-OO/miNmPCJS/5GffqXeBnPvdx1HnHvi9AHb4Uoy9N+zucwo7ZQV40lQ+ODcAX9UaRW/6x3a8CxQ3G4q1t/ltKQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-plan": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.0-rc.6.tgz",
-      "integrity": "sha512-9M3IOty+8exURc2h/favb3g5YRb8bkE1X1chyQjAaBqCDN8F3wtBSgc+jrYXW/mOabiM1vygliejvI7bDEjHhg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.0-rc.7.tgz",
+      "integrity": "sha512-b6qqGcq5MxulD+XBxcD3ZewgJ17OUegeSA0Ov0afC4hvgyhWhZP3b+odH92ax7Ckaat8/Yx2j4NPpu81e30qLA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-primitives": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-primitives/-/dsh-client-ui-primitives-0.1.0-rc.6.tgz",
-      "integrity": "sha512-vZ9/V5pXYbkumLEOHagEjzSWvVxX+CtXZ13+iNz3BnqDVsy0HYLgnrWwcLLPHqHLUmww9NlxXe9husoS7o/zyw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-primitives/-/dsh-client-ui-primitives-0.1.0-rc.7.tgz",
+      "integrity": "sha512-x3cnIAeOdDMd7no8JwP65q7J9Fj4xQWAZPPJY4MzgfQAAOcHJb0T0d5Uo4FXMiCcTeU/73n7BssS5PE7jjgiDg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/langs": "^4.3.1",
@@ -1486,224 +1491,224 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.0-rc.6.tgz",
-      "integrity": "sha512-g+6w62SWnwMWkn6VuLK6MHcSKbXQZD7oTYLG5wjhDRDULOEBCgikXD3LJo/esOsVncXABDiih8KuDW3Fg8TfSQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.0-rc.7.tgz",
+      "integrity": "sha512-I02BGKw3/yG25yf5omsMwmwJ2CnFyxTvbxqgRgSmTCUxATkLT87K8SxcemRZqXnFXQZhm6Il6bwVCpVfRfmNoA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.0-rc.6.tgz",
-      "integrity": "sha512-AmN1VkT4YJq0Tg7odtLteFGLvGZCklbmL/uCCc3YHw6bQ/n+ZE+92tPMDxjMfHVPPcwqQS5T57ReLdAzJ3WyHA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.0-rc.7.tgz",
+      "integrity": "sha512-L5heQqyzZ/Kd+/hj8Ptd89OOss6FI8TjD3iwC47V3Xj/8ZgtnHwEA7vSqeoTe03uzRz8Zd8ec+bz/q47z8/I/Q==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.0-rc.6.tgz",
-      "integrity": "sha512-cgY7Em1QNwVK+ou2hI6i/vQj8MZK44US/u84wA6zuqvtDTP45jgNfYZBy1BCWnnUh6HslXVLj/1WzawEZn3YLw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.0-rc.7.tgz",
+      "integrity": "sha512-q73sXPomdUGpucj6pgKuO3WrGzqCoqyZhbqOZQL7EIdJcl9N3P+tNhsNj+ls1UOcOpb36Ou2NzUdIeyHSNVmKg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.0-rc.6.tgz",
-      "integrity": "sha512-XRozBoG63/lH2gG8rnISASD3PwPGM429OQVXpJtryR/aPqsLoUzwAefmVETbuWlt25R82dbmGiX/y45dAdG30g==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Ei6q5/UdUC9SxrTcbn/XR1NCe4iZgovhmbKCKBKBHMCNxhE0umdUJL8M7uKZdlpItJQ2ggiK9L8RmztKDmv59A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.0-rc.6.tgz",
-      "integrity": "sha512-KdBqYbXmkt5WMdEC9Hi0jcCd4T19YqE4VgdZSFBsvNHR4RVMAS4G7EgZey2NdAl911Imc/kKsANxWLZ/ETquwQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.0-rc.7.tgz",
+      "integrity": "sha512-oOOgj9NTv1GE+QdKhBfkcWG2+WS9uJz5NYgIZzahbg6xCbu4a2vugcCKcyslQEKKOB35mGHH/orPcoj2N+DeHg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.0-rc.6.tgz",
-      "integrity": "sha512-q31eeswx19M8tKeMFsDTluWWi9fqZ/m4l8xT5m6eTB50pFFkaPHcl10uHzhCOOxKPMUX3HM4TjyoOclZXruT0Q==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.0-rc.7.tgz",
+      "integrity": "sha512-YduvLROf3gniqYggfRfkvNDMtqvWlREmwxVtxullWTXhrgXmcPya7GCKJeru8ZuyrF3FU1XqOR8KJT+OzLSv7w==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-skill": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.0-rc.6.tgz",
-      "integrity": "sha512-ucxbx/It3eZodYUfW6tcygYtvERm0xojcpb5OjQ1YwkNh8ldplnDioONTdDVqVTDczIz8vM66QvASr8K3kFMSg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.0-rc.7.tgz",
+      "integrity": "sha512-jxqQhu4RkNjEf2zTm/h9qJZ+q/mHdSBVC05XqfsdNP1VRni9k9L/LcR2TWHfyuvM61drtdi5s+/ZW9pbxaQPiQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-slots": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-slots/-/dsh-client-ui-slots-0.1.0-rc.6.tgz",
-      "integrity": "sha512-F4VZA60bMRi4DAbZvNipM4E/Jl01QC0cQCPpeIEIh1/lq/y/bpc7IqujtzWESHPe3qSljTURip3hkANfsYs3UA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-slots/-/dsh-client-ui-slots-0.1.0-rc.7.tgz",
+      "integrity": "sha512-5rPP/6IWZflhiegVHU56IOPGHtrhLgBV44mOFn2JNVwiwxxmKeIhEcnYD4M0eKkI+pRiJIO5WvkRYokIGgyFiA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.0-rc.6.tgz",
-      "integrity": "sha512-8yZkEhPCoOhtDfz1k6lzjF89QS+9zL188dQytCIXUewlhReva6UdoNvIX0OW1a6evDlZ/Vpn2P+mLb4sRG7n7w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.0-rc.7.tgz",
+      "integrity": "sha512-geEZbS5N68tYJIPSToWIFPj0EjRiJBzryLvv3VL+INqt6urYCEm2uY7arNLUFJhHpjOJVi45ZM8qlh0qw5Sk7Q==",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-theme": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Wu+bvnuti/gLA+t5a2cWUMQJ5UCqxt6oEK+OJiJ68gN0ixs2skpaN0nFdFoY2exC5KByXrNlN1rRrD+FsZSBLA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.0-rc.7.tgz",
+      "integrity": "sha512-T5YaUZEJv0XHL0VYuP4/Vg+tbQGgRq0+gqsbqryuU5nq59PPISDED81zpCSb1jkZ/xFNc5Weq68+54cUGndpQg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-tool": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.0-rc.6.tgz",
-      "integrity": "sha512-pjNksBDDwWdRTb+YiZ1DSXWPipfw7C89B4bydopjwBtacOmx+rZH8Z9i8iFpmMwD5IFVd9ZJzwRR44sYkiun5g==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.0-rc.7.tgz",
+      "integrity": "sha512-smo+6QWddCdtLQb4AUVbaaxsu3h8ImQlMDTBYK4qeoxlVTQdKgrNdgtQe5YoB8bvuGLQd6obVVwwScPNaD73xw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.0-rc.6.tgz",
-      "integrity": "sha512-pTAXYZHfbiRieYzfpH+BmLC2RXA2SDqT4oxGmW5sr2frBOXCZMsDEXJ/r770tmgQW9hzQaK58Nua74ru/bQg2Q==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Iuksc3q9Rpwj+EQMoCv9BqfLBEclDiUGiGwUec2p2FhZjr1yEBK4ujlQK2N71EteyBjQ5yODE+/S+TzNkrou9w==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.9",
@@ -1711,241 +1716,241 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.0-rc.6.tgz",
-      "integrity": "sha512-NiO6w/10LfohgdQKbAihentLzQ72xnc9GdGTZ0DQTEpDu9l712g8OFeFOTcTWycn03N9+tBBTMxt/L21aavMVw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.0-rc.7.tgz",
+      "integrity": "sha512-HrFy3NpBx8J1Az+4WCljgXQvt/TTa6G3SKgtF0ZxdstB+BYoiMyBjO8aXAKQ94BM7zLcOVfUmL1bCb9t6tFmvg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
         "clsx": "^2.0.0",
         "react": "^18.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.0-rc.6.tgz",
-      "integrity": "sha512-RqaBep4GdAsa2lZ1u2FPsu564EsiloPkvmfU1Nyi5j7+h+azx0wfxAzs5WI++TApm2qsbaHYLK/yxAlkyW89NQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.0-rc.7.tgz",
+      "integrity": "sha512-XTKDLADe621GN+D2ysnOdVFvK1Et4nxvdrvsCxl7epsfrelsZD4l+/BleUQ+G/vQVZt3v03VkVVnE0SPGpt9Fg==",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.0-rc.6.tgz",
-      "integrity": "sha512-5Ajod9AuYaw4gMw0DNVVA5XEg9bm/kkWaJwXWw73JQG0FuRFRxNtVtN2p04lRVdZ9v0o2IkvNLVrnexur3S+uA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.0-rc.7.tgz",
+      "integrity": "sha512-+8TmQprJ4y1J9AyM+/ABkndWsv6/lwA7by6HlRup4Ks2auQBhejFG7FjZPFACjkWLuJaIgDUN1aRQ5MNFCanfQ==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-web": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-web/-/dsh-client-web-0.1.0-rc.6.tgz",
-      "integrity": "sha512-T0N/QeR/cVwj+Ss/GjnbGoEy+a63m5nhjD8Z9eRhaj3rgJHAoYrGf08/IbzAqXULZRZ5Y+Uqg338yhMymv4hwA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-web/-/dsh-client-web-0.1.0-rc.7.tgz",
+      "integrity": "sha512-1pb5B7V8vhrgoCFsBwa8A+MsXkPvwPJ8fJ5ldMZ4Cd1RyFPgVev48LW/z2WF4tc6qkots2wnjZ2i6bMz8wvk2g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-web-react": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-web-react/-/dsh-client-web-react-0.1.0-rc.6.tgz",
-      "integrity": "sha512-2PAnRsZzokVr/nCcwX87axdxzobQYp76xzX70vYSqghlDab1phsIdgDSm1JxpszN9G3ETBMTLPM9xz30iodqYQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-web-react/-/dsh-client-web-react-0.1.0-rc.7.tgz",
+      "integrity": "sha512-aw8s6RgMVJNNPTHB4TzVmKsuROp9yZDMKKXsMEEha8CESlHhCF1c+qxLsjAcilwY5CYCwin2T/3lot88k+ITiw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
         "react": "^18.2.0",
         "use-sync-external-store": "1.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-cmdline": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.0-rc.6.tgz",
-      "integrity": "sha512-dqRHF+kIlTBwt+fio/34ttp6B7Lrpm31A+EOoEwBuwaziiHTEAWVl50hS53dPFmPyVBRINavBdx7Fa7UT2/2iw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.0-rc.7.tgz",
+      "integrity": "sha512-jNY9OOSpcH3csXqCwj8MMinByo42aUVIEauTSK1tNIOn6h6q0Y7SPu1ObIo5i3k0Khh/OWIiBTS1SbBlxcJHjw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.6.tgz",
-      "integrity": "sha512-aw8D4IOeMo11A3uxQeE4LFoW3bvaQnVkGFqqtS+lsINDARrOCJHXLUgecoKpys+Lc5erZZ4UQDnymJmL4OCcKA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.7.tgz",
+      "integrity": "sha512-vzW82eU4so0qJQ/XS7BGBUSguJMAgEOW3GaJJW0g+W5ysBJg+UC/Jjo1Np8mPjSpjjl4eoyXpshJzrwjoxCpRg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.0-rc.6.tgz",
-      "integrity": "sha512-I2YX2ZSeQnQrSJGffM2upL+7y7vGsLwKv478gesusgYtT0kH/MOcszO9ZpnV8sIqvlkgzvWgBhXzniGHWh40ZA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.0-rc.7.tgz",
+      "integrity": "sha512-CEGOMie1k733yc6TCSZuAtgbcs5H2QPO9wZnDnkx/kqaj3W+cEZGz6zZvljYNMWspNpomDTqOqpcB4ZAOI/K3g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-compact": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.0-rc.6.tgz",
-      "integrity": "sha512-aTadVzxYa+Me/9QqolHnXaduRVKPxe8z3XraZ9EdQp6Cz/QrYS9DMUbO2Bp434qgwAdye0SytuHLBBb9h8GVQw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.0-rc.7.tgz",
+      "integrity": "sha512-zDBNVlCAwnieffyctzqZ7hUGLJqyTjqvtCEvzSNckmd2owyuYNPDIeFu4NTo/xN8Z/TISiuGbgA0wnIBCIsNtQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-feedback": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.0-rc.6.tgz",
-      "integrity": "sha512-VGVszTifY/LkgrTOctj8FRCVm62fwLZEGUan8rTqxLwIWYt7JZ9avckTtuB3Ls62hNBKGSAdbZ7fgH4n8KKMxQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.0-rc.7.tgz",
+      "integrity": "sha512-DM/EGrz8vvgRJSxV4UAWtyJpxFi1v8gWkj/iT9q5iGex0zNdDO4Ml0/u/e73brmN3bsGyubsdUuIdkGsl8n/Ig==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-goal": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.0-rc.6.tgz",
-      "integrity": "sha512-3roWsvwDYPswLmpxxKcCjAAi8rRP9+jXhZ0yCss/zNAAKHgxlO8AJ5EcTkWnN9ODUnwzith448aQyU5mbm+GCg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.0-rc.7.tgz",
+      "integrity": "sha512-ezuYaKmblRkOaFLUpzrTK9DiTrbES2lBtmkzo/Fg4UteDHLBVEaBgoips0J15gXJm8mE6o3LHhsgmGCIdNepKQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.0-rc.6.tgz",
-      "integrity": "sha512-dq1GZmGTPXEGG01ksZ6Jj6DxAkzAbg+nepvfnM/P74d6EUcsFsEy7CfS18n0VJ6/2Wp0xOWsQyyuFElqbynO7w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.0-rc.7.tgz",
+      "integrity": "sha512-SYrQpJZQ4fvfyfw3IJ5j0goUiOFZb1ZhcANgUp99HVlhhN/l1oEOAvEZL1efaSE7KIG6qp4JEn7iLtNdo8+mEA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Uu8qgrHom13gdwwxAnqmNuWM8MqafkRlhjQMMJYmaMVVxjEUewSJ6lwtMbUEBR5ViLsfv4pTm5TnhxNCjedBUw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.0-rc.7.tgz",
+      "integrity": "sha512-9SDsfhfOzriMw4AF/md6MDOjl+YOwtE9BKFwunCGzfyWZnOUljoKEZxjtU0w1sIESSAjJnTicqb2NBOAIV9YQQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-basic": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.0-rc.6.tgz",
-      "integrity": "sha512-sqfFPBy1SqsOmaWro/GOAcDkrryjsmJLU/M+V4HZakoE7hLyGVhMElrRG5E5OlplIl2Akntc+YYwX36kDfEItw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.0-rc.7.tgz",
+      "integrity": "sha512-c4bkTsJMKeDDgN3F9GBvEJCnsaLyl3I+uXb42rBPhOzH85bG2x55fMO9lBhtpvE5h5JUOP/tBMtTAW2OCe10Mg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-compaction-tool-result-pruner": {
@@ -1954,44 +1959,44 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.0-rc.6.tgz",
-      "integrity": "sha512-xLtF3Js38AvKRITHi1ghWShsIphgT4EPpgr65VecCVpzCun0Agok2rZwKE7Kecw+pw2oC8kafHAc32SfmUudqw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.0-rc.7.tgz",
+      "integrity": "sha512-W4SbSgHlAhCB6ZXjr1/BdRiTn1F1x5nZdCY+0AazHoJY9FDACN0hUd6Rlkc40n3x0BHxXN/sZFDHCtT/26Fw+Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.0-rc.6.tgz",
-      "integrity": "sha512-ESZ/Gd4E8F4VjNETEvS5EGeYn1J2CpLMlEHjklaE8HJ1lww/D9D9AMYQVvcn+QmnF0mX3pqmwmeKtA2lh5hOqA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.0-rc.7.tgz",
+      "integrity": "sha512-D8A93lu2T1/QfT9yRErxI3ptgTyGwJUIorzf5WQe4+3/buv1LUKCXJHabm0fknaDiQdUOge+MjdZDNV2SoYGvw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.0-rc.6.tgz",
-      "integrity": "sha512-opN+kvxYf40rBVWhURZmq2E8uGWkv8r9L0YfynYAu/2YE7W/oGEQx2x1Mp0LxuWq1uec8rtu2GL2U17ORNuuVw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.0-rc.7.tgz",
+      "integrity": "sha512-A7R39cSNsLwjm+P54bUFBUd5+YbdyKkC5cLQqYt12STt0Z06az10Qt5rsL25rnWkxW7x7Ql0wVA83tOmO2oy0g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1999,31 +2004,31 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.0-rc.6.tgz",
-      "integrity": "sha512-zyYRs3A9gxfZjZfONzJdMhM0Gzbslpha+FGYkLDRAozgPj0N7mZdE+Qflx2V4WNrCnsSjuvOW0HFBxWtSRUTUw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.0-rc.7.tgz",
+      "integrity": "sha512-24oY36x90GN3QG2BASlryjzsO5eLA1U9vsvH1tPtBRJ1pBC6JqnW2v0SfDI/pcMT0ZbWo0uEATiik8rrv6xRpA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-DSDcC1i8hd3Ynyr6MTPFoEdAsxcmZSLo68IPBPvaPGHZ+rCX8XDAjghWvXrNkLtkjms0ngNVPJS3rNMRcJFq0w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-3HB4nHXzR3HreJE4MfVSX45Am1/JiKFSDOYmrnyX7kK3Hvb9qH1J2Mm4gCzNislCemhZ+wlYQgevrvyH1L1PvQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2032,31 +2037,31 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.0-rc.6.tgz",
-      "integrity": "sha512-OTkwb4QsZgmjtA/8ZEPh1FapmrBr3N989/G4Wmo1JkAvKbMxkYty6LxjckOawTTz7GJTfUoZCrw9uopDfIMMNw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.0-rc.7.tgz",
+      "integrity": "sha512-l4jEcfjrV7hWTQo6sH0oXntg4pz1nVuDXRcprps6NhZ0/OOer/9SzUx7J9aLnLeX9XDtExXsFbxkXW5Js3ZFwg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-zP0OW474s7tvzEVQnBBTGL6Jrv/YyQXt4nswIbc3Aqr9JyHSfhZ/5IJoipZqfYXLS3ISWMhrF2npRg8L1NGsIQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-gbiH8xBrBw/1iRM3MLwI9zlFqLRg+1d+hNs8Etdn240xjWPuFdv5Hjg+eu4V5I+lU3M/lZieahEUpwYRScGuVw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2064,39 +2069,39 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.0-rc.6.tgz",
-      "integrity": "sha512-EiBMACBVmVEs0fDFkbVH6OwXrVDp9GrTG8c62vGBfuljZvRNv6yVwS+SDblboJrIPcp67axxHRVPOEy7z1CUKQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.0-rc.7.tgz",
+      "integrity": "sha512-UbLBBWzUfBHAaZ6xGY/pPlIemGKz2iPoiCfmMkFQeLXVlLzeMrsTY4mvdx5ywu63tKYHvPpHHGdXMRFHqrTBvw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.0-rc.6.tgz",
-      "integrity": "sha512-NLUeuZkeQVNPIpUute6TW4Ts1et6XxLkQIOxunL5T9mXwizp+tcdCeNjBW6XMiG6gvpECA+IA3amFCvbVSXtXw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.0-rc.7.tgz",
+      "integrity": "sha512-QMv2QbqVAKkFAmIIPFmW8cvjk8U9T4ZEVsoPdbanw5Enrg3qEYZUmii9WBkAxNtQhG5MRUf5Tg8jDkZqPScYrQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.0-rc.6.tgz",
-      "integrity": "sha512-cONQOvFqZmjtw5HSgbXJ5/8rZ2gHqdf69ONhH21cLFu5jJKVy9YbLt42SlD2sdGMv/co9nN8Kt9bWQiZ/96VbQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.0-rc.7.tgz",
+      "integrity": "sha512-/pI2o0YcP21ReT+OQx7aA8SyUsnuEHxTQtMbu3DvN9ChvaFeptCTXGvHWocwVtzEEi48mdvAXF4Mx0Ptj1LJYA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2104,176 +2109,176 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.0-rc.6.tgz",
-      "integrity": "sha512-+tpbRXZ3nq/C2btBxyFC88RU0IC0H39JY1WyL07fq3j24AWS5jZb9/05gEJPyoyaIDkV/Li4dJVCdJH4VaF9Fw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.0-rc.7.tgz",
+      "integrity": "sha512-PWIaza45vFqqrf8bYyw5tPgEXRqLliHqAn3uKEwui8b1hM6UHJtApq1jX83PO4gtJZs/yAnRK6LCbaS5VJBC9A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-headless": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.0-rc.6.tgz",
-      "integrity": "sha512-0jdWiQMWwkbJ/PnUJng8NrrBM5fsMXCWYFKW3CUFCllhEMJwhoSrd5F7aRsqwKrIGqTRORLPRVOxdawhnVCSGQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.0-rc.7.tgz",
+      "integrity": "sha512-EKn/wrMKgqxPUPwLgoTGk3BY8vFcYSYBWfXxnc8ZOKiH2pmprKnzm89AcOkbERNBJzPySQEsDdSoWwWJ2Mut4w==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "commander": "^15.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.0-rc.6.tgz",
-      "integrity": "sha512-gIiUBmqB3L8inFr+hvjZv2/i6EVJOHIHCHg7bBFVhcl4HDK94+8wUCXTLGy80tcuISzIQiIaLuJq/NhSmV9Amw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.0-rc.7.tgz",
+      "integrity": "sha512-9Bu0eAbPw/FfCNpiX9hvyP5wedMUUQBc2sVTtU+xtH27/iUPxXoamFtBt3ydBJUeuVhja/leuhJ/d3MRhXO9fQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.0-rc.6.tgz",
-      "integrity": "sha512-sydiTngUEtvCyUwtCpXusQXVuiq0Kv7t2Axe8UKbimhhQLktnfhAmsEF+QHFTG5zcnxAuuigPiUTeY0Cr8+CnA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.0-rc.7.tgz",
+      "integrity": "sha512-oBCIJzzvVXijtxAPqSlQUlYTywEmkn3JEpMB2PM8W4UafnxNhqvDh8ikGE7/1y6KWoFUS4jHGwerUzyp3C6oWw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "fflate": "^0.8.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.0-rc.6.tgz",
-      "integrity": "sha512-1XafIFC2H5sPi720ATQWgCTgjZum7ZUng6H+z9uDMOhkKLFO7X2n8D2ddmGuQINnKV7sjlw0Q1uBr/sFiY4Bqw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.0-rc.7.tgz",
+      "integrity": "sha512-CamVZ4wOjGcgzOiRFQtG0J0hy4EY3nXJBRFs0S397+H7b9eJUTtaMdOxP5w7VhMQ0Aq2ND7gpadwIcFaqINsMw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.0-rc.6.tgz",
-      "integrity": "sha512-0jtXMY67uVQOmYjQKxN3PbJrrCEe5YjDpjw+gpQyuclglyZbZpDzAaoboRnp5PyvM/EQPS+TK/v05/7QNj/owA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.0-rc.7.tgz",
+      "integrity": "sha512-QFuI5xGvVQAtbgN5xEZddM9+s5/2GWem8Gvq5hQpi1faUPyY/GS34B3lpuui0khSyS2NTa5GUXtYhDN1qZTVjw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.0-rc.6.tgz",
-      "integrity": "sha512-NAQOaGoEEpC0XEV5k6He/8t9UVy9EM/fq8a40dy9XjgvcCePelfOZOLaN9lnIp4UAY+CbVFglhzsuFF5M2rueg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.0-rc.7.tgz",
+      "integrity": "sha512-yVHhAPK61gurrgys+xKia3RCr2OlwFCSb/XGzSDuzkVtAmqtG03oWTvnMiNpRKUyGCRFdgN0TP3QDg46rRlQ/g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.0-rc.6.tgz",
-      "integrity": "sha512-mr93KFRWfZ5HeAOT7N9IUYCzYsc7/CwG+tx76ozXL5znyUFS7OJfTJovcfglQv+GD+0wftX/N/857iVDsxr2cQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.0-rc.7.tgz",
+      "integrity": "sha512-CMHnPXL0oqwCnwt4TVRBAUfM4GNwkcZ1yURLlUo11ISBYh11LbOCXri3LoDjXzdCaZ21CWEKl25sZHnHnQ2GWg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.7",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-frontend-static": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.0-rc.6.tgz",
-      "integrity": "sha512-WrUEn7jCykwbn+weYWbZrrWWOf4VGNsdv9m88AZK9+gX39EqsUU1mZhTMVlw8Pjea11/W091sszyyPDgK8HJNw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.0-rc.7.tgz",
+      "integrity": "sha512-qSKYgM2W5EV8mE5J3OEujTY4z7mRwPBCRK3hQrl8vm4IAuSf0vfv2qrS9rpgU2SUrpHlQCqsu44bp8OPX+XeUg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.0-rc.6.tgz",
-      "integrity": "sha512-FObaWsBb1Wlyg5/UH7nSNRUCjslZmUEOO90E2g01asefzXICmvY9rDsaAHzOvuAljX9+IDWn678kDJBK+3OFkA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.0-rc.7.tgz",
+      "integrity": "sha512-B8ITfMnBAdgkkuvoMrBdVgydhsCYGnP8XIGXIouOQyT9/eWbD3WqO76XG+u+e2G36ACXu2NaIxsRh3ijzyorwg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2281,28 +2286,28 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Zod2L+JPss8uGuVMc+5VMQYidCyOZWV8H7LsvyzVR73dhB9zIIm4smuRwuHrk6ss+F/QWmHWV+/yUgqbBJTLjA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.0-rc.7.tgz",
+      "integrity": "sha512-ip6HeN9YpWJXgWKAWsL3JUrI8j+MHEvbQ/m3U5ubP/Pc0AQ9x+6xZ/nYe+22112I12rihiwb85ykFwFfx0QbKQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.6.tgz",
-      "integrity": "sha512-WfEfOi99a4cpOugRAHTBSTnesLieu3ist1q9PXDXFBHX++K1rAl9+sB7YrdnbB8LH0UOY532gS9xJUYU6w0SLw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.7.tgz",
+      "integrity": "sha512-PnO1F4aZGUmqZPyuPJpBUfQ4DZmjCGCNGr0yuN2iURTP/e6h0kGnTNTYgR2NqMvAtpP66WNiHhvH2LMqumk1+A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2313,65 +2318,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.0-rc.6.tgz",
-      "integrity": "sha512-fmyvSOVsNObmRnciuH57ZntuCSb0gflRleCeQx1ToGHRoGrR4Ndnstx33SuIXUQt6OSUhD2w2WKQTReXogpnSQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.0-rc.7.tgz",
+      "integrity": "sha512-+omM89dEsaiAL1XtsSTMmRF46POp5g25Qs5KVj+Zfrk7whlXjLXwFiaukt/htdVdHIOM51qM+tCleqlHOU0Chw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-vnCcHPjvXLQq2i80No61oKF/165+OvEC2iUBmVTxl6ka87yNECwYf4nrspHKqP9HbVWndtNP0lGgrnz7bo0XCw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-DAC8i+sshAkXPI8IcrUp5O6cOOkLLsKsD7mAcorFFbQjcPVBLdeRmtko3E1J9Jmf79IjoAvKVE+J+y84km9yKA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-launch-environment": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.0-rc.6.tgz",
-      "integrity": "sha512-tTRJ1464PJUDe1Em1qq0mfdgGREzGGWo3JSqP6xeYDoX+MRXVP9/ChsZ5k6VBMjARAxw0HGBf7WR6VcupHbMZg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.0-rc.7.tgz",
+      "integrity": "sha512-ATVyi47hyAWFINOxi8TGurRF8rShW/WzqWKqjxEQU5gLZbWtAMgkpAc+hwlyo/lXytGaj5cMXyzeyjpD6URHFg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.6.tgz",
-      "integrity": "sha512-kuFGC8bHlzGTwlRxQhXjf3CYWl8M4NzH+EYIkrW8rri4iMc9W53xrdvkil5No/DUlMm8g1u7GdeiWYFy0TMvtA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.7.tgz",
+      "integrity": "sha512-VaB9kQ8XOA+R5jtsWf92QMc1WpaatEAFUvQePGUYrzQ7Z86b9VhQQzmchh5VmknT4oRSSdn0re5tReCvfcYNXQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Md9ik1e8tmrKcL2aRpif8qdndl9TObbfHodj6CeVlkrL9y+PEghVPZqOYtnuRcv4/e0nVSIJsUw2gFvaL+T40Q==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.0-rc.7.tgz",
+      "integrity": "sha512-cWNbBF+LeFrexht5V8cFeo4Kb0KeFaQWtemPJeTHRcijafq4OuQvgJEPx1IyelzzX6vctLQGSlmvvCNesLvIcw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2379,19 +2384,19 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.0-rc.6.tgz",
-      "integrity": "sha512-5RvzkpVCYLg9A3IGdm04px7XOaF/xikuMLe2toBY4A0qtJraXiZtUN1QBOL9i6u7DTOLG9oHP/USsbWRpyI+1Q==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.0-rc.7.tgz",
+      "integrity": "sha512-8sZuvgylK9ZKQmZtUU4z3DVBcM4Q4SH4OWo4qeOahLOsteT9NdIwZFer6f0QwqH6DjXIqz2Gq+XtntYXznGZPw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2399,37 +2404,37 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-retry": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.0-rc.6.tgz",
-      "integrity": "sha512-HdjBWcQ6spwA8B5dScRhndLQNiKoQTkq36O+kmJ80B9V4z08K5XrJwAInH9cCxJ91CqNzx/sxCdDds0oZDH1Pw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.0-rc.7.tgz",
+      "integrity": "sha512-yyn5Yqth6vdScgmcYDF7L3a1jbfcu2y205HyTx9d84H+eU+h9m8k0Mc+1l8VCJbv9GILPCvoijP8wFTPDas7gQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-mcp-client": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.0-rc.6.tgz",
-      "integrity": "sha512-seBl0SLn308CbPwGVSm2BM3HECaNln3mbpcdHtw4DjnI5mZRILxC6wgKXAtYcNWKxMY1FaiwFWcgQ2+HHCQ7PQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.0-rc.7.tgz",
+      "integrity": "sha512-hjdki2TTXfyZMJuddOVXV0lEhZjdku2aoPagVKV4TOhqz3jDJE0mQds87mtDOI9J4pyRGWfYXky6HN9Bi/usgg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2438,17 +2443,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.0-rc.6.tgz",
-      "integrity": "sha512-yqI49BjgVODSPQex7KdRhc4fUquvhifRYe73QP3w6snXYB6058tH8WQk2Yx+m1APi60dLEAZ1AJibRA4oCo6WQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.0-rc.7.tgz",
+      "integrity": "sha512-P/Inw7dQMZCC6I6NC6G0UF9SeOVlpQxOBg2+LoCdvyTt40itDow2wmlThqkQDIt4UMHLT4yRc0Gd6a4gmTNJ2w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2456,40 +2462,40 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.0-rc.6.tgz",
-      "integrity": "sha512-b2AwcAlNmTDPho/dMQ5wOicEwkDG1FSNSCUvluFp9JBbM8AqUMI3rVuOGFPIT0BEOi+ehpW/if0BZ2S35FSEwA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.0-rc.7.tgz",
+      "integrity": "sha512-c7NiAYPx5Ho2ZYOODRvt0yTZ9l00n7QvRh8paiyLaYBOuzo30KDo5wTJXGLxMkfzi6EQsWw1tljd8MnpGL2P4Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.0-rc.6.tgz",
-      "integrity": "sha512-3TQJxGqjotWrvNKI+Da8nIDjzpKZEGpImeMBp7EklfO0CDbiXA5B0Ms39zBniWkWr1lvbm2iJiYERY5uDeP6og==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.0-rc.7.tgz",
+      "integrity": "sha512-bhmSfXIaLWLrYwC4ziMZ7GkNy5i9ltGBvlNZ5eB7NZoDAMh0Du7pKkMY+oqm2ajvx5O5qiFkHEhYoypRpEB56g==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-permission-presets": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.0-rc.6.tgz",
-      "integrity": "sha512-enFyuj9mTN44sMAwLoiommngZSY5yp09JtKOKT541lycacUotuvlTj9W+KJ0whtIOuYQ1jdIzYnyFGnH0J10SQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.0-rc.7.tgz",
+      "integrity": "sha512-AC6cyrinc3fQ2/TKmm8V1r/32f3VekR/w6rS1+RWGefRm6PDGnNo4T96/U4EoMyWDq0VBCn1Oye+uqhWPtl/3g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2497,50 +2503,50 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-persona": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.0-rc.6.tgz",
-      "integrity": "sha512-rY5AVVopkS9vJl+hGHGQP0nSwzxawubRvEKo4JZmGK7bKZlvevRvj8bd2wLNhTx54jppz+u0iEUq/fqG5k9Mvg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.0-rc.7.tgz",
+      "integrity": "sha512-1XhQNi3pIQ9TMUiquo+RRS4VpbXYhpFmZJ845kaVGToAexS2gJRVte8i/wKaDHDp/huAhJIsZemHlX0qADDsjw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-plan-mode": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.0-rc.6.tgz",
-      "integrity": "sha512-kabVmxbdjLSJkY3bM0s+VuDBuIhPNvKdW8CHXz/UmpQfm2KNfrS46+EEgDgRnz2xFxfAGLcV9KFm0iDEksE22A==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.0-rc.7.tgz",
+      "integrity": "sha512-VXUxBvmZ9PYinVbYsu7GmT8BZMXCfAbqExNMoR4RoZm+leOLzZOkWOKea9THoJwIik0lUbAO5lzrqaeVKa99Dw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-commands": {
@@ -2549,203 +2555,203 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-TtITwtlDvxyXDE4HKJW9R6uWKU5kr72Y+8JHYV3Kj/HPAzQqwbVo/2e9wvq7H4t5Soo8K+KG5ZqBpMmpp+FAWg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-AImknM43+7bIR9BzEatmbZMvhjgBgAt7MWqJzmTo1KnBNTY1j7r/RmOiQTBX4R+tpsLXMza5oW7svHSAYw/ypw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.0-rc.6.tgz",
-      "integrity": "sha512-UNVwsEyakQgjKYuWIIb1Xm03RHMtm0NdwYORgtBgVb2FV20KipBt1MhfHhBPT4FPPWIKjM94Vph9ZOhO5cCOeQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.0-rc.7.tgz",
+      "integrity": "sha512-mXJcllRKoGnFhVs1mtUjjmqdfMymTRif5lrtxdhlkpegH6E9qKF7Wyq1Wnjkpsk6QW/iCicrRkXF2Bw623eDag==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.0-rc.6.tgz",
-      "integrity": "sha512-iN9FjWXL8e/IrxTFmybTKDqtB6obV5jt6ao2I3EQWOhQ0GVfXBuz1SY6Yx7gILQXWsCUeGRu1ltLyywdubpJcw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.0-rc.7.tgz",
+      "integrity": "sha512-AdG/wyhpWSJcLkRqs3j2VVgS6uH5xQf0mK7WZsdQ/RidB3OVYZiBg9Mto7Of25AtV5lP7ZN6TrqCqWgi60XwFA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.0-rc.6.tgz",
-      "integrity": "sha512-SLZjuivQQKHTx4H7xlsjraEGGMIEA8BYOwvlm/9uZBrBrlttMU+d8Ne6QYpDcOwIEubL8mvrWRg8j3rtY3lVyA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.0-rc.7.tgz",
+      "integrity": "sha512-he43z39/SC8cMzPDsoP7EEXiXKjav3VClj/U943pxycvRL78JGkNEQQjv21n5mnuto0ti/gFBquybSI4sBAFqA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-W0CehRbWqAaHAYFw24wvYLlGxxJr2OlQQlFH/p1QbeNKtHzZ+6pgjksyFotgHdzOycNnVoBjb92RbQPfJhJZ9A==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-jahNeS/WnBinCisOB4O+zeS366v7gWt6Uzfso0/C5He/vZFEITW5jPfWrJkZLuuN5S55LshaDEnegsddEIp6kw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.0-rc.7",
         "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.0-rc.6.tgz",
-      "integrity": "sha512-XEB7+pJZVPWmZXv27EX/4V/1noVLUF5ZHyy3EY5tC4XtEyayWKtvHL4y9OTLIYhlU4Ualv5ag8s5ueGGq3ID8Q==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.0-rc.7.tgz",
+      "integrity": "sha512-TnOy1SnnSNPVZyw9UFNwQ7eE2lGxQBU6kye7+aAwDbNvSnudCJDEnQJhjTvGewHWA6PYA0O60XERKcCQAnK+dw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.0-rc.6.tgz",
-      "integrity": "sha512-/L1TUOQMsJe8B2v1pJpTaLwkvMQIwrjlUg4+6yx2flU7AyycjFzlKwmzQQzo19/evkiqO88mLgod3FiLhqxEvA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Br+Ocg+dr1PcCA71DxPJd7/7Cel+HLnRyglbkhSPx9mEYpXXgioVCkDHJh7J9OvjRw19UF56g2CvgVah6HwFww==",
       "license": "MIT",
       "dependencies": {
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-schedule": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.0-rc.6.tgz",
-      "integrity": "sha512-83p0mxkMUWwRZkazWICbD1SZO6hKwFVb9W3adDSR4wmojJQYTnawopnwTJn+Sij0V+gvvA4wTcL4rwDgbawDHA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.0-rc.7.tgz",
+      "integrity": "sha512-vlvjvhE2B07XG3X+jUsfEDUjsiEGln8GFdy+ojWm27FKtA8JuoMdrMMUcCuVHnyr23jyk2Ft/qGA3JIJUOvIKQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.6.tgz",
-      "integrity": "sha512-UlDLV4syLoJinNg9imhXrSAHrdaTa5Ff8gg46rzjFJGPUOhAk3DZff0hryT5OhrBi0A5Tj92qVpg2pRVvxnUzQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.7.tgz",
+      "integrity": "sha512-8gn+sANXhpv+9egbNwq49/uI3XhbmB33obo9yMyzyzruan3zFoxeH4UV54jTC2hjbu8gFNPsyNam9AAtRV8/Cg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.6.tgz",
-      "integrity": "sha512-8tu8I6VWC7050GAUXWhcEWQw4pakALQc8TlhKr52m7Y4+kIKeNt3FBgP86PaGPBtpK0p5zUPRQNkFpzZbBdxyw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.7.tgz",
+      "integrity": "sha512-02WVTkqIH+TyDL7dhMN3Hm+qcTEdhD0fVDC0aIAyND2fBdXj3CagEXXvpmt3mzwWfKwOTGL1RdxtC6pMA4Bl1A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.0-rc.6.tgz",
-      "integrity": "sha512-wdWNyS/95wI3QB9SHeeeQ9HDIWeFQKInI54Wqlw35H+bGGjGZE92nx9QiqiiosoxHedQFBdA0TKgON4EIoxCgg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Gw8GDvEJsH815NQuKkWhPPmw61hqhcdVpaaTXbCTAq/+0YdgNzNxAGIzizufAmq099QsqVWX0zs7IWGpWzCfEw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-log-export": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.0-rc.6.tgz",
-      "integrity": "sha512-/4JSblyx7p3uxgVXe/YJSqd7rfXzclKjhi7/XmAj32P/fFAsmD2BIjIykgqdyyg07N2twxpGuH0P6jtlrmOiBg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.0-rc.7.tgz",
+      "integrity": "sha512-yToQnjzMGl5KCq//k9bN4OUXxpyRRjh3hBtnf/9AVVSvvV5DGDLHryEm7erECLOnoWZnng5J5SDERcykrVbYlA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "react": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.0-rc.6.tgz",
-      "integrity": "sha512-AbNBe+IYCbZqSHqOACVdj8QTynm2HZ0cThrEuI6nGMtlWLYLx6lzZ1rgO/56Av9mIScjyTBGJAIKhEYaMTBG9g==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.0-rc.7.tgz",
+      "integrity": "sha512-NFH1uIGQDgMFOijgAv8lLWRiY3eHFEZW2alwuHlu4C32P4+jdChh9fjPlzBar3ZZTq0ZW0qWCdbYZS02DNxsvA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.0-rc.6.tgz",
-      "integrity": "sha512-US9Q4b5CZJPRRqa/M+WESL5VAOLjfYWjdzb3TQ/7zmpR4/+EQWCOFA9CtDSMh4t1oFOQBjz2+YJJcGu59MKHDA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.0-rc.7.tgz",
+      "integrity": "sha512-amPgKP84E99YEiOroeoQNya3Rjm1VRWWU6y0ft02iVtFohTmWRMLESArkAAtFfap76bk34xEkvujp34nJl40Ow==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2753,29 +2759,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.0-rc.6.tgz",
-      "integrity": "sha512-DYLALBPdEI1LZjJ4B6rdGdGY4gy+iR2+5Xh2xJoAGa/pTyN5Z55TNfvuMJrmeRBjAuDXNUQpmURbvos5rJ4veg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.0-rc.7.tgz",
+      "integrity": "sha512-BXehLYt6wYnV0PNNhv5GECePkH1w+1yuu/R63d2tdYdUQ7XVrd6tu5hMwfTH0P9AnBDxJir08FRu2WKO69JypA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Fqyd5aN7MvIiRMWxs0Q4dWmSMKLqdWNk5U97EFdeWY3Ol5bk8SSFfFrij4941B5y4K2f7C0mE9nLSQ3mfL2KHg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.0-rc.7.tgz",
+      "integrity": "sha512-qWf7p2Xgr0LnY4o466ei3L/81QbGFQcCbEi+4XX9rxLKgnU+RvlQzwmIilrgz9N2hK/RqwS1Nb03bFRisxVeaw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2783,26 +2789,26 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.0-rc.6.tgz",
-      "integrity": "sha512-bGzRrZnWuXDUtAmwkRxT74Nuc4PLQJmJ4IeGgSSTIGJ9JQCNbvVjr4ZWDWg+D/PvbZwh9mpYJspDZdUP42eWAA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.0-rc.7.tgz",
+      "integrity": "sha512-JKlEpByllYQU9JZLadrS3ClWCVZMcKRB4nc6iCWuNExyRi/Whwa5GicKFs+jXwGKe/rdSbTCom/jYLwkqipjuw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -2811,19 +2817,19 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.0-rc.6.tgz",
-      "integrity": "sha512-sbeOPAAJetQbvgyFB7zVANSlJPjNgEGxiixin/DI9TcXHcUqq3nrPgS+1iI+WJjD6/zhHdIticeEayuWXtORdA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.0-rc.7.tgz",
+      "integrity": "sha512-XuhVkX2V+tx/xO9/gCzPHGbovoApwaojwCjNFAuBUbHLMvMl1wMdxvxSgk/xLPKnll98daXRPoq5Csg6hrG8MA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.7"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -2832,57 +2838,57 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.0-rc.6.tgz",
-      "integrity": "sha512-ubnfGbTBy/NnVnY8RXhTTXGO2Ga21Ze/1O9PBCzQk5wYfTqa2SUtx7t4MiJ1rVsDZMQ4YMpehqqGJFXf/z2dhQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.0-rc.7.tgz",
+      "integrity": "sha512-lyD9VbGrOSVkAV8mr6aIl22bdWIe61lC9/dtZ6CtS3DLnewvSkZ4CNlUDG/qS1SUIZfk7A2UixgXYBIB2771xw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-stats": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.0-rc.6.tgz",
-      "integrity": "sha512-B2Rwp1klSl7DmRpViPnuIlmlPgsARdxqRpsz7MwoXTC1oKYipWgoCw8JFOsDxVj8Rno1o1kWVjVAM10I/FC1aw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.0-rc.7.tgz",
+      "integrity": "sha512-ryf7HSYdmLbrTv4HQmeW/h0bHLiCNnSZYiY9RoBrzg2qh89MU8S+Q/a9CLVWA06TRXKt7tNbizF82dCj2/O0bQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.0-rc.6.tgz",
-      "integrity": "sha512-x3t7lu+SLHvxhmOlocNyOwcj9t4MxUkzh7QyOh/YSMvWgojSOhNdnKcjWq4pE9PxFXBWMDpN3bLNvtk5jFA/+w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.0-rc.7.tgz",
+      "integrity": "sha512-6f5U7nt5Iqwh5RAFBqV2Ib7LJU2o89Et0r0eV7bskYws+PNM7ZRRW/Nw4a12ZcnuTp1eKPyVE8H6oJua6/7XLA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.0-rc.6.tgz",
-      "integrity": "sha512-e2tbkXm3wh33kkKNLfpM5q019DDG4Bpvlg1UyqZq3mffOP5O3e696mZA+sC0RhKB0xfLWMaAZq9n3WN2qtmWdw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.0-rc.7.tgz",
+      "integrity": "sha512-k5zHavA2RoBtZ5igD+qpbdfyxKvesZa2w+YKLfMtUnZOj7HZM9qcxvfYo4xJ9spNLpN5OGY/sWZBB5itilZlCw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2895,18 +2901,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.0-rc.6.tgz",
-      "integrity": "sha512-RHV1ujuomvQB63HPI/n25c2/2It5XQ7zNQKozSqYOPQw7AIr16PT9iFqC7sCQ4l2gAY5GI3FbI1cQgHzjHNOag==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.0-rc.7.tgz",
+      "integrity": "sha512-jhFiZa/C58zchuJkBodnkiPil7AEK8mHfB/hMOAW3N/7tUg5nbMLBERNqHdDMbIrvhTndrF4SN9qy+ltUf0cOQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2914,34 +2920,34 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.0-rc.6.tgz",
-      "integrity": "sha512-eYta0tVmNnivANde4R2G9NW4V9w1fq9KYod7kZ4YeuVu3rjObCmlXKOOJiGwRis21PC5YVIhaPxszM+V35zizA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.0-rc.7.tgz",
+      "integrity": "sha512-tFocCpSglf69VC6a23R9OcomMBQdfQZm8MvAOGgENBzWz9htDLuyq6jukKzPdTtS3VdRDu4wzJtaWKAYBUCX4w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title-llm": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.0-rc.6.tgz",
-      "integrity": "sha512-BiqsXDSbyZbQ1XtLhKpILKdnDgZaQKWopZpSQW+Cy6i0wozMJ/xeO+oCWEFn0rQtsgBY6b+rKVKUW4wc7u9Ydg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.0-rc.7.tgz",
+      "integrity": "sha512-mpQo/1x4jaWNdQAXckOs68U59u+/WHJlb/BX1zAvr02eJPV3Wac2/7NP+/vTw5TElEyzIAU8k0f3PMgvozUk0g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2949,29 +2955,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.0-rc.6.tgz",
-      "integrity": "sha512-5ZlH2FNRU0kkdcCoEJohvdb2fiNnxM+iZqN3icbR3WQbMm8RPRrXlZlps5YUaQKPRbNRHA2LkOXW998QRlhHcA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.0-rc.7.tgz",
+      "integrity": "sha512-cS1+StK2xIVykrskw+KrO+hKJxYaVVgY2Jex2we5zASTNLHYCj74WQluPlaFjFgnXoZ1RYz8HNXL5/Ho6h1Ynw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings-file": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.0-rc.6.tgz",
-      "integrity": "sha512-OgwvP/dTlrWd8MRhjJbeolMJHDdyjLtvd+gS3z2mvCGDmNkkf0RxcB/8o2uoqe97iuklTWmy6cCws6dlmnDL+g==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.0-rc.7.tgz",
+      "integrity": "sha512-ODz9QWtCOjmwX7gxewPBfIHkA9twPiHDpcwgAW4sQUztgsJZKUtoe2T47loNH6QlHBPcSL5WMP4/QlnkRVKC0Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2980,73 +2986,73 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.0-rc.6.tgz",
-      "integrity": "sha512-l/pcwbdpM+Zgp2AzH0kH0z7bPU7L3k4uG1t5Du1V5ilk70tyMSxz2upNfAbjkDHZZZO18LTs33aq+zRWHX1CUg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.0-rc.7.tgz",
+      "integrity": "sha512-in3ifbq80tn5cf1ICBBsRdwKjURB0g0dIRdCVUgl/GDqCdC/S0TjMLXw4nmFdCssYLm7JbG5a59BfJG0KFuz6Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell-env": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.0-rc.6.tgz",
-      "integrity": "sha512-znxHFSqduw8U/AxKSO8SgSt703Bl+irRzTU0ukJT+ySlnyAwSAg8sZHLo5ZlEt5K8BdWhxz8Vc5jibOtJPB3ZQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.0-rc.7.tgz",
+      "integrity": "sha512-joSBNw/d54gq/VjkHLGSJ6y/Qr+594sObF4ApbJi2eEopx41L0Ky7kNW/W7cbrGIIN3KBGRDdiGv1s1paWzsMw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.6.tgz",
-      "integrity": "sha512-VyRlCOASIRuTflKwn4NvbdAXxSPnnLJ+RAQUI4GK5pOtPwI2DhJrbovqpyp5kNAkZMsqvIeHWu5PcCEJ+FpQ2w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.7.tgz",
+      "integrity": "sha512-tDaqB1TOs27fSt6FZdjvPs4THXAFKoKOEgQG+iFUv63O5bm+glyLY3K1LTK8JeofB4lg3+4JIAeWRslnLJH57w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-badge": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.0-rc.6.tgz",
-      "integrity": "sha512-k268iImXPFwA3barkSqusu9OlA8BcC0O8ZEvs5IY9bUJPCC0Tlw4VY8bumFt/2DSwh5cV4bBzZk96S8XA1Pd2A==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.0-rc.7.tgz",
+      "integrity": "sha512-01Ue3mvLYyBwNj+fAuTUZN4gJLuDySPDqAZhCtWoYagZudCuLB8kAdpYWztKA4TRVSyml+EfGo1LrWvQeTD1wQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.0-rc.6.tgz",
-      "integrity": "sha512-NCgz8lCAdvd0oSGIF0EKg1OXfIC7x9r0an7mgC19F0DGzYZJe5ve6AwEYpSvKITE3V8W4NbUzLKyyZG3VH5QtQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.0-rc.7.tgz",
+      "integrity": "sha512-i95xycP3vkz4IZnIO4BTzGNB6waKl1M5AsW2x04C0FIqLa4BSILvVUVwqcbwpBZm7Cd/KF50Q050au3NvauGrw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3055,10 +3061,10 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
@@ -3090,65 +3096,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-spill": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.0-rc.6.tgz",
-      "integrity": "sha512-reV4utwd3E5LgiNrsaqh6i6zxHboVyrrL1ilALRukDbMxSyup1vuSRh+4CPxSUh9YcoToFJ6jz2Zmlsw755g1w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.0-rc.7.tgz",
+      "integrity": "sha512-EdX5AZElelHlCKlbflZipl4KRDiEHWLN/8smgnkzAhJgpXFq5dyp9jK58dO5v7cuODeq+/SfeDyUE5Mffdhh8Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-DskqKnE16ZFmlqEVniiZI/QjVpUfRVol4ZlAlc3PZ4ROmVqzi0eyXIVcxng5BDZSmjHbPO1PAh0I3TkAzFjMuQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-jx198A2cc1gxsoKb2pRmXnDbIwIHAKg78ZjRMyiLRGpOFEZugVudILdDMp8u+lGpavP9xVAxBc1n75Z5NDRw7g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-spill": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-policy": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.0-rc.6.tgz",
-      "integrity": "sha512-irdZNe/nZAeFKW/NyRZZS12sKLQhl3uLEPOCgYwh0jv8kin6fPdiW1cOqh/IOFuL+Bk0yF+646bRzamR9YUn8Q==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.0-rc.7.tgz",
+      "integrity": "sha512-fYypZXcXFkXybf8N0tz70+XCtxvnn9mDN8JiKnTp2ZNhXb/zvFbdf661Pp45lFWS6j0cHZsdZ5T8DfuQjfO94Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-spill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.0-rc.6.tgz",
-      "integrity": "sha512-zq15tNz5ywWuM15eqWADn7SKAPKyDYBto1WxZDIVJxHwQTBqu8gVaCdZo5IonH827qnabyiuJedgh9SkbSrTjg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.0-rc.7.tgz",
+      "integrity": "sha512-M+6+SOjWWcfYoGASBMx+b1sHmWPFAHXF57rE/Mew9k5tHC5bEV8+owWwYOWQfv41eO1FfRMibZd0rH6mwPNApg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.0-rc.6.tgz",
-      "integrity": "sha512-/5qDCIIf9JNpoRG5VrY/CXFIuch1tDE0H5XREHsKd6LE26TOHcTAUH6gyersFG4e3TPoOLJYDp1+SapFLd7+kQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.0-rc.7.tgz",
+      "integrity": "sha512-UxXwoCB0q4+/F+zddvi8I4LknTIlGD/1ec57Ym52kWRb7a8qGgrcIYrOC3yPCozn8rkirAuhEAkyAhR6AO5QDw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3156,49 +3162,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-json": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.0-rc.6.tgz",
-      "integrity": "sha512-BtpDh+k7L5f/wdvUXTNdtTjBORwRxpQAZXgFW6VaVlfsPmsIZZ3L7lrPZWIow9Cbv+lCT8uiFj7A/CxRMb7Ppg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.0-rc.7.tgz",
+      "integrity": "sha512-xYvEY3+ttxJg4/UPzXuxgeKcLxKvDP4alvPpEfRwuMBcp//O6FtzEJSqV8zycJVYHU8V0wmUKRIn4V1ycXlFgA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.0-rc.6.tgz",
-      "integrity": "sha512-vROmBDAlaFAzzSlTBOlvg/7fO55zxhUztnLtB3lKmN5RevrNQBjTsbeIMDQ8ow5ZplxEOnLU+sikFoA5JaoH8A==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.0-rc.7.tgz",
+      "integrity": "sha512-PEpA9XT6E4hg7N8m7GYQyDLwFUwoqWTz0Cm9SrdAoNcju4byG08qy4+muDZbG0a1tm3PR4rxNB5zKcobDhDocg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-agent-presets": {
@@ -3228,173 +3234,173 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.0-rc.6.tgz",
-      "integrity": "sha512-S+BF0f2U0YkUf6vD6ZF82nREiWlrVe836U8FPV6PzgnVNGkEOb21rH2W9TSRjerB1G6KWjG/oBqrQIdKyFElVQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.0-rc.7.tgz",
+      "integrity": "sha512-PnT/poBisBmA9U+mLZeyQJfHS4Ps8kwN1ioZEmv36TwnROCrmwzog5FB33r9rXU/gKVX0dD/LkjxxTGmzC1xCA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.0-rc.6.tgz",
-      "integrity": "sha512-KK8Ep4PeSyrM3YQdcZhetXsiBd+bliKu6NWWKyTh60LobKtVNREfPBlqRfzc0mU0ZIKD4VEC7RfuJaqvz4UlPw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.0-rc.7.tgz",
+      "integrity": "sha512-YleMt6xtXmW8LkHZ95MLPq1urIt1+sBUK908GCQ2EhV6nyfUwNog4XVDlVbzf3GXzc+3z/xiMW2GvVp3IQ5NIA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.0-rc.6.tgz",
-      "integrity": "sha512-62mtUEr5megxVy6CwQCdZVq5MCSt+kMw74ns5m7PK0PlZTWcxQVBQHNdfkE9sX4Cageu7YTvciUJuH8amm6bsQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.0-rc.7.tgz",
+      "integrity": "sha512-4C06MeBvsbgiUrWh+tge91wRLSOOJDU/Ub7b9Q6nTxQKEMJooJwCQRPfgaWtdXuNHrJGIJ87GKsgqV2iwfQ/jA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.0-rc.6.tgz",
-      "integrity": "sha512-nZaZRjSnE1he+GAd14vURAH7n3Fw5eGx3nzMbkB96Y6Qx+oQB/7PTuXxKVxlCh8TSfMJTf851ahwWb1eALjKlw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.0-rc.7.tgz",
+      "integrity": "sha512-xiHD61S2trIZ0CzhSMgXxZJVyJ2c76DkX4eqP3Of4mBEnm6C7g7FChII6uL0z5v1bnOnTmpHzwPX8YCwqb7dbg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.0-rc.6.tgz",
-      "integrity": "sha512-D2daTRaprE25ti1Ra69eURPwLULpnRyUHqAGtcMHddcjNIsZ4yR0DGinYOsgoRymzu3t02qLxyoio05atSViRw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Q1zl35fRNSASv2FOi6viwR29cn3vtOcyKfamcmRB789m6sb6CdlhIMettvcxxDDHwTSH/jjz3hqb0JAx2GT32g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-pty": "^1.1.0"
+        "node-pty": "1.2.0-beta.15"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.6.tgz",
-      "integrity": "sha512-E7g+XChh4q4/wX++v56z1pV4SA1Rtz42xkznLPPi9FlXrrzJxwHMOUzBZ9Rz3Y1kLhQ++HJG3ZatmNx3rjFilg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Rair2ZkzgoIIr+UstYVYeqeUgORNPIW1LNcsXz3Zjglx4FGjsmzs0UALdNYvSBpBvCLNmt4E6+XQIrBbS/s9jw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.0-rc.6.tgz",
-      "integrity": "sha512-riHLAQhXJJ2TT9XrDWGMgJf21RBqQgSZdEVvG4+xGEf9NZWcoszxdp+KW7rpwfrKuuD70p8RHCPGW4gCQPA+/A==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.0-rc.7.tgz",
+      "integrity": "sha512-B22qppmKWvw5Ez9eMKnppHiaMrikIcHmfmvyd296EspnhTBJAvXDnc9NggT0DUnSvm+2gh5ffohhMJel9A2pSA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.0-rc.6.tgz",
-      "integrity": "sha512-KRR/b/qqKO+sf6yc0xPC64LCZ+SQgTAnEMSO7gNXQ4BeAIzUbeKYfeVYiG6XZRbQ6al6o5sWIbZ0lUt3pHGdXw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.0-rc.7.tgz",
+      "integrity": "sha512-2muS7xmy4olNEpGANp0ViK3/r4A4UlfQa5w24HJ2PrCy0J3qlk1vwHrpj30nAGK6sCaxbXmb8IjYUfNs7st7zw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-time-context": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.0-rc.6.tgz",
-      "integrity": "sha512-5tylnw0kS74xmhUAW1H1tHsMVjjVuEFyQvn4/ocSmyrR656ghwNuYJ6/CCu358QBMsTrRNfGRlUw/IAZ1ySiLg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.0-rc.7.tgz",
+      "integrity": "sha512-rZhEYA/urMq8sReaMc5rb9A/p7X1MXwktoF5Y6SwGUWqJQsdvHzXppksOEqJpg4a1pNDBe2N9X5o+wMKPmukMQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.6.tgz",
-      "integrity": "sha512-CUean0fAnfsJVszFEip7PsU/S26W+JfDFfsza2dCtlw8n6xlkbHA9Gjxdk2aTwqDGCgXEPkRW7mYkdJ0n6FR7w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Ufl9G7zP7Tky/zkXscavEiolEfAwutfbPeLb5sUU/tPQlDykhh1NwGrarNJ11fdR723zmA/3co4LgxtDtWCOEQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tmux-context": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Wl7oOUO9XH7i6Bfu5L0+Nph2jzyF972eb949Hx/6akcKq+uNLFrq07L96LcAAQRezU8AQqtowzVs2LUbJ5dViA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.0-rc.7.tgz",
+      "integrity": "sha512-DYoWGpJglqzWxCFDzynJ7ebt9m7Redlm2Iuon5U2tJ0rsyOSRIgKuwQMXI67FdN/MNVXvSQ2xybUqu+5V0krnA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-token-meter": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.0-rc.6.tgz",
-      "integrity": "sha512-qU5FT4n1RJXP3Ss8NJ5TTvPo8rZ6cxcrCedp1t0sTAj93SGssAanq47voSmznPP52nwz/SLeunznAIT0jhbsZQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.0-rc.7.tgz",
+      "integrity": "sha512-i2WOx26otsAt3sTFOoXjo2xsdvUyC5CAuNiJyRQoo6yn1smx+NX541clIOYdx1uneZFmV0T6bK46JpdXasxaAA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3402,100 +3408,100 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.0-rc.6.tgz",
-      "integrity": "sha512-AlDljdccjmygPkLcW2t7atz1iDtzMr2F55DAB+0nw26er74f4WQsQ6pqJg64glr/03oDVrxSlxtSOid4U3Cvqw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.0-rc.7.tgz",
+      "integrity": "sha512-ZqwrTw+w4GepNCVQ7NIq71s+Hlrqu3jAfYCdKuNbkUy461EjlRLGMcHspSHAt1uhdwL9QDTodB6RRhpg65Hozw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.0-rc.6.tgz",
-      "integrity": "sha512-yzo/xPCObiFe+OU0e8E5nVOGpW6mp9vx/3q+MHQ0aqEbqrqHUfVMGPobfDAd/I1Ja/9Nag5NIvHpI2Hwx7lACg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.0-rc.7.tgz",
+      "integrity": "sha512-nfc0SI3Xk36rgIOLmTBDSrSTN3Ufp9Wvefta/M82kbBCo6fesB4lst+VAw74039jzHUboXc2gwQ/j5rRcOpiuw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.0-rc.6.tgz",
-      "integrity": "sha512-bsM1RHwkpNRAy0zufIDNUWxeiuGngc+R35RZ20gbWM878rHOZVuicy4MG8NKhzqGLqMD4NuDoNfjtDUkZHC48A==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.0-rc.7.tgz",
+      "integrity": "sha512-5tMC1TuWiGDerYd0UuUUzRdmv+uy/22lXbxmmrmUfR8aACeK6T76yXorvuvJSDYjhPpLoUovz9XU5LqGm3D2Wg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.0-rc.6.tgz",
-      "integrity": "sha512-PBK6Lkj4AK4LJXBJW+67AfSE1bxMUbjAE8kYL4loKOetGpEpu2iU35jb7HirjsgG7Byz2mRxT/jvbWhW9/uxOA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.0-rc.7.tgz",
+      "integrity": "sha512-GKmrKxwfIhk51dEEzWjvPKTZ2SK/RNxKXROAaSsZ/HGcerv2kmBHRCEPlaphKBoWhFuw7KAhDnzI6foXLg4BWQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.0-rc.6.tgz",
-      "integrity": "sha512-MdsdiOzLaGps29FW2I6eO3vWUFttK80XGieD99rZM4p1pqwFQ8Ix22SIOhMeIqz70m1CvjoLxLak1vElte3lQw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.0-rc.7.tgz",
+      "integrity": "sha512-tzZ1A+HhfqkMyOWwPgkWezY34rrK/OHD6BBX9DZ4km5/545JZ37+jmViza4TwrUhVxbs+Szhrx6g6V3Hm+674A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.0-rc.6.tgz",
-      "integrity": "sha512-bJfo8cCacX3WBygG8GbIlGz3jQ15MyIv4htGCjKpIIRHrXHSAelNtzceO2xQ21/9BkXrvg+i50mqySOcKQ0b3w==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.0-rc.7.tgz",
+      "integrity": "sha512-/Uf2z6OZckk0Nz7XjVbzf/yUnvDeY58CkUjAqy2FxgGuNc0rvIR6VzRER5NZ+30bXeB8TPnjMuCVB+j/8zltrw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3503,22 +3509,22 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.0-rc.6.tgz",
-      "integrity": "sha512-MUu9QF2Du8F6zdFP5rPEti9LKr/IyCYLM24XbaeuZZCrbq6Q1Rf9sng3v5bD9TlT+Wm+uXv3AqPX+8r8gcdqIQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.0-rc.7.tgz",
+      "integrity": "sha512-0Lo6bbpPcSMKZlWkBGx2KjwyLy5zYJKMH8fmwz8orwOKHjbfYQT51GV9cpdhLq6NYTwKeMUaxTZC4xPlZ03SAg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3526,185 +3532,185 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-spill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-goal": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.0-rc.6.tgz",
-      "integrity": "sha512-5rYb1wWJa2HfCxi1JNMkPJwN0upoblJEVlnV+omTx4ZDGekg2dyfftaQdFH9cwiW576is8bAUgPE9Rd0sZCAzw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.0-rc.7.tgz",
+      "integrity": "sha512-bQTVYD7nAtddefQZvvoKsoRHehA/hAHIPbNRdY+L97HVwKnowg5rlcUn/v+MJFQ1NPaTrTAfVQiHXGKEeeI9tA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.0-rc.6.tgz",
-      "integrity": "sha512-mcftmyHx2bq8u5Qwo7znysa3vOKO86ccJvgEZqfDV7S+UhOGbPDue7psyx1/jD/5fbK+653JbxQ8ds9wsLkiPw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.0-rc.7.tgz",
+      "integrity": "sha512-n/YcmHVTBrN3soZqzMElsnzIQoClOS3U1n5oqpg+oPyesMehpp7DFjdqh7kCZGEmI8chtq4AhYsPUWTPo85G7g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.0-rc.6.tgz",
-      "integrity": "sha512-x8ZlXUpOmcEiQobSTNSj18TPWVzyGe68pXJi6njea28DKVSe5Cx/L1bl9WImxru9f06+BkAm2ievJ+VKe89aeA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.0-rc.7.tgz",
+      "integrity": "sha512-J24DC4otd3gAVvJ2jPpCfxrrujB/5isEqScp53O2vSvFP7rKn/Rwo8ddr1v462JVWyUG5HtyKpR23cPmQrP0+w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.0-rc.6.tgz",
-      "integrity": "sha512-/PTqAS4oeiC1kn2/V98quJNuzALW3SD8TIk8M0cWQwZUkwS7D421p9WO0PPaV+6BQYFkgONfXJ+vzb6DJ6x5dg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.0-rc.7.tgz",
+      "integrity": "sha512-1ZCj5w7GRcbs0zuDiDpZLJKc1zs/WSn1WX9VWTuXvWocV66Rq8GGMZLGDksBeltd+jv/dym7xro4+xFl87059Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-skill": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.0-rc.6.tgz",
-      "integrity": "sha512-AebSfHSt6j0PXuN3yK9+X4aC6tHSnFdm2hZglII7aEHr/lL9UbynPb3NTumh6thXZ9Earvwhf9JdOxHMsjHqfw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.0-rc.7.tgz",
+      "integrity": "sha512-AnXLgiDXq8qB196qq4LnJ6rC5ukoPA4WZH+ILSFpLm59owkfwJLS9rGsfP+PGqiTN7NhoZtAwGmZoYCdSDi0kA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Kv+zA9ZQCn85VLfox2WVvNI/iU6e3ml4gPLqXiKMC027/iwmGHTcRMKOlDNnwydFTJOucNs8wW4Ac3FafCn3gA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.0-rc.7.tgz",
+      "integrity": "sha512-p4GmCg5wC9uw9BaVK9W0hOnEnjGvhhRF234ClVnQMbHwzfgPbhc0eSYUNJQmouqxLAa4kVuiF0nVZvc3aftCeQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.0-rc.6.tgz",
-      "integrity": "sha512-yK+ETLxDZhtwc19uqv5yAVzq3x/i2hjV9p67Or1a+s9Eqs+eu+ZJJk5hQ/2JeRiJet2otOC4zzOkYb/UVSBFyA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.0-rc.7.tgz",
+      "integrity": "sha512-QWs7SeItxpaJ3zY5Vh0scAv84QI+ZRyg9+dws15H88T+dp9dRr4gmR+fqEUdwd9JhPJF5VIORtKY/MqVtaiYQA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.0-rc.6.tgz",
-      "integrity": "sha512-zoVt+uV8yyg1dAuIMydtz/AfARZPkjFOXQLd90a3Bj8GdxpE3tdaR6ZIv3xD39Grxe2vRz4gOZEJ9qth3O+s9g==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.0-rc.7.tgz",
+      "integrity": "sha512-VPWUrhTc+X9DcrM/WC+ikM7vCjW54KzRU9wfdhFbXD6hea3hBQ4AlhEdtFtRwmgv3HmjYIUgHkPA3h7pqTsB1Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-report": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.0-rc.6.tgz",
-      "integrity": "sha512-DqnJ6yJ0wO35jdcpCSuogbx/PC4xE8wrcVxXPvSw9I59p/8nROsfwB9UXuJoilp/wenREUoTi0X8+5ZOVSRLqw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.0-rc.7.tgz",
+      "integrity": "sha512-bdDcRsiB9t4EILfA4gO+FWwXrj6SA12SP0nqymz5yOI5AJWR6pzuIOwRk7IdguHBzq8pDyfelw0YxN+EtkS+tA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-todo": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.0-rc.6.tgz",
-      "integrity": "sha512-ll9xmgkrV6nsxjEZn5+YkNwQei7WrMMisnbr9mAKmqN5vpyOVHXisLvKdiASEmgpm4rsicnR8Y0wcBUfbeJTxA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.0-rc.7.tgz",
+      "integrity": "sha512-Jm00eSYvNq8Qj5GmXdsC7EY3Q6TLSzBTiODNAu2bs5HxEqE5ssQ/fdcxuAXAfSFmh2Vq0ENLZckDg3q5Xvj6Qg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3712,17 +3718,17 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-web": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.0-rc.6.tgz",
-      "integrity": "sha512-2iw+F65+1+I3gwi8N+LzC6GD6vnhDSHfo9D+Pm+4h2O2d+4YKjeaOukx65sV9HTvFumY1tWXnYhBbDCJYBJAig==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.0-rc.7.tgz",
+      "integrity": "sha512-FJyrD+LspCOIP05/v9hv6MJNkTbgDw8ZpmyAXk6sRopA3yOUju5SnN5HpSZ97ZAK65T6tHYbTMdJhy51D41wOw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3731,56 +3737,56 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-web": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.0-rc.6.tgz",
-      "integrity": "sha512-w/D4RuFwxcx39Ryb//RFkSi1hp/QFVX/m6K7dFZ8HFdJVyu5otg5RJqvlDO55QNNLA8EndUOnc1GHl691MEDpg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.0-rc.7.tgz",
+      "integrity": "sha512-EF9qbGiCK+SdFhckVcS8o4F0Rrib4VEbt5yCe0njj4UrHubjz5Ldmz68TqdrvFqw6mvQ11SUqAm1ookp5hp8gA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.6.tgz",
-      "integrity": "sha512-Tu08EPK3JyK0iNjH4FGzu/1uADynNSS6SmwOLdfytUN0YNqwNuKFSt2OJUg19famNlTgy992DcHfDu0T+gLXFg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.7.tgz",
+      "integrity": "sha512-7Kq3EEv354aNcxbS0NRfxxyJiZhCsvFV/03a3MdkYO/gG2eM9+E4xQum0N2FL5bw7JiGlgw8jdLMkcNGmavEaA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-loader": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.0-rc.6.tgz",
-      "integrity": "sha512-PIC2iV1Sr+GtY9PpIGdW+pzoMDXSlxDx7QIfTbaeOVF5TRCxbe0gL6hsDEUIhkVOdfSpE731yxt0d8YpdNByzg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.0-rc.7.tgz",
+      "integrity": "sha512-0sU6QDo5/8/F7eIi9YGOqI4PTz34O6+NOUr3qRK6U3m6YWh4SVzn1Fc5LXqpnaZPNQpetuLnkvTvFylewBghJA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -3788,234 +3794,234 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.6.tgz",
-      "integrity": "sha512-weWzN8r01YCkoDCAM7BsKw2YhRrD4zL8N2SAZu9hovYtXSq8xHXsP4Zh8RLYIlYcuotjyff/6hic+0TJPd14YA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.7.tgz",
+      "integrity": "sha512-R7qdvaRRHbz5xijoVOxueeBB/VT0eDzuQNQN4iNEBUbI/L9xG9bZutktTQlgrIlBSn1sPH4pLqiCiM6ErQPTaQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.0-rc.6.tgz",
-      "integrity": "sha512-ry2AApGn0vEEIRWDC7TlLiLj5K8+2OblxXlGHs1u9APVxhPjZLok6Kfo57yfeJyW+EONGXv1DQcU05U+aYE7Tg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.0-rc.7.tgz",
+      "integrity": "sha512-7AQNJLNZTw7/5DzjbfBy4dRqr6VSwc74HBOSPpxm0zzzbmXOEqRCRzMps25IByoAeltRz1ZyY4fzN3tcYa+XwQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.6.tgz",
-      "integrity": "sha512-9rnkSDGOpu2XUeGwbPeTzVUTFWTND1PMPM5L/ZQPptV5yyZlQiNxM2rCC6OdL+ZVerwxEqrRhZIQn/KVtQfKag==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.7.tgz",
+      "integrity": "sha512-kYMpU6eg1m1BcfSC4FLWUcNH/QAE8tcu0WRkQzqzoCw8bK/Nl3dqHtd2qSVzI/emIviTulM5I230e4wPi/kuVg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.0-rc.6.tgz",
-      "integrity": "sha512-5vG4Ug+hVQuwU4KN7CFpF9qObBEYY/mPe1FHhToYO8Y2ICdHt3eX0Or9oEJFW68bZAMfuiAshZL8oUubr7obRg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.0-rc.7.tgz",
+      "integrity": "sha512-dfT6pj84lJdhrtbW2pV6hRftoKDkqx0aJevrhUhOy7Lv3CqTOheuLwwyT69Lww+n/q80Z+yp41qJq9loCkrOaw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-web": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.0-rc.6.tgz",
-      "integrity": "sha512-ABFbyDgo+DGaCtdRnjYG7Rz2K4dFlPA+xCEIt5MDobK/9CRQNpdZ4YrhHiq0nxwl1oxEM1Zw48ylFt+PwtS9ug==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.0-rc.7.tgz",
+      "integrity": "sha512-v3Wx/Kn57RyLDqvEhmz0m0p4YluLGSabmMp7dRVJSemYUzT6ZB0JCtMhWkXh6O3kNHSBGpfxeY9Pk+8k80X11Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-app": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.0-rc.6.tgz",
-      "integrity": "sha512-GKvfD1oHbdNN4Mbb77nCydfv2ZRxGVnKcKIGUfXGvs5cNC3cfPYPP/Ok9b/Kbk9zFYMuz+lLikka+HK3zyUcAQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.0-rc.7.tgz",
+      "integrity": "sha512-hcpVwEk5/SgZ63TRUmGaQsC1p2zBBSO8/KAr4xfM2XSwq/tbvpMLrkyt1zehBXcsx6ijB2s62bsr6AYOz9EczA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-hmr": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-goal": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-plan": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-skill": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-frontend-static": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-log-export": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-web-frontend": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "commander": "^15.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-frontend": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.0-rc.6.tgz",
-      "integrity": "sha512-+RpdDF11FqUZSbJGoZ4oLIk/4PJR+ynTS4ELMn9QqucbYZ8tv0Itq9ZtG2o6pKIe7NO0lj/eBjCR2EoRKx7L+g==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.0-rc.7.tgz",
+      "integrity": "sha512-U9Neu6x2/0hrDwCeExEjGO9KkXiJEoJgp61QF/XQkaHyg4E7YSWZDG9NttlhepqFgqs6Dn/qcjrL5G0JGuWYeA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-client-web": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-web": "^0.1.0-rc.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.0-rc.6.tgz",
-      "integrity": "sha512-+p3eOiUIN5Gk8KLjgAgIXmC6Y/db7LDb1TQ+iCAxz/zNJ2vbGVAoP+Br2jSUA1vbUdHTj49zTEWAQKaebuldCw==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.0-rc.7.tgz",
+      "integrity": "sha512-NciK9Tm68RK5XOzl+Jcr4+eG6M5Svq1/23Mhjor9QVYPW1J+wnyxUt6RKLIrmjyiS6VOCOCcZVtyITFkkfVaSQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-web": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.0-rc.6.tgz",
-      "integrity": "sha512-zpTqaEp5/aXp3Zj5OfpZpTZxncak8af0FSSCOj5e6Eo6+o6cW2Y48fPk5Rl9Dzcbm/x4Y4PZfJSyqazeA27YeA==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.0-rc.7.tgz",
+      "integrity": "sha512-PRGT0iF2KcOTxDC1DDIrNOe9bID3zZms902ScrxGAGj8AksRO97kj+3U2MOhRPfHkkNhSQMHCLt42DiclYhWtA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.0-rc.6.tgz",
-      "integrity": "sha512-PE5F8KW/qPmRzDoyC5EDw+44S1W7EDW+Iwox4l0LNG/WUqeARiRHVtTaNoEQyUqOZwUc6hs11SHlp1cZvwNHfg==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.0-rc.7.tgz",
+      "integrity": "sha512-v0YIoPylB1SJW5gBV8gaqoE0PCAZLzEgIU5OqckBKiApHBd0jIo7EzCeTW9+9Tzd8gwwcBQYv7Yxr++rmH8WGQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.0-rc.6.tgz",
-      "integrity": "sha512-3R5mX5JTBD9jDpUdauqaswDlxxJzlrRtJ7aH4Ok5jPdlxw0LhC5aIsS5S5RCtFLI1xDzonnInEczjmqmdGQcDQ==",
+      "version": "0.1.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.0-rc.7.tgz",
+      "integrity": "sha512-0czW0bI+uFFOS8h8eJ9SGZSdv+StEsa/+E1WEjZQXVeIOxo520Pv47dq+Z3mTyBfV8gJB+UcY0AQ3F0FddYohg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7"
       }
     },
     "node_modules/@deepseek-ai/node-addon-landlock-run": {
@@ -4142,9 +4148,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
-      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -5417,12 +5423,12 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
-      "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.17.0",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5430,13 +5436,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
-      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5444,13 +5450,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
-      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5484,13 +5490,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
-      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5498,9 +5504,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
-      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5811,9 +5817,8 @@
       ]
     },
     "node_modules/@wsl043/dsh-portable-desktop-bridge": {
-      "version": "0.2.0-rc.6",
-      "resolved": "file:../desktop-bridge",
-      "license": "MIT"
+      "resolved": "../desktop-bridge",
+      "link": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -6826,9 +6831,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -7899,39 +7904,39 @@
       "license": "MIT"
     },
     "node_modules/node-addon-native-custom-loader": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-native-custom-loader/-/node-addon-native-custom-loader-0.1.4.tgz",
-      "integrity": "sha512-DreegO6EoC1JHWYBv3j8Miwp2Zl/CyBeNyoeyCbnEdjyYFEulR4Gcb3wj9fXF7KMDY0ZJ5MWwHcXP8GVNyScnA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-native-custom-loader/-/node-addon-native-custom-loader-0.1.5.tgz",
+      "integrity": "sha512-rL0XXRytayIChYf1xaG9/1NzGBRTyFkQTIpn+MDz/hpr0PZw1a9PZIoH9HlYfagNawhXU+jfN650EvoSIvR7Vw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/node-addon-require-builtin": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin/-/node-addon-require-builtin-0.1.4.tgz",
-      "integrity": "sha512-yuXz43GmtQyMrO75u2Z8KZAafMhnMH8RTOZBJWGDU9HoD2QxT6q4PF28iLNm/OS9BkS8MHwCKpgTk3d6qW584A==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin/-/node-addon-require-builtin-0.1.5.tgz",
+      "integrity": "sha512-isaquiStlp7qdFpaffy+2ssJPUR/kLPRE5gqfeWbb0Ahph9H7O3BOFwThqkVaTrxfpnjrQauxlOEgvzD+snhUg==",
       "license": "MIT",
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "node-addon-require-builtin-darwin-arm64": "0.1.4",
-        "node-addon-require-builtin-darwin-x64": "0.1.4",
-        "node-addon-require-builtin-linux-arm64-gnu": "0.1.4",
-        "node-addon-require-builtin-linux-x64-gnu": "0.1.4",
-        "node-addon-require-builtin-win32-arm64-msvc": "0.1.4",
-        "node-addon-require-builtin-win32-ia32-msvc": "0.1.4",
-        "node-addon-require-builtin-win32-x64-msvc": "0.1.4"
+        "node-addon-require-builtin-darwin-arm64": "0.1.5",
+        "node-addon-require-builtin-darwin-x64": "0.1.5",
+        "node-addon-require-builtin-linux-arm64-gnu": "0.1.5",
+        "node-addon-require-builtin-linux-x64-gnu": "0.1.5",
+        "node-addon-require-builtin-win32-arm64-msvc": "0.1.5",
+        "node-addon-require-builtin-win32-ia32-msvc": "0.1.5",
+        "node-addon-require-builtin-win32-x64-msvc": "0.1.5"
       }
     },
     "node_modules/node-addon-require-builtin-darwin-arm64": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-arm64/-/node-addon-require-builtin-darwin-arm64-0.1.4.tgz",
-      "integrity": "sha512-pqiTPbqlDKRIo8YKoWMjuFge4kyHbsdYkAcGW5MAVcJSCyU0M1hhpiLdWlvX753XKL3xlGeuPmv2NqTNRV0/hw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-arm64/-/node-addon-require-builtin-darwin-arm64-0.1.5.tgz",
+      "integrity": "sha512-MZ5RyGhuU7DTbwuNpOQW81/ep8n5Yd5YlZa6dWiEfJEh+01Dl4cCKGmMCWNgb0VtqAImRtAOtmZIPtwngiemKQ==",
       "cpu": [
         "arm64"
       ],
@@ -7941,16 +7946,16 @@
         "darwin"
       ],
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/node-addon-require-builtin-darwin-x64": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-x64/-/node-addon-require-builtin-darwin-x64-0.1.4.tgz",
-      "integrity": "sha512-i9oThh+w6d+H79YQuc3d3MZCx4YZ6aMWlQ0HYMgOTWvSRzppXmksa/xPV8O20G1gjpq5do/9/hgImixj3XIcjQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-x64/-/node-addon-require-builtin-darwin-x64-0.1.5.tgz",
+      "integrity": "sha512-wdCSPn49AdNZ2EXHQqswiXk1cROFe9zSRaAX8PwQLxmjdLt+xZF7vZP6VlqgXm+VAOHv98q8kp9m7mO9jY3OgQ==",
       "cpu": [
         "x64"
       ],
@@ -7960,16 +7965,16 @@
         "darwin"
       ],
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/node-addon-require-builtin-linux-arm64-gnu": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-arm64-gnu/-/node-addon-require-builtin-linux-arm64-gnu-0.1.4.tgz",
-      "integrity": "sha512-qbmYtkiIFp7h1ZvYYHH0MGFQbc03OyvplkeS90j+t3VMomkRc/YwZ140WzVM3eYJYZ7XHq+s1GL5ZdFQFPUXBQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-arm64-gnu/-/node-addon-require-builtin-linux-arm64-gnu-0.1.5.tgz",
+      "integrity": "sha512-hCqzKpQiknDDv6rUdZqrxCBXROg/uUruO0geUuZsdM9M/Lds45gSb4bDE958HlPaCvrDyR0wTHl3II8A7yQeew==",
       "cpu": [
         "arm64"
       ],
@@ -7982,16 +7987,16 @@
         "linux"
       ],
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/node-addon-require-builtin-linux-x64-gnu": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-x64-gnu/-/node-addon-require-builtin-linux-x64-gnu-0.1.4.tgz",
-      "integrity": "sha512-4jC617+yOrYYuKgNmN2KMD722G6BICpjEzAcmzA3j5tt+zmey5M/c/z9JxqdjnNmU9CQWseBaJu/fGdbHZXSOg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-x64-gnu/-/node-addon-require-builtin-linux-x64-gnu-0.1.5.tgz",
+      "integrity": "sha512-lgP+ruwWXbcXDslhp5uIc+dFgzITEGPZ4E50WdHGt/OzcoVhN6y5z72pRRvxy8DE661//QxqmCLe72rS3SVg+w==",
       "cpu": [
         "x64"
       ],
@@ -8004,16 +8009,16 @@
         "linux"
       ],
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/node-addon-require-builtin-win32-arm64-msvc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-arm64-msvc/-/node-addon-require-builtin-win32-arm64-msvc-0.1.4.tgz",
-      "integrity": "sha512-4TW96aPR108R3RxJbUNLXU6FLTZ7n8fWtSpPbPtvYWXa9cXojvCMdH4BvrHM6W2M+Iu42nqMxRyylP3PeTjOmA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-arm64-msvc/-/node-addon-require-builtin-win32-arm64-msvc-0.1.5.tgz",
+      "integrity": "sha512-KEO2eWS4lvZg6JmPPz04OdI4Ojrc7YzOs++4r6VnvwsqYN2r6mjGSGpouQkk8J2eLXBzC7X/D9wYTbUuQS8u1Q==",
       "cpu": [
         "arm64"
       ],
@@ -8023,16 +8028,16 @@
         "win32"
       ],
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/node-addon-require-builtin-win32-ia32-msvc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-ia32-msvc/-/node-addon-require-builtin-win32-ia32-msvc-0.1.4.tgz",
-      "integrity": "sha512-a3ZRkiMKaE7uRjI+H+Ic7dvhPIk0rW9mHV47IEiqJzoRZqnDp5JPjQfAnngu979HR59Ghy+mfexJ/kStBlP3eQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-ia32-msvc/-/node-addon-require-builtin-win32-ia32-msvc-0.1.5.tgz",
+      "integrity": "sha512-iSC988EqZm5XbKWp/giW6K6EBRTrHt/YQbAkKsZLglt7PplmvvrZ7C3tUsyh1wVxUTYAaxFdE2xbqSdpw0rb6g==",
       "cpu": [
         "ia32"
       ],
@@ -8042,16 +8047,16 @@
         "win32"
       ],
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20 <23"
       }
     },
     "node_modules/node-addon-require-builtin-win32-x64-msvc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-x64-msvc/-/node-addon-require-builtin-win32-x64-msvc-0.1.4.tgz",
-      "integrity": "sha512-EGx7AcJKB7fNxo/YHV32JTUg1Hetbdnh6uPaqPhklhyRSMM13/7hZK1pTACqMS9dwnR3Lakxl9HKG9/eAoIyyg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-x64-msvc/-/node-addon-require-builtin-win32-x64-msvc-0.1.5.tgz",
+      "integrity": "sha512-pjuco/ESU3ChIp7WwacWfY2ENu2K5rGAgqjcXedoiFcTrjTf5Ln/miKSuNfE6IiuJ7tfMTJH6VH5hq+C1Y8JMQ==",
       "cpu": [
         "x64"
       ],
@@ -8061,7 +8066,7 @@
         "win32"
       ],
       "dependencies": {
-        "node-addon-native-custom-loader": "0.1.4"
+        "node-addon-native-custom-loader": "0.1.5"
       },
       "engines": {
         "node": ">=20"
@@ -8106,9 +8111,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.15.tgz",
+      "integrity": "sha512-vORSzHXi4Ofl7HemVWpuudLqCPdaQb4LfpRCUpE5HPxhp4JYscl8zZwxh11p26v2wvW24WMwnMfLjhRLixrfxA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8282,6 +8287,9 @@
       },
       "engines": {
         "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
       }
     },
     "node_modules/property-information": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,19 +1,19 @@
 {
   "name": "deepseek-harness-portable-runtime",
-  "version": "0.1.0-rc.6",
+  "version": "0.1.0-rc.7",
   "private": true,
   "description": "Pinned official DeepSeek Harness runtime for DSH-Portable.",
   "license": "MIT",
   "dependencies": {
+    "@deepseek-ai/dsh": "0.1.0-rc.7",
     "@wsl043/dsh-portable-desktop-bridge": "file:../desktop-bridge",
-    "@deepseek-ai/dsh": "0.1.0-rc.6",
     "pnpm": "11.7.0"
   },
   "allowScripts": {
-    "@deepseek-ai/dsh-subprocess-local@0.1.0-rc.6": true,
+    "@deepseek-ai/dsh-subprocess-local@0.1.0-rc.7": true,
     "@google/genai@1.52.0": true,
     "koffi@3.1.5": true,
-    "node-pty@1.1.0": true,
+    "node-pty@1.2.0-beta.15": true,
     "protobufjs@7.6.5": true
   }
 }

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.2.3"
+  #define AppVersion "0.2.4"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.2.3.65534
+VersionInfoVersion=0.2.4.65534
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/installer/windows/DeepSeek-Herness.iss
+++ b/installer/windows/DeepSeek-Herness.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.2.3"
+  #define AppVersion "0.2.4"
 #endif
 
 [Setup]
@@ -36,7 +36,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.2.3.65534
+VersionInfoVersion=0.2.4.65534
 VersionInfoProductName=DeepSeek-Herness
 VersionInfoDescription=DeepSeek-Herness installer
 VersionInfoCompany=WSL043

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.2.3"
+version = "0.2.4"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info-installed.plist
+++ b/launcher/macos/Info-installed.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.2.3</string>
+	<string>0.2.4</string>
   <key>CFBundleVersion</key>
-	<string>2003999</string>
+	<string>2004999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/macos/Info-stop-installed.plist
+++ b/launcher/macos/Info-stop-installed.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.2.3</string>
+	<string>0.2.4</string>
   <key>CFBundleVersion</key>
-	<string>2003999</string>
+	<string>2004999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.2.3</string>
+	<string>0.2.4</string>
   <key>CFBundleVersion</key>
-	<string>2003999</string>
+	<string>2004999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -22,8 +22,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.2.3.65534")]
-[assembly: System.Reflection.AssemblyFileVersion("0.2.3.65534")]
+[assembly: System.Reflection.AssemblyVersion("0.2.4.65534")]
+[assembly: System.Reflection.AssemblyFileVersion("0.2.4.65534")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -7,8 +7,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.2.3.65534")]
-[assembly: AssemblyFileVersion("0.2.3.65534")]
+[assembly: AssemblyVersion("0.2.4.65534")]
+[assembly: AssemblyFileVersion("0.2.4.65534")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -21,8 +21,8 @@ using Microsoft.Web.WebView2.WinForms;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.2.3.65534")]
-[assembly: AssemblyFileVersion("0.2.3.65534")]
+[assembly: AssemblyVersion("0.2.4.65534")]
+[assembly: AssemblyFileVersion("0.2.4.65534")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -25,6 +25,7 @@ NODE_ARCHIVE="$(lock_value node.runtimes.$RUNTIME_KEY.archive)"
 NODE_SHA256="$(lock_value node.runtimes.$RUNTIME_KEY.sha256)"
 DSH_VERSION="$(lock_value dsh.version)"
 DSH_COMMIT="$(lock_value dsh.reviewedCommit)"
+DSH_NOTICES_SHA256="$(lock_value dsh.noticesSha256)"
 PORTABLE_VERSION="$("$BUILD_NODE" -p 'require(process.argv[1]).version' "$PROJECT_ROOT/package.json")"
 
 DOWNLOAD_DIR="$CACHE_DIR/downloads"
@@ -96,7 +97,7 @@ NOTICES="$DOWNLOAD_DIR/DeepSeek-Harness-THIRD_PARTY_NOTICES-$DSH_COMMIT.md"
 if [[ ! -f "$NOTICES" ]]; then
   curl --fail --location --retry 3 --output "$NOTICES" "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/$DSH_COMMIT/THIRD_PARTY_NOTICES.md"
 fi
-printf '%s  %s\n' '61f68731049dbea19ba91ad8cf363dd2778c5f7b1f9a63496a6a62c1129eefee' "$NOTICES" | sha256sum --check
+printf '%s  %s\n' "$DSH_NOTICES_SHA256" "$NOTICES" | sha256sum --check
 cp "$NOTICES" "$STAGE/licenses/DeepSeek-Harness-THIRD_PARTY_NOTICES.md"
 
 cat > "$STAGE/licenses/COMPONENTS.json" <<EOF

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -25,6 +25,7 @@ NODE_ARCHIVE="$(lock_value node.runtimes.$RUNTIME_KEY.archive)"
 NODE_SHA256="$(lock_value node.runtimes.$RUNTIME_KEY.sha256)"
 DSH_VERSION="$(lock_value dsh.version)"
 DSH_COMMIT="$(lock_value dsh.reviewedCommit)"
+DSH_NOTICES_SHA256="$(lock_value dsh.noticesSha256)"
 PORTABLE_VERSION="$("$BUILD_NODE" -p 'require(process.argv[1]).version' "$PROJECT_ROOT/package.json")"
 
 DOWNLOAD_DIR="$CACHE_DIR/downloads"
@@ -91,7 +92,7 @@ NOTICES="$DOWNLOAD_DIR/DeepSeek-Harness-THIRD_PARTY_NOTICES-$DSH_COMMIT.md"
 if [[ ! -f "$NOTICES" ]]; then
   curl --fail --location --retry 3 --output "$NOTICES" "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/$DSH_COMMIT/THIRD_PARTY_NOTICES.md"
 fi
-printf '%s  %s\n' '61f68731049dbea19ba91ad8cf363dd2778c5f7b1f9a63496a6a62c1129eefee' "$NOTICES" | shasum -a 256 -c -
+printf '%s  %s\n' "$DSH_NOTICES_SHA256" "$NOTICES" | shasum -a 256 -c -
 cp "$NOTICES" "$STAGE/licenses/DeepSeek-Harness-THIRD_PARTY_NOTICES.md"
 
 cat > "$STAGE/licenses/COMPONENTS.json" <<EOF

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -143,7 +143,7 @@ try {
     if (-not (Test-Path -LiteralPath $Notices)) {
         Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/$($Lock.dsh.reviewedCommit)/THIRD_PARTY_NOTICES.md" -OutFile $Notices
     }
-    Assert-Sha256 $Notices '61f68731049dbea19ba91ad8cf363dd2778c5f7b1f9a63496a6a62c1129eefee'
+    Assert-Sha256 $Notices $Lock.dsh.noticesSha256
     Copy-Item $Notices (Join-Path $Stage 'licenses\DeepSeek-Harness-THIRD_PARTY_NOTICES.md')
 
     $Components = [ordered]@{

--- a/scripts/install-linux-packages.sh
+++ b/scripts/install-linux-packages.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "This installer only runs on Linux." >&2
+  exit 2
+fi
+if (($# == 0)); then
+  echo "Usage: $0 <package> [package ...]" >&2
+  exit 2
+fi
+
+readonly APT_MAX_ATTEMPTS=3
+readonly APT_TIMEOUT_SECONDS=180
+readonly APT_KILL_GRACE_SECONDS=15
+
+run_apt() {
+  sudo env DEBIAN_FRONTEND=noninteractive \
+    timeout --foreground --signal=TERM --kill-after="${APT_KILL_GRACE_SECONDS}s" "${APT_TIMEOUT_SECONDS}s" \
+    apt-get \
+      -o Acquire::Retries=2 \
+      -o Acquire::http::Timeout=20 \
+      -o Acquire::https::Timeout=20 \
+      -o DPkg::Lock::Timeout=60 \
+      "$@"
+}
+
+for ((attempt = 1; attempt <= APT_MAX_ATTEMPTS; attempt += 1)); do
+  echo "Installing Linux dependencies (attempt ${attempt}/${APT_MAX_ATTEMPTS})..."
+  if run_apt update && run_apt install -y --no-install-recommends "$@"; then
+    exit 0
+  fi
+  if ((attempt < APT_MAX_ATTEMPTS)); then
+    sleep $((attempt * 5))
+  fi
+done
+
+echo "Linux dependency installation failed after ${APT_MAX_ATTEMPTS} bounded attempts." >&2
+exit 1

--- a/scripts/prune-runtime.mjs
+++ b/scripts/prune-runtime.mjs
@@ -15,9 +15,13 @@ await access(path.join(ptyRoot, 'package.json'))
 const target = `${platform}-${architecture}`
 const allowed = new Set(['win32-x64', 'darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64'])
 assert.equal(allowed.has(target), true, `unsupported runtime prune target: ${target}`)
-const linuxNativeRoot = path.join(ptyRoot, 'build', 'Release')
-const nativeRoot = platform === 'linux' ? linuxNativeRoot : path.join(prebuildRoot, target)
-await access(path.join(nativeRoot, 'pty.node'))
+const nativeRoot = path.join(prebuildRoot, target)
+const requiredNativeFiles = platform === 'win32'
+  ? ['conpty.node', 'conpty_console_list.node', 'conpty/conpty.dll', 'conpty/OpenConsole.exe']
+  : platform === 'darwin'
+    ? ['pty.node', 'spawn-helper']
+    : ['pty.node']
+for (const relative of requiredNativeFiles) await access(path.join(nativeRoot, ...relative.split('/')))
 
 async function bytes(root) {
   const info = await stat(root)
@@ -75,23 +79,13 @@ async function removeDebugSymbols(root) {
 
 const before = await bytes(ptyRoot)
 for (const entry of await readdir(prebuildRoot, { withFileTypes: true })) {
-  if (entry.isDirectory() && (platform === 'linux' || entry.name !== target)) {
+  if (entry.isDirectory() && entry.name !== target) {
     await removeTree(path.join(prebuildRoot, entry.name))
   }
 }
 await removeDebugSymbols(nativeRoot)
 
 if (platform === 'linux') {
-  const buildRoot = path.join(ptyRoot, 'build')
-  for (const entry of await readdir(buildRoot, { withFileTypes: true })) {
-    if (entry.name !== 'Release') await removeTree(path.join(buildRoot, entry.name))
-  }
-  for (const entry of await readdir(linuxNativeRoot, { withFileTypes: true })) {
-    if (!['pty.node', 'spawn-helper'].includes(entry.name)) {
-      await removeTree(path.join(linuxNativeRoot, entry.name))
-    }
-  }
-
   // Koffi publishes both glibc and musl binaries in the same Linux package.
   // DSH-Portable is built and supported on Ubuntu/glibc; retaining the unused
   // musl binary makes linuxdeploy try to resolve libc.musl-*.so.1 and abort.
@@ -109,8 +103,7 @@ if (platform === 'linux') {
 // npm install has already selected and validated the target prebuild. These
 // directories contain only build inputs or TypeScript declarations and are not
 // read by node-pty's runtime loader.
-const removablePtyDirectories = ['benchmark', 'benchmarks', 'deps', 'examples', 'scripts', 'src', 'test', 'tests', 'third_party', 'typings']
-if (platform !== 'linux') removablePtyDirectories.push('build')
+const removablePtyDirectories = ['benchmark', 'benchmarks', 'build', 'deps', 'examples', 'scripts', 'src', 'test', 'tests', 'third_party', 'typings']
 for (const name of removablePtyDirectories) {
   const filename = path.join(ptyRoot, name)
   try {
@@ -138,7 +131,7 @@ const targetFiles = await readdir(nativeRoot)
 assert.equal(targetFiles.some((name) => name.endsWith('.node')), true, `node-pty target ${target} has no native module`)
 assert.equal(targetFiles.some((name) => name.endsWith('.pdb')), false, `node-pty target ${target} retained debug symbols`)
 const remainingTargets = (await readdir(prebuildRoot, { withFileTypes: true })).filter((entry) => entry.isDirectory()).map((entry) => entry.name)
-assert.deepEqual(remainingTargets, platform === 'linux' ? [] : [target])
+assert.deepEqual(remainingTargets, [target])
 if (platform === 'linux') {
   await access(path.join(nodeModules, '@koromix', `koffi-linux-${architecture}`, `linux_${architecture}`, 'koffi.node'))
   await assert.rejects(access(path.join(nodeModules, '@koromix', `koffi-linux-${architecture}`, `musl_${architecture}`)), { code: 'ENOENT' })

--- a/scripts/set-product-version.mjs
+++ b/scripts/set-product-version.mjs
@@ -40,6 +40,11 @@ async function stageJsonVersion(filename, occurrences = 1) {
 await Promise.all([
   stageJsonVersion('package.json'),
   stageJsonVersion('desktop-bridge/package.json'),
+  stageReplace(
+    'app/package-lock.json',
+    /("\.\.\/desktop-bridge"\s*:\s*\{[\s\S]*?"version"\s*:\s*")[^"]+/,
+    `$1${policy.version}`,
+  ),
   stageJsonVersion('launcher/linux/package.json'),
   stageJsonVersion('launcher/linux/package-lock.json', 2),
   stageJsonVersion('launcher/linux/tauri.conf.json'),

--- a/scripts/smoke-windows-native-download.mjs
+++ b/scripts/smoke-windows-native-download.mjs
@@ -91,6 +91,21 @@ async function evaluate(client, expression) {
   return result.result?.value
 }
 
+async function waitForDocumentBody(client, launcher, timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs
+  let latest = 'document is not ready'
+  while (Date.now() < deadline) {
+    if (launcher.exitCode !== null) throw new Error(`desktop host exited before the DSH document became ready: ${launcher.exitCode}`)
+    try {
+      if (await evaluate(client, "Boolean(document.body && document.readyState !== 'loading')")) return
+    } catch (error) {
+      latest = error instanceof Error ? error.message : String(error)
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`timed out waiting for the embedded DSH document body; latest=${latest}`)
+}
+
 async function portable(args) {
   return execFileAsync(portableNode, [portableCli, ...args], {
     cwd: root,
@@ -124,6 +139,7 @@ try {
   client = new CdpClient(page.webSocketDebuggerUrl)
   await client.open()
   await client.send('Runtime.enable')
+  await waitForDocumentBody(client, launcher)
   const filename = 'dsh-native-download-smoke.txt'
   const body = 'DSH native WebView2 download passed.'
   await evaluate(client, `(() => {

--- a/scripts/update-upstream.mjs
+++ b/scripts/update-upstream.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { appendFile, readFile, rename, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -31,21 +32,62 @@ const state = evaluateUpstream({
 })
 const { changed, version } = state
 if (changed) {
-  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-  const install = spawnSync(npm, [
+  const noticesResponse = await fetch(
+    `https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/${state.commit}/THIRD_PARTY_NOTICES.md`,
+    {
+      headers: {
+        'user-agent': 'DSH-Portable-upstream-candidate',
+        ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+      },
+    },
+  )
+  if (!noticesResponse.ok) {
+    throw new Error(`official notices returned HTTP ${noticesResponse.status}`)
+  }
+  const noticesSha256 = createHash('sha256')
+    .update(Buffer.from(await noticesResponse.arrayBuffer()))
+    .digest('hex')
+  const installArgs = [
     'install', '--package-lock-only', '--ignore-scripts', '--no-audit', '--no-fund', '--save-exact',
     `@deepseek-ai/dsh@${version}`, `pnpm@${currentLock.pnpm.version}`,
-  ], { cwd: path.join(root, 'app'), encoding: 'utf8' })
-  if (install.status !== 0) throw new Error(`npm lock refresh failed:\n${install.stderr || install.stdout}`)
+  ]
+  const npmCli = path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')
+  const command = process.platform === 'win32' ? process.execPath : 'npm'
+  const args = process.platform === 'win32' ? [npmCli, ...installArgs] : installArgs
+  const install = spawnSync(command, args, { cwd: path.join(root, 'app'), encoding: 'utf8' })
+  if (install.error || install.status !== 0) {
+    throw new Error(`npm lock refresh failed:\n${install.error?.message || install.stderr || install.stdout}`)
+  }
 
-  const packageLock = JSON.parse(await readFile(path.join(root, 'app', 'package-lock.json'), 'utf8'))
+  const runtimeManifestPath = path.join(root, 'app', 'package.json')
+  const packageLockPath = path.join(root, 'app', 'package-lock.json')
+  const runtimeManifest = JSON.parse(await readFile(runtimeManifestPath, 'utf8'))
+  const packageLock = JSON.parse(await readFile(packageLockPath, 'utf8'))
   const lockedDsh = packageLock.packages?.['node_modules/@deepseek-ai/dsh']
   if (lockedDsh?.version !== version || lockedDsh?.integrity !== state.integrity) {
     throw new Error('refreshed package lock does not match the official npm version and integrity')
   }
+  const lockedSubprocess = packageLock.packages?.['node_modules/@deepseek-ai/dsh-subprocess-local']?.version
+  const lockedNodePty = packageLock.packages?.['node_modules/node-pty']?.version
+  if (!lockedSubprocess || !lockedNodePty) {
+    throw new Error('refreshed package lock is missing a required native runtime dependency')
+  }
+  runtimeManifest.version = version
+  for (const key of Object.keys(runtimeManifest.allowScripts ?? {})) {
+    if (key.startsWith('@deepseek-ai/dsh-subprocess-local@') || key.startsWith('node-pty@')) {
+      delete runtimeManifest.allowScripts[key]
+    }
+  }
+  runtimeManifest.allowScripts[`@deepseek-ai/dsh-subprocess-local@${lockedSubprocess}`] = true
+  runtimeManifest.allowScripts[`node-pty@${lockedNodePty}`] = true
+  packageLock.version = version
+  packageLock.packages[''].version = version
+  await writeFile(runtimeManifestPath, `${JSON.stringify(runtimeManifest, null, 2)}\n`, 'utf8')
+  await writeFile(packageLockPath, `${JSON.stringify(packageLock, null, 2)}\n`, 'utf8')
   currentLock.dsh.version = version
   currentLock.dsh.integrity = state.integrity
   currentLock.dsh.reviewedCommit = state.commit
+  currentLock.dsh.noticesSha256 = noticesSha256
   const target = path.join(root, 'upstream.lock.json')
   const temporary = `${target}.tmp`
   await writeFile(temporary, `${JSON.stringify(currentLock, null, 2)}\n`, 'utf8')

--- a/scripts/verify-lock.mjs
+++ b/scripts/verify-lock.mjs
@@ -31,8 +31,11 @@ assert.equal(packageManager?.integrity, upstream.pnpm.integrity, 'pinned pnpm in
 assert.equal(packageManager?.license, 'MIT', 'pnpm npm license')
 assert.equal(packageManager?.bin?.pnpm, 'bin/pnpm.mjs', 'pnpm executable entry')
 const desktopBridge = lockfile.packages?.[`node_modules/${desktopBridgePackage}`]
-assert.equal(desktopBridge?.resolved, 'file:../desktop-bridge', 'desktop bridge must stay a local product component')
-assert.equal(desktopBridge?.license, 'MIT', 'desktop bridge license')
+assert.equal(desktopBridge?.resolved, '../desktop-bridge', 'desktop bridge must resolve only to the local product component')
+assert.equal(desktopBridge?.link, true, 'desktop bridge must stay an npm local link')
+const desktopBridgeSource = lockfile.packages?.['../desktop-bridge']
+assert.equal(desktopBridgeSource?.name, desktopBridgePackage, 'desktop bridge link target identity')
+assert.equal(desktopBridgeSource?.license, 'MIT', 'desktop bridge license')
 
 const serializedRoot = JSON.stringify(root)
 for (const forbidden of ['@yanxu', 'openai-codex', 'opencode-zen', 'GenericAgent']) {

--- a/templates/RELEASE-NOTES.md
+++ b/templates/RELEASE-NOTES.md
@@ -1,16 +1,16 @@
-> 打包官方 DeepSeek Harness 预览版（`@deepseek-ai/dsh 0.1.0-rc.6`）。DSH-Portable 是独立社区分发项目。
+> 打包官方 DeepSeek Harness 预览版（`@deepseek-ai/dsh 0.1.0-rc.7`）。DSH-Portable 是独立社区分发项目。
 
-0.2.3 修正 Windows 托盘的基础交互：
+0.2.4 同步官方 rc.7，并继续保持便携数据与桌面体验：
 
-- 左键单击托盘图标会直接打开 DeepSeek Harness；右键才显示任务菜单，点击菜单外会按
-  Windows 原生行为关闭菜单。
-- “打开 DeepSeek Harness”固定在一级菜单首项；最近 3 个会话仍直接可达，其余会话进入
-  “更多”，菜单最多两层。
-- “启动时检查更新”会在点击后立即显示开关结果，重启后继续使用用户选择。
-- 网页式右键菜单和浏览器状态栏不再出现在桌面窗口中。
-- 导出会话等文件下载由桌面壳接管，真实进度与完成状态直接显示在 DSH 原有导出窗口中。
-- 托盘继续跟随 DSH 的中文/英文与明暗外观；本次内置官方 DSH 仍为 `0.1.0-rc.6`。
-- 插件命令异常中断后留下的失效锁会被安全回收，不再永久阻止后续插件安装或更新。
+- 设置页现在可显示插件注册的设置卡；Job Panel 可呈现 Codex、Claude Code 等外部 Agent
+  启动的子任务。
+- MCP、ACP 与嵌套 PTC 工具返回的图片可保留在对话上下文中。
+- 修复大段历史记录分页可能导致的栈溢出，以及达到最大 Token 后会话无法继续的问题。
+- 改善最小模式下持续 Bash 调用的延迟；问题卡片可折叠，并保留尚未提交的答案草稿。
+- DeepSeek 模型增加 `low` 推理强度选项；原 Code 模式统一更名为 PTC 模式。
+- Portable 已适配官方新版终端运行时；Windows、macOS、Linux x64 与 ARM64 继续使用同一套
+  完整发布门。
+- “启动时检查更新”仍可在应用菜单中关闭；关闭后不会自动提醒，仍可随时手动检查。
 
 普通更新只替换 DSH 应用组件并保留用户数据。
 
@@ -43,23 +43,23 @@
 
 ## English
 
-> Packages the official DeepSeek Harness preview (`@deepseek-ai/dsh 0.1.0-rc.6`).
+> Packages the official DeepSeek Harness preview (`@deepseek-ai/dsh 0.1.0-rc.7`).
 > DSH-Portable is an independent community distribution.
 
-0.2.3 corrects the fundamental Windows tray interactions:
+0.2.4 updates the bundled official runtime to rc.7 while preserving portable data and desktop behavior:
 
-- Left-clicking the tray icon opens DeepSeek Harness directly. Right-clicking opens the task menu,
-  and clicking elsewhere dismisses it through the native Windows menu behavior.
-- **Open DeepSeek Harness** is the first top-level command. The three most recent sessions remain
-  directly accessible, remaining sessions are under More, and the menu is never deeper than two levels.
-- **Check for updates at startup** now reflects a click immediately and keeps the choice after restart.
-- Web-style context menus and the browser status bar no longer appear in the desktop window.
-- Session exports and other downloads are owned by the desktop shell, with native progress and
-  completion state shown directly in DSH's existing export dialog.
-- The tray continues to follow DSH language and light/dark appearance. The bundled official DSH
-  remains `0.1.0-rc.6` in this release.
-- Stale plugin-command locks left by an interrupted process are safely recovered instead of blocking
-  future plugin installs or updates.
+- Settings can now show plugin-registered cards, and the Job Panel can surface subagent tasks launched
+  by external tools such as Codex and Claude Code.
+- Images returned through MCP, ACP, and nested PTC tools remain available in conversation context.
+- Large-history pagination no longer risks a stack overflow, and sessions remain usable after
+  max-token truncation.
+- Persistent Bash work in minimal mode has lower latency. Question cards can collapse without losing
+  unsubmitted answer drafts.
+- DeepSeek models gain a `low` reasoning-effort option, and Code mode is now named PTC mode.
+- The Portable packages support the updated terminal runtime across Windows, macOS, Linux x64, and
+  Linux ARM64 through the same release gate.
+- **Check for updates at startup** remains optional. Turn it off to suppress automatic prompts while
+  keeping manual update checks available.
 
 If an older launcher crosses a compatibility boundary, it downloads one complete package and updates
 in place while preserving `data`, `workspace`, sessions, credentials, and plugins. Finished products

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -121,10 +121,11 @@ test('macOS GUI is a native WKWebView app rather than a Chrome app-mode launcher
 })
 
 test('CI release gate verifies native desktop ownership, lifecycle, and application identity', async () => {
-  const [workflow, windowsSmoke, traySmoke, macSmoke] = await Promise.all([
+  const [workflow, windowsSmoke, traySmoke, nativeDownloadSmoke, macSmoke] = await Promise.all([
     read('.github/workflows/ci.yml'),
     read('scripts/smoke-windows-desktop-host.ps1'),
     read('scripts/smoke-windows-native-tray.ps1'),
+    read('scripts/smoke-windows-native-download.mjs'),
     read('scripts/smoke-macos-desktop-host.sh'),
   ])
 
@@ -137,6 +138,12 @@ test('CI release gate verifies native desktop ownership, lifecycle, and applicat
   assert.doesNotMatch(traySmoke, /[^\x00-\x7F]/, 'Windows PowerShell 5.1 smoke scripts must remain encoding-safe without a BOM')
   assert.match(traySmoke, /CaptureDirectory/)
   assert.match(traySmoke, /Bitmap\.Save/)
+  assert.match(nativeDownloadSmoke, /async function waitForDocumentBody/)
+  assert.match(nativeDownloadSmoke, /document\.body\s*&&\s*document\.readyState\s*!==\s*['"]loading['"]/)
+  assert.ok(
+    nativeDownloadSmoke.indexOf('await waitForDocumentBody') < nativeDownloadSmoke.indexOf('document.body.appendChild(anchor)'),
+    'the real native download smoke must wait for the embedded document before injecting a download',
+  )
   assert.match(workflow, /macos-desktop-host:/)
   assert.match(workflow, /smoke-macos-desktop-host\.sh/)
   assert.doesNotMatch(workflow, /browser ownership and Stop|windows-browser-lifecycle:|macos-browser-lifecycle:/)

--- a/tests/distribution-contract.test.mjs
+++ b/tests/distribution-contract.test.mjs
@@ -1,16 +1,19 @@
 import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const read = (name) => readFile(path.join(root, name), 'utf8')
+const execFileAsync = promisify(execFile)
 
 test('runtime dependency boundary contains official DSH, the private desktop bridge, and its pinned package manager only', async () => {
   const runtime = JSON.parse(await read('app/package.json'))
   assert.deepEqual(runtime.dependencies, {
-    '@deepseek-ai/dsh': '0.1.0-rc.6',
+    '@deepseek-ai/dsh': '0.1.0-rc.7',
     '@wsl043/dsh-portable-desktop-bridge': 'file:../desktop-bridge',
     pnpm: '11.7.0',
   })
@@ -19,10 +22,10 @@ test('runtime dependency boundary contains official DSH, the private desktop bri
     assert.equal(serialized.includes(forbidden), false, forbidden)
   }
   assert.deepEqual(runtime.allowScripts, {
-    '@deepseek-ai/dsh-subprocess-local@0.1.0-rc.6': true,
+    '@deepseek-ai/dsh-subprocess-local@0.1.0-rc.7': true,
     '@google/genai@1.52.0': true,
     'koffi@3.1.5': true,
-    'node-pty@1.1.0': true,
+    'node-pty@1.2.0-beta.15': true,
     'protobufjs@7.6.5': true,
   })
 })
@@ -30,9 +33,12 @@ test('runtime dependency boundary contains official DSH, the private desktop bri
 test('upstream lock pins independently verifiable DSH and Node artifacts', async () => {
   const lock = JSON.parse(await read('upstream.lock.json'))
   assert.equal(lock.dsh.package, '@deepseek-ai/dsh')
+  assert.equal(lock.dsh.version, '0.1.0-rc.7')
+  assert.equal(lock.dsh.reviewedCommit, '99f6f02fecdb7dff40c3fbc9470f5907c29f74ca')
   assert.match(lock.dsh.version, /^0\.1\.0-rc\.\d+$/)
   assert.match(lock.dsh.integrity, /^sha512-/)
   assert.match(lock.dsh.reviewedCommit, /^[0-9a-f]{40}$/)
+  assert.equal(lock.dsh.noticesSha256, '4a2ff8717eeb94173df9f98316437ce6e0817f740cd1e23098d5b29a3e72791a')
   assert.deepEqual(lock.pnpm, {
     package: 'pnpm',
     version: '11.7.0',
@@ -60,8 +66,23 @@ test('committed npm lock resolves the exact reviewed DSH artifact', async () => 
   assert.equal(pnpm.version, upstream.pnpm.version)
   assert.equal(pnpm.integrity, upstream.pnpm.integrity)
   const desktopBridge = lockfile.packages['node_modules/@wsl043/dsh-portable-desktop-bridge']
-  assert.equal(desktopBridge.resolved, 'file:../desktop-bridge')
-  assert.equal(desktopBridge.license, 'MIT')
+  assert.equal(desktopBridge.resolved, '../desktop-bridge')
+  assert.equal(desktopBridge.link, true)
+  const desktopBridgeSource = lockfile.packages['../desktop-bridge']
+  const desktopBridgeManifest = JSON.parse(await read('desktop-bridge/package.json'))
+  assert.equal(desktopBridgeSource.name, '@wsl043/dsh-portable-desktop-bridge')
+  assert.equal(desktopBridgeSource.version, desktopBridgeManifest.version)
+  assert.equal(desktopBridgeSource.license, 'MIT')
+})
+
+test('the independent lock verifier accepts the current local bridge link and exact upstream pins', async () => {
+  const { stdout } = await execFileAsync(process.execPath, [
+    path.join(root, 'scripts', 'verify-lock.mjs'),
+    path.join(root, 'app', 'package-lock.json'),
+    path.join(root, 'upstream.lock.json'),
+  ])
+  const result = JSON.parse(stdout)
+  assert.equal(result.dshVersion, '0.1.0-rc.7')
 })
 
 test('build script verifies downloads and emits ZIP plus checksum', async () => {
@@ -82,6 +103,22 @@ test('build script verifies downloads and emits ZIP plus checksum', async () => 
   assert.match(script, /File\]::Replace/)
   assert.doesNotMatch(script, /File\]::Replace\([^\n]+\$null/)
   assert.match(script, /UTF8Encoding\]::new\(\$false\)/)
+  assert.match(script, /Lock\.dsh\.noticesSha256/)
+  assert.doesNotMatch(script, /61f68731049dbea19ba91ad8cf363dd2778c5f7b1f9a63496a6a62c1129eefee/)
+})
+
+test('all platform builders verify official notices through the reviewed upstream lock', async () => {
+  const [windows, macos, linux] = await Promise.all([
+    read('scripts/build-windows.ps1'),
+    read('scripts/build-macos.sh'),
+    read('scripts/build-linux.sh'),
+  ])
+  assert.match(windows, /Lock\.dsh\.noticesSha256/)
+  assert.match(macos, /lock_value dsh\.noticesSha256/)
+  assert.match(linux, /lock_value dsh\.noticesSha256/)
+  for (const builder of [windows, macos, linux]) {
+    assert.doesNotMatch(builder, /61f68731049dbea19ba91ad8cf363dd2778c5f7b1f9a63496a6a62c1129eefee/)
+  }
 })
 
 test('one-click launchers resolve everything from their own folder', async () => {

--- a/tests/linux-packaging-contract.test.mjs
+++ b/tests/linux-packaging-contract.test.mjs
@@ -111,6 +111,28 @@ test('Linux packaging and real product smokes run independently on x64 and arm64
   assert.match(appImagePluginSmoke, /mv "\$ROOT" "\$MOVED"/)
 })
 
+test('Linux CI dependency installation is bounded, retryable, and shared by every product job', async () => {
+  const [workflow, installer] = await Promise.all([
+    read('.github/workflows/ci.yml'),
+    read('scripts/install-linux-packages.sh'),
+  ])
+  assert.doesNotMatch(workflow, /sudo\s+apt-get\s+(?:update|install)/)
+  assert.equal(
+    (workflow.match(/bash scripts\/install-linux-packages\.sh/g) ?? []).length,
+    4,
+    'all four Linux jobs must use the bounded package installer',
+  )
+  assert.match(installer, /DEBIAN_FRONTEND=noninteractive/)
+  assert.match(installer, /APT_MAX_ATTEMPTS=3/)
+  assert.match(installer, /timeout\s+--foreground[\s\S]+APT_TIMEOUT_SECONDS/)
+  assert.match(installer, /Acquire::Retries=2/)
+  assert.match(installer, /Acquire::http::Timeout=20/)
+  assert.match(installer, /Acquire::https::Timeout=20/)
+  assert.match(installer, /apt-get[\s\S]+update/)
+  assert.match(installer, /apt-get[\s\S]+install[\s\S]+--no-install-recommends/)
+  assert.doesNotMatch(installer, /curl[^\n]*\|\s*(?:ba)?sh/)
+})
+
 test('release staging exposes two obvious Linux choices per architecture', async () => {
   const staging = await read('scripts/stage-release-assets.mjs')
   for (const arch of ['x64', 'arm64']) {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -243,6 +243,12 @@ test('installable official preview updates become tested candidates while source
   assert.match(workflow, /No candidate PR was created because there is no new installable package/)
   assert.match(updater, /package-lock-only/)
   assert.match(updater, /upstream\.lock\.json/)
+  assert.match(updater, /process\.execPath/)
+  assert.match(updater, /npm-cli\.js/)
+  assert.match(updater, /THIRD_PARTY_NOTICES\.md/)
+  assert.match(updater, /createHash\(['"]sha256['"]\)/)
+  assert.match(updater, /noticesSha256/)
+  assert.doesNotMatch(updater, /process\.platform\s*===\s*['"]win32['"]\s*\?\s*['"]npm\.cmd['"]/)
 })
 
 test('desktop icons are derived from the pinned official DSH mark', async () => {

--- a/tests/runtime-prune.test.mjs
+++ b/tests/runtime-prune.test.mjs
@@ -30,7 +30,10 @@ test('runtime pruning removes packaging-only payload while preserving runtime an
   await fixtureFile(appDir, 'node-pty/lib/index.d.ts')
   await fixtureFile(appDir, 'node-pty/tests/runtime.test.js')
   await fixtureFile(appDir, 'node-pty/build/Release/conpty/OpenConsole.exe')
-  await fixtureFile(appDir, 'node-pty/prebuilds/win32-x64/pty.node')
+  await fixtureFile(appDir, 'node-pty/prebuilds/win32-x64/conpty.node')
+  await fixtureFile(appDir, 'node-pty/prebuilds/win32-x64/conpty_console_list.node')
+  await fixtureFile(appDir, 'node-pty/prebuilds/win32-x64/conpty.pdb')
+  await fixtureFile(appDir, 'node-pty/prebuilds/win32-x64/conpty/conpty.dll')
   await fixtureFile(appDir, 'node-pty/prebuilds/win32-x64/conpty/OpenConsole.exe')
   await fixtureFile(appDir, 'node-pty/prebuilds/darwin-arm64/pty.node')
   await fixtureFile(appDir, '@types/example/package.json', '{"name":"@types/example"}')
@@ -61,7 +64,9 @@ test('runtime pruning removes packaging-only payload while preserving runtime an
     'node-pty/package.json',
     'node-pty/lib/index.js',
     'node-pty/LICENSE',
-    'node-pty/prebuilds/win32-x64/pty.node',
+    'node-pty/prebuilds/win32-x64/conpty.node',
+    'node-pty/prebuilds/win32-x64/conpty_console_list.node',
+    'node-pty/prebuilds/win32-x64/conpty/conpty.dll',
     'node-pty/prebuilds/win32-x64/conpty/OpenConsole.exe',
     'example-package/package.json',
     'example-package/dist/index.js',
@@ -85,6 +90,7 @@ test('runtime pruning removes packaging-only payload while preserving runtime an
     'node-pty/lib/index.d.ts',
     'node-pty/tests/runtime.test.js',
     'node-pty/build',
+    'node-pty/prebuilds/win32-x64/conpty.pdb',
     'node-pty/prebuilds/darwin-arm64',
     '@types/example',
     'example-package/dist/index.js.map',
@@ -109,7 +115,7 @@ test('Linux pruning keeps only the native node-pty runtime products', async (t) 
 
   await fixtureFile(appDir, 'node-pty/package.json', '{"name":"node-pty"}')
   await fixtureFile(appDir, 'node-pty/lib/index.js', 'module.exports = true')
-  await fixtureFile(appDir, 'node-pty/build/Release/pty.node', 'native')
+  await fixtureFile(appDir, 'node-pty/prebuilds/linux-x64/pty.node', 'native')
   await fixtureFile(appDir, 'node-pty/build/Release/obj.target/pty/src/unix/pty.o', 'object')
   await fixtureFile(appDir, 'node-pty/build/Makefile', 'generated')
   await fixtureFile(appDir, 'node-pty/prebuilds/win32-x64/pty.node', 'windows')
@@ -122,12 +128,34 @@ test('Linux pruning keeps only the native node-pty runtime products', async (t) 
     encoding: 'utf8',
   })
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
-  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/build/Release/pty.node')), true)
-  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/build/Release/obj.target')), false)
-  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/build/Makefile')), false)
+  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/prebuilds/linux-x64/pty.node')), true)
+  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/build')), false)
   assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/prebuilds/win32-x64')), false)
   assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/prebuilds/darwin-arm64')), false)
   assert.equal(await exists(path.join(appDir, 'node_modules/@koromix/koffi-linux-x64/linux_x64/koffi.node')), true)
   assert.equal(await exists(path.join(appDir, 'node_modules/@koromix/koffi-linux-x64/musl_x64')), false)
   assert.equal(JSON.parse(result.stdout.trim()).target, 'linux-x64')
+})
+
+test('macOS pruning preserves the pty module and spawn helper for the selected architecture', async (t) => {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), 'dsh-prune-macos-'))
+  t.after(() => rm(temporary, { recursive: true, force: true }))
+  const appDir = path.join(temporary, 'app')
+
+  await fixtureFile(appDir, 'node-pty/package.json', '{"name":"node-pty"}')
+  await fixtureFile(appDir, 'node-pty/lib/index.js', 'module.exports = true')
+  await fixtureFile(appDir, 'node-pty/prebuilds/darwin-arm64/pty.node', 'native')
+  await fixtureFile(appDir, 'node-pty/prebuilds/darwin-arm64/spawn-helper', 'helper')
+  await fixtureFile(appDir, 'node-pty/prebuilds/darwin-x64/pty.node', 'other')
+  await fixtureFile(appDir, 'node-pty/build/Release/pty.node', 'build output')
+
+  const result = spawnSync(process.execPath, [pruneScript, appDir, 'darwin', 'arm64'], {
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/prebuilds/darwin-arm64/pty.node')), true)
+  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper')), true)
+  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/prebuilds/darwin-x64')), false)
+  assert.equal(await exists(path.join(appDir, 'node_modules/node-pty/build')), false)
+  assert.equal(JSON.parse(result.stdout.trim()).target, 'darwin-arm64')
 })

--- a/tests/version-policy.test.mjs
+++ b/tests/version-policy.test.mjs
@@ -36,6 +36,10 @@ test('all finished-product manifests use the same stable product version', async
   const manifest = JSON.parse(await read('package.json'))
   const policy = classifyProductVersion(manifest.version)
   assert.equal(policy.channel, 'stable')
+  const desktopBridge = JSON.parse(await read('desktop-bridge/package.json'))
+  const appLock = JSON.parse(await read('app/package-lock.json'))
+  assert.equal(desktopBridge.version, policy.version)
+  assert.equal(appLock.packages['../desktop-bridge'].version, policy.version)
 
   const sources = await Promise.all([
     read('installer/windows/DSH-Portable.iss'),

--- a/upstream.lock.json
+++ b/upstream.lock.json
@@ -2,10 +2,11 @@
   "schemaVersion": 1,
   "dsh": {
     "package": "@deepseek-ai/dsh",
-    "version": "0.1.0-rc.6",
-    "integrity": "sha512-brpZfED7ieRa2PQ5tUxMhHrM1pb2CmKFVM/f6yMULBDMicahk+Z2OsHgTwTDnoiZm23Ftu9rQz0NN4pflaoJcg==",
+    "version": "0.1.0-rc.7",
+    "integrity": "sha512-ZceDCJ8FAywih+USW/OMk9jEhunlvJBGEz4kqrhau23hPzbciOazZrywH0nBRsaalSeAJ1JGBmjtw4OSjToStw==",
     "sourceRepository": "https://github.com/deepseek-ai/deepseek-harness",
-    "reviewedCommit": "47f943859bef60e4160492346772ded9b24f765a"
+    "reviewedCommit": "99f6f02fecdb7dff40c3fbc9470f5907c29f74ca",
+    "noticesSha256": "4a2ff8717eeb94173df9f98316437ce6e0817f740cd1e23098d5b29a3e72791a"
   },
   "pnpm": {
     "package": "pnpm",


### PR DESCRIPTION
## Summary
- update the bundled official DeepSeek Harness runtime from `0.1.0-rc.6` to `0.1.0-rc.7`
- adapt native terminal pruning for the new `node-pty` prebuild layout on Windows, macOS, and Linux
- pin official notices with the reviewed upstream commit and keep upstream refresh/version tooling consistent
- bound Linux package installation with noninteractive mode, network timeouts, and finite retries
- prepare DSH-Portable `0.2.4` release metadata and bilingual user-facing notes

## Verification
- `node --test tests/*.test.mjs` — 118 passed
- real official rc.7 CLI/config/server smoke
- real Windows portable build, movable Unicode-path launch, WebView2 host, tray, native download, plugin lifecycle, component update/rollback
- full Windows/macOS/Linux x64/arm64 PR matrix is the merge gate