### PR TITLE
Allow slow active Linux dependency transfers

### DIFF
--- a/scripts/install-linux-packages.sh
+++ b/scripts/install-linux-packages.sh
@@ -10,8 +10,8 @@ if (($# == 0)); then
   exit 2
 fi
 
-readonly APT_MAX_ATTEMPTS=3
-readonly APT_TIMEOUT_SECONDS=180
+readonly APT_MAX_ATTEMPTS=2
+readonly APT_TIMEOUT_SECONDS=600
 readonly APT_KILL_GRACE_SECONDS=15
 
 run_apt() {

--- a/tests/linux-packaging-contract.test.mjs
+++ b/tests/linux-packaging-contract.test.mjs
@@ -123,7 +123,8 @@ test('Linux CI dependency installation is bounded, retryable, and shared by ever
     'all four Linux jobs must use the bounded package installer',
   )
   assert.match(installer, /DEBIAN_FRONTEND=noninteractive/)
-  assert.match(installer, /APT_MAX_ATTEMPTS=3/)
+  assert.match(installer, /APT_MAX_ATTEMPTS=2/)
+  assert.match(installer, /APT_TIMEOUT_SECONDS=600/)
   assert.match(installer, /timeout\s+--foreground[\s\S]+APT_TIMEOUT_SECONDS/)
   assert.match(installer, /Acquire::Retries=2/)
   assert.match(installer, /Acquire::http::Timeout=20/)


### PR DESCRIPTION
## Summary
- keep APT network inactivity timeouts at 20 seconds
- allow a slow but active desktop dependency transfer up to 10 minutes
- cap the installer at two attempts so a truly stuck runner still fails in finite time

## Evidence
- main run `32092496738` made continuous download progress but the previous 180-second total timer killed the 27.3 MB WebKit package on all three attempts
- focused Linux packaging contract: 8 passed
- full source contracts: 118 passed