### PR TITLE
Use an atomic portable-folder move in plugin smoke

### DIFF
--- a/scripts/smoke-windows-plugins.ps1
+++ b/scripts/smoke-windows-plugins.ps1
@@ -232,7 +232,10 @@ try {
         Write-Host '[plugin-smoke] move folder, load cached remote archive, then repeat local archive add/list/remove'
         $MovedRoot = "$Root-plugin-moved"
         if (Test-Path -LiteralPath $MovedRoot) { throw "plugin move target already exists: $MovedRoot" }
-        Move-Item -LiteralPath $Root -Destination $MovedRoot
+        # A same-volume user move is a directory rename. PowerShell's provider
+        # can traverse pnpm links and fail on a valid link whose target is being
+        # regenerated; Directory.Move preserves the tree without dereferencing it.
+        [System.IO.Directory]::Move($Root, $MovedRoot)
         $Root = $MovedRoot
         $ExpectedStateRoot = $MovedRoot
         $ProfileRoot = Join-Path $ExpectedStateRoot "data\dsh-home\profiles\$Profile"

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -446,6 +446,8 @@ test('plugin management is a generic finished-product capability and release gat
   assert.match(smoke, /\$ExitCode\s*=\s*\$LASTEXITCODE/)
   assert.match(smoke, /\$null\s+-ne\s+\$ProcessExitCode/)
   assert.match(smoke, /Product-Status/)
+  assert.match(smoke, /\[System\.IO\.Directory\]::Move\(\$Root,\s*\$MovedRoot\)/)
+  assert.doesNotMatch(smoke, /Move-Item\s+-LiteralPath\s+\$Root/)
   assert.doesNotMatch(smoke, /where\.exe/i)
   assert.doesNotMatch(smoke, /codex|openai-codex|zen/i)
 })


### PR DESCRIPTION
## Summary
- move the finished Windows portable tree with a same-volume directory rename
- preserve pnpm links without PowerShell provider traversal
- keep the real plugin add/update/restart/remove/move release gate

## Verification
- local source suite: 118/118
- real finished-product Windows plugin lifecycle passed after moving the portable folder
- full GitHub release matrix required before merge