### PR TITLE
dev: extend embedded WebView2 navigation timeout to 60s

### DIFF
--- a/.github/workflows/dev-bootstrap-payload.yml
+++ b/.github/workflows/dev-bootstrap-payload.yml
@@ -1,0 +1,91 @@
+name: Development bootstrap payload
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/dev-bootstrap-payload.yml'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  publish-dev60-payload:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'dev/webview2-navigation-timeout-60s'
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download previously validated WebView2 60s development artifact
+        uses: actions/download-artifact@v8
+        with:
+          run-id: 32273447594
+          github-token: ${{ github.token }}
+          name: windows-x64-dev-webview2-60s
+          path: downloaded
+
+      - name: Stage compact dev60 manifest
+        shell: powershell
+        run: |
+          $PayloadName = 'DSH-Portable-windows-x64-dev-webview2-60s.zip'
+          $PayloadPath = Join-Path 'downloaded' $PayloadName
+          if (-not (Test-Path -LiteralPath $PayloadPath)) { throw "Missing payload: $PayloadPath" }
+          $Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $PayloadPath).Hash.ToLowerInvariant()
+          $Bytes = (Get-Item -LiteralPath $PayloadPath).Length
+          $PayloadUrl = 'https://github.com/WSL043/DSH-Portable/raw/dev60/dev-payload/' + $PayloadName
+          $Manifest = [ordered]@{
+            schemaVersion = 1
+            version = '0.2.4-dev-webview2-60s'
+            payloads = [ordered]@{
+              windowsX64 = [ordered]@{
+                filename = $PayloadName
+                url = $PayloadUrl
+                sha256 = $Hash
+                bytes = $Bytes
+              }
+            }
+          }
+          New-Item -ItemType Directory -Force -Path 'staged/dev-payload' | Out-Null
+          Copy-Item -Force $PayloadPath 'staged/dev-payload/'
+          [System.IO.File]::WriteAllText(
+            (Join-Path 'staged/dev-payload' 'portable-manifest.json'),
+            (($Manifest | ConvertTo-Json -Depth 6) + [Environment]::NewLine),
+            [System.Text.UTF8Encoding]::new($false)
+          )
+
+      - name: Check out dev60 payload branch
+        uses: actions/checkout@v7
+        with:
+          ref: dev60
+          path: dev60-repo
+          persist-credentials: true
+
+      - name: Publish validated payload to dev60 branch
+        shell: powershell
+        run: |
+          $Target = Join-Path 'dev60-repo' 'dev-payload'
+          New-Item -ItemType Directory -Force -Path $Target | Out-Null
+          Copy-Item -Force 'staged/dev-payload/portable-manifest.json' (Join-Path $Target 'portable-manifest.json')
+          Copy-Item -Force 'staged/dev-payload/DSH-Portable-windows-x64-dev-webview2-60s.zip' (Join-Path $Target 'DSH-Portable-windows-x64-dev-webview2-60s.zip')
+          git -C dev60-repo config user.name 'github-actions[bot]'
+          git -C dev60-repo config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C dev60-repo add dev-payload/portable-manifest.json dev-payload/DSH-Portable-windows-x64-dev-webview2-60s.zip
+          git -C dev60-repo diff --cached --quiet
+          if ($LASTEXITCODE -ne 0) {
+            git -C dev60-repo commit -m 'dev: publish WebView2 60s portable payload'
+            if ($LASTEXITCODE -ne 0) { throw 'Could not commit dev60 payload.' }
+            git -C dev60-repo push origin HEAD:dev60
+            if ($LASTEXITCODE -ne 0) { throw 'Could not push dev60 payload.' }
+          }
+
+      - name: Verify public dev60 manifest
+        shell: powershell
+        run: |
+          $ManifestUrl = 'https://github.com/WSL043/DSH-Portable/raw/dev60/dev-payload/portable-manifest.json'
+          $Manifest = Invoke-RestMethod -UseBasicParsing -Uri $ManifestUrl
+          if ($Manifest.schemaVersion -ne 1) { throw 'Published dev60 manifest schema is invalid.' }
+          $Expected = (Get-FileHash -Algorithm SHA256 -LiteralPath 'downloaded/DSH-Portable-windows-x64-dev-webview2-60s.zip').Hash.ToLowerInvariant()
+          if ($Manifest.payloads.windowsX64.sha256 -ne $Expected) { throw 'Published dev60 manifest hash mismatch.' }

--- a/.github/workflows/dev-windows-webview2.yml
+++ b/.github/workflows/dev-windows-webview2.yml
@@ -6,13 +6,14 @@ on:
     paths:
       - '.github/workflows/dev-windows-webview2.yml'
       - 'scripts/build-windows-dev.ps1'
+      - 'scripts/build-windows-dev-bootstrap.ps1'
       - 'scripts/build-windows.ps1'
-      - 'scripts/build-windows-inno.ps1'
       - 'launcher/windows/DSH-Portable.cs'
+      - 'launcher/windows/DSH-Bootstrap.cs'
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   windows-webview2-dev:
@@ -31,56 +32,83 @@ jobs:
         shell: powershell
         run: ./scripts/build-windows-dev.ps1 -OutputDir artifacts
 
-      - name: Install pinned Inno Setup 7 compiler
+      - name: Stage temporary development payload manifest
         shell: powershell
         run: |
-          $Installer = Join-Path $env:RUNNER_TEMP 'innosetup-7.1.0-x64.exe'
-          $CompilerRoot = Join-Path $env:RUNNER_TEMP 'is7'
-          $ExpectedSha256 = '0362a383ed217d4c4239b5933866dd96d3eb2102737da92f80f6057a4b40df2f'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/jrsoftware/issrc/releases/download/is-7_1_0/innosetup-7.1.0-x64.exe' -OutFile $Installer
-          $ActualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $Installer).Hash.ToLowerInvariant()
-          if ($ActualSha256 -ne $ExpectedSha256) { throw "Inno Setup SHA-256 mismatch: $ActualSha256" }
-          $Arguments = '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CURRENTUSER /PORTABLE=1 /DIR="{0}"' -f $CompilerRoot
-          $Process = Start-Process -FilePath $Installer -ArgumentList $Arguments -Wait -PassThru
-          if ($Process.ExitCode -ne 0) { throw "Inno Setup installation failed with code $($Process.ExitCode)" }
-          $Iscc = Join-Path $CompilerRoot 'ISCC.exe'
-          if (-not (Test-Path -LiteralPath $Iscc)) { throw "ISCC.exe is missing: $Iscc" }
-          "ISCC_PATH=$Iscc" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Package offline development self-extractor
-        shell: powershell
-        run: ./scripts/build-windows-inno.ps1 -Kind portable -Archive 'artifacts/DSH-Portable-windows-x64-offline.zip' -OutputDir 'artifacts' -IsccPath $env:ISCC_PATH
-
-      - name: Stage clearly named development downloads
-        shell: powershell
-        run: |
-          $DevBase = 'DSH-Portable-windows-x64-dev-webview2-60s'
-          Copy-Item -Force 'artifacts/DSH-Portable-windows-x64-offline.exe' "artifacts/$DevBase.exe"
-          Copy-Item -Force 'artifacts/DSH-Portable-windows-x64-offline.zip' "artifacts/$DevBase.zip"
-          foreach ($Extension in @('exe', 'zip')) {
-            $File = "artifacts/$DevBase.$Extension"
-            $Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $File).Hash.ToLowerInvariant()
-            "$Hash  $DevBase.$Extension" | Set-Content -LiteralPath ($File + '.sha256') -Encoding ascii -NoNewline
+          $PayloadName = 'DSH-Portable-windows-x64-dev-webview2-60s.zip'
+          $PayloadPath = Join-Path 'artifacts' $PayloadName
+          Copy-Item -Force 'artifacts/DSH-Portable-windows-x64-offline.zip' $PayloadPath
+          $Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $PayloadPath).Hash.ToLowerInvariant()
+          $Bytes = (Get-Item -LiteralPath $PayloadPath).Length
+          $PayloadUrl = 'https://raw.githubusercontent.com/WSL043/DSH-Portable/dev-payload-webview2-60s/dev-payload/' + $PayloadName
+          $Manifest = [ordered]@{
+            schemaVersion = 1
+            version = '0.2.4-dev-webview2-60s'
+            payloads = [ordered]@{
+              windowsX64 = [ordered]@{
+                filename = $PayloadName
+                url = $PayloadUrl
+                sha256 = $Hash
+                bytes = $Bytes
+              }
+            }
           }
-          @'
-          DEVELOPMENT TEST BUILD — DO NOT PUBLISH
+          New-Item -ItemType Directory -Force -Path 'artifacts/dev-payload' | Out-Null
+          [System.IO.File]::WriteAllText(
+            (Join-Path 'artifacts/dev-payload' 'portable-manifest.json'),
+            (($Manifest | ConvertTo-Json -Depth 6) + [Environment]::NewLine),
+            [System.Text.UTF8Encoding]::new($false)
+          )
+          Copy-Item -Force $PayloadPath 'artifacts/dev-payload/'
+          "$Hash  $PayloadName" | Set-Content -LiteralPath ($PayloadPath + '.sha256') -Encoding ascii -NoNewline
 
-          Changes under test:
-          - Initial embedded WebView2 navigation timeout: 30s -> 60s
-          - Post-update embedded WebView2 navigation timeout: 30s -> 60s
-          - Timeout diagnostics now explicitly identify the embedded WebView2 layer and note that the local backend had already become ready.
+      - name: Build lightweight development bootstrap
+        shell: powershell
+        run: |
+          $ManifestUrl = 'https://raw.githubusercontent.com/WSL043/DSH-Portable/dev-payload-webview2-60s/dev-payload/portable-manifest.json'
+          ./scripts/build-windows-dev-bootstrap.ps1 -ManifestUrl $ManifestUrl -OutputDir artifacts
 
-          The stable release channel and main branch are not modified by this build.
-          '@ | Set-Content -LiteralPath 'artifacts/DEV-NOTES.txt' -Encoding utf8
+      - name: Check out temporary payload branch
+        uses: actions/checkout@v7
+        with:
+          ref: dev-payload-webview2-60s
+          path: dev-payload-repo
+          persist-credentials: true
+
+      - name: Publish temporary development payload branch
+        shell: powershell
+        run: |
+          $Target = Join-Path 'dev-payload-repo' 'dev-payload'
+          New-Item -ItemType Directory -Force -Path $Target | Out-Null
+          Copy-Item -Force 'artifacts/dev-payload/portable-manifest.json' (Join-Path $Target 'portable-manifest.json')
+          Copy-Item -Force 'artifacts/dev-payload/DSH-Portable-windows-x64-dev-webview2-60s.zip' (Join-Path $Target 'DSH-Portable-windows-x64-dev-webview2-60s.zip')
+          git -C dev-payload-repo config user.name 'github-actions[bot]'
+          git -C dev-payload-repo config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C dev-payload-repo add dev-payload/portable-manifest.json dev-payload/DSH-Portable-windows-x64-dev-webview2-60s.zip
+          git -C dev-payload-repo diff --cached --quiet
+          if ($LASTEXITCODE -ne 0) {
+            git -C dev-payload-repo commit -m 'dev: refresh WebView2 60s bootstrap payload'
+            if ($LASTEXITCODE -ne 0) { throw 'Could not commit temporary development payload.' }
+            git -C dev-payload-repo push origin HEAD:dev-payload-webview2-60s
+            if ($LASTEXITCODE -ne 0) { throw 'Could not push temporary development payload.' }
+          }
+
+      - name: Verify published development manifest
+        shell: powershell
+        run: |
+          $ManifestUrl = 'https://raw.githubusercontent.com/WSL043/DSH-Portable/dev-payload-webview2-60s/dev-payload/portable-manifest.json'
+          $Manifest = Invoke-RestMethod -UseBasicParsing -Uri $ManifestUrl
+          if ($Manifest.schemaVersion -ne 1) { throw 'Published development manifest schema is invalid.' }
+          if ($Manifest.payloads.windowsX64.sha256 -ne (Get-FileHash -Algorithm SHA256 -LiteralPath 'artifacts/DSH-Portable-windows-x64-dev-webview2-60s.zip').Hash.ToLowerInvariant()) {
+            throw 'Published development manifest hash does not match the development payload.'
+          }
 
       - uses: actions/upload-artifact@v7
         with:
-          name: windows-x64-dev-webview2-60s
+          name: windows-x64-dev-bootstrap-webview2-60s
           path: |
-            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.exe
-            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.exe.sha256
-            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.zip
-            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.zip.sha256
-            artifacts/DEV-NOTES.txt
+            artifacts/DSH-Portable-windows-x64-dev-bootstrap.exe
+            artifacts/DSH-Portable-windows-x64-dev-bootstrap.exe.sha256
+            artifacts/dev-payload/portable-manifest.json
           if-no-files-found: error
           compression-level: 0

--- a/.github/workflows/dev-windows-webview2.yml
+++ b/.github/workflows/dev-windows-webview2.yml
@@ -1,0 +1,86 @@
+name: Development Windows WebView2 package
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/dev-windows-webview2.yml'
+      - 'scripts/build-windows-dev.ps1'
+      - 'scripts/build-windows.ps1'
+      - 'scripts/build-windows-inno.ps1'
+      - 'launcher/windows/DSH-Portable.cs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-webview2-dev:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'dev/webview2-navigation-timeout-60s'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Build patched Windows development base
+        shell: powershell
+        run: ./scripts/build-windows-dev.ps1 -OutputDir artifacts
+
+      - name: Install pinned Inno Setup 7 compiler
+        shell: powershell
+        run: |
+          $Installer = Join-Path $env:RUNNER_TEMP 'innosetup-7.1.0-x64.exe'
+          $CompilerRoot = Join-Path $env:RUNNER_TEMP 'is7'
+          $ExpectedSha256 = '0362a383ed217d4c4239b5933866dd96d3eb2102737da92f80f6057a4b40df2f'
+          Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/jrsoftware/issrc/releases/download/is-7_1_0/innosetup-7.1.0-x64.exe' -OutFile $Installer
+          $ActualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $Installer).Hash.ToLowerInvariant()
+          if ($ActualSha256 -ne $ExpectedSha256) { throw "Inno Setup SHA-256 mismatch: $ActualSha256" }
+          $Arguments = '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CURRENTUSER /PORTABLE=1 /DIR="{0}"' -f $CompilerRoot
+          $Process = Start-Process -FilePath $Installer -ArgumentList $Arguments -Wait -PassThru
+          if ($Process.ExitCode -ne 0) { throw "Inno Setup installation failed with code $($Process.ExitCode)" }
+          $Iscc = Join-Path $CompilerRoot 'ISCC.exe'
+          if (-not (Test-Path -LiteralPath $Iscc)) { throw "ISCC.exe is missing: $Iscc" }
+          "ISCC_PATH=$Iscc" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Package offline development self-extractor
+        shell: powershell
+        run: ./scripts/build-windows-inno.ps1 -Kind portable -Archive 'artifacts/DSH-Portable-windows-x64-offline.zip' -OutputDir 'artifacts' -IsccPath $env:ISCC_PATH
+
+      - name: Stage clearly named development downloads
+        shell: powershell
+        run: |
+          $DevBase = 'DSH-Portable-windows-x64-dev-webview2-60s'
+          Copy-Item -Force 'artifacts/DSH-Portable-windows-x64-offline.exe' "artifacts/$DevBase.exe"
+          Copy-Item -Force 'artifacts/DSH-Portable-windows-x64-offline.zip' "artifacts/$DevBase.zip"
+          foreach ($Extension in @('exe', 'zip')) {
+            $File = "artifacts/$DevBase.$Extension"
+            $Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $File).Hash.ToLowerInvariant()
+            "$Hash  $DevBase.$Extension" | Set-Content -LiteralPath ($File + '.sha256') -Encoding ascii -NoNewline
+          }
+          @'
+          DEVELOPMENT TEST BUILD — DO NOT PUBLISH
+
+          Changes under test:
+          - Initial embedded WebView2 navigation timeout: 30s -> 60s
+          - Post-update embedded WebView2 navigation timeout: 30s -> 60s
+          - Timeout diagnostics now explicitly identify the embedded WebView2 layer and note that the local backend had already become ready.
+
+          The stable release channel and main branch are not modified by this build.
+          '@ | Set-Content -LiteralPath 'artifacts/DEV-NOTES.txt' -Encoding utf8
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-x64-dev-webview2-60s
+          path: |
+            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.exe
+            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.exe.sha256
+            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.zip
+            artifacts/DSH-Portable-windows-x64-dev-webview2-60s.zip.sha256
+            artifacts/DEV-NOTES.txt
+          if-no-files-found: error
+          compression-level: 0

--- a/dev-payload/README.txt
+++ b/dev-payload/README.txt
@@ -1,0 +1,1 @@
+Temporary development payload channel for the WebView2 60-second bootstrap test. Stable release assets are not used by this test bootstrap.

--- a/scripts/build-windows-dev-bootstrap.ps1
+++ b/scripts/build-windows-dev-bootstrap.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ManifestUrl,
+    [string]$OutputDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+if (-not $OutputDir) { $OutputDir = Join-Path $ProjectRoot 'artifacts' }
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$SourcePath = Join-Path $ProjectRoot 'launcher\windows\DSH-Bootstrap.cs'
+$ManifestPath = Join-Path $ProjectRoot 'launcher\windows\DSH-Portable.manifest'
+$IconPath = Join-Path $ProjectRoot 'assets\DSH-Portable.ico'
+$Original = [System.IO.File]::ReadAllText($SourcePath)
+$Patched = $Original
+$StableManifest = 'https://github.com/WSL043/DSH-Portable/releases/download/update-channel-stable/portable-manifest.json'
+
+$Count = ([regex]::Matches($Patched, [regex]::Escape($StableManifest))).Count
+if ($Count -ne 1) {
+    throw "Expected exactly one stable bootstrap manifest URL, found $Count."
+}
+$Patched = $Patched.Replace($StableManifest, $ManifestUrl)
+
+$Csc = Join-Path $env:WINDIR 'Microsoft.NET\Framework64\v4.0.30319\csc.exe'
+if (-not (Test-Path -LiteralPath $Csc)) { $Csc = Join-Path $env:WINDIR 'Microsoft.NET\Framework\v4.0.30319\csc.exe' }
+if (-not (Test-Path -LiteralPath $Csc)) { throw 'The Windows .NET Framework C# compiler is unavailable.' }
+
+$Output = Join-Path $OutputDir 'DSH-Portable-windows-x64-dev-bootstrap.exe'
+try {
+    [System.IO.File]::WriteAllText($SourcePath, $Patched, [System.Text.UTF8Encoding]::new($false))
+    $CompilerArgs = @(
+        '/nologo', '/target:winexe', '/platform:x64', '/optimize+',
+        "/win32icon:$IconPath",
+        "/win32manifest:$ManifestPath",
+        '/reference:System.dll', '/reference:System.Core.dll', '/reference:System.Drawing.dll',
+        '/reference:System.Windows.Forms.dll', '/reference:System.Net.Http.dll',
+        '/reference:System.Runtime.Serialization.dll', '/reference:System.IO.Compression.dll',
+        "/out:$Output",
+        $SourcePath
+    )
+    & $Csc $CompilerArgs
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $Output)) {
+        throw 'Development bootstrap compilation failed.'
+    }
+} finally {
+    [System.IO.File]::WriteAllText($SourcePath, $Original, [System.Text.UTF8Encoding]::new($false))
+}
+
+$Size = (Get-Item -LiteralPath $Output).Length
+if ($Size -ge 1MB) { throw "Development bootstrap exceeded 1 MiB: $Size bytes" }
+$Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $Output).Hash.ToLowerInvariant()
+"$Hash  DSH-Portable-windows-x64-dev-bootstrap.exe" | Set-Content -LiteralPath ($Output + '.sha256') -Encoding ascii -NoNewline
+Write-Host "Development bootstrap: $Output ($Size bytes)"
+Write-Host "SHA-256: $Hash"

--- a/scripts/build-windows-dev.ps1
+++ b/scripts/build-windows-dev.ps1
@@ -18,14 +18,24 @@ if ($DelayCount -ne 2) {
 }
 $PatchedSource = [regex]::Replace($PatchedSource, $DelayPattern, 'Task.Delay(60000)')
 
-$Replacements = [ordered]@{
-    '更新后的工作台未能在 30 秒内打开。' = '更新后的工作台未能在 60 秒内通过内置 WebView2 打开。后端在超时前已经就绪。'
+# Keep this script ASCII-only because Windows PowerShell 5.1 treats a UTF-8
+# script without a BOM as an ANSI code page. Construct the Chinese seconds
+# marker from its Unicode code point instead of embedding non-ASCII source.
+$SecondCharacter = [string][char]0x79D2
+$Chinese30Seconds = '30 ' + $SecondCharacter
+$Chinese60Seconds = '60 ' + $SecondCharacter
+$ChineseTimeoutCount = [regex]::Matches($PatchedSource, [regex]::Escape($Chinese30Seconds)).Count
+if ($ChineseTimeoutCount -ne 2) {
+    throw "Expected exactly two Chinese 30-second timeout labels, found $ChineseTimeoutCount."
+}
+$PatchedSource = $PatchedSource.Replace($Chinese30Seconds, $Chinese60Seconds)
+
+$EnglishReplacements = [ordered]@{
     'The updated workspace did not open within 30 seconds.' = 'The updated workspace did not open in the embedded WebView2 within 60 seconds. The local backend had already become ready before this timeout.'
-    'DeepSeek Harness 工作台未能在 30 秒内打开。' = 'DeepSeek Harness 工作台未能在 60 秒内通过内置 WebView2 打开。后端在超时前已经就绪。'
     'The DeepSeek Harness workspace did not open within 30 seconds.' = 'The DeepSeek Harness workspace did not open in the embedded WebView2 within 60 seconds. The local backend had already become ready before this timeout.'
 }
 
-foreach ($Entry in $Replacements.GetEnumerator()) {
+foreach ($Entry in $EnglishReplacements.GetEnumerator()) {
     $Count = ([regex]::Matches($PatchedSource, [regex]::Escape([string]$Entry.Key))).Count
     if ($Count -ne 1) {
         throw "Expected one launcher message matching '$($Entry.Key)', found $Count. Refusing to build an ambiguous dev package."
@@ -36,7 +46,7 @@ foreach ($Entry in $Replacements.GetEnumerator()) {
 if ([regex]::Matches($PatchedSource, 'Task\.Delay\(60000\)').Count -ne 2) {
     throw 'The development timeout patch did not produce exactly two 60-second navigation waits.'
 }
-if ($PatchedSource.Contains('within 30 seconds') -or $PatchedSource.Contains('30 秒内打开')) {
+if ($PatchedSource.Contains('within 30 seconds') -or $PatchedSource.Contains($Chinese30Seconds)) {
     throw 'A stale 30-second workspace timeout message remains after the development patch.'
 }
 

--- a/scripts/build-windows-dev.ps1
+++ b/scripts/build-windows-dev.ps1
@@ -1,0 +1,53 @@
+[CmdletBinding()]
+param(
+    [string]$OutputDir,
+    [string]$CacheDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$LauncherSource = Join-Path $ProjectRoot 'launcher\windows\DSH-Portable.cs'
+$OriginalSource = [System.IO.File]::ReadAllText($LauncherSource)
+$PatchedSource = $OriginalSource
+
+$DelayPattern = 'Task\.Delay\(30000\)'
+$DelayCount = [regex]::Matches($PatchedSource, $DelayPattern).Count
+if ($DelayCount -ne 2) {
+    throw "Expected exactly two 30-second WebView2 navigation delays, found $DelayCount. Refusing to build an ambiguous dev package."
+}
+$PatchedSource = [regex]::Replace($PatchedSource, $DelayPattern, 'Task.Delay(60000)')
+
+$Replacements = [ordered]@{
+    '更新后的工作台未能在 30 秒内打开。' = '更新后的工作台未能在 60 秒内通过内置 WebView2 打开。后端在超时前已经就绪。'
+    'The updated workspace did not open within 30 seconds.' = 'The updated workspace did not open in the embedded WebView2 within 60 seconds. The local backend had already become ready before this timeout.'
+    'DeepSeek Harness 工作台未能在 30 秒内打开。' = 'DeepSeek Harness 工作台未能在 60 秒内通过内置 WebView2 打开。后端在超时前已经就绪。'
+    'The DeepSeek Harness workspace did not open within 30 seconds.' = 'The DeepSeek Harness workspace did not open in the embedded WebView2 within 60 seconds. The local backend had already become ready before this timeout.'
+}
+
+foreach ($Entry in $Replacements.GetEnumerator()) {
+    $Count = ([regex]::Matches($PatchedSource, [regex]::Escape([string]$Entry.Key))).Count
+    if ($Count -ne 1) {
+        throw "Expected one launcher message matching '$($Entry.Key)', found $Count. Refusing to build an ambiguous dev package."
+    }
+    $PatchedSource = $PatchedSource.Replace([string]$Entry.Key, [string]$Entry.Value)
+}
+
+if ([regex]::Matches($PatchedSource, 'Task\.Delay\(60000\)').Count -ne 2) {
+    throw 'The development timeout patch did not produce exactly two 60-second navigation waits.'
+}
+if ($PatchedSource.Contains('within 30 seconds') -or $PatchedSource.Contains('30 秒内打开')) {
+    throw 'A stale 30-second workspace timeout message remains after the development patch.'
+}
+
+try {
+    [System.IO.File]::WriteAllText($LauncherSource, $PatchedSource, [System.Text.UTF8Encoding]::new($false))
+    Write-Host 'Development patch applied: embedded WebView2 navigation timeout is 60 seconds on initial and post-update navigation.'
+
+    $BuildArgs = @{}
+    if ($OutputDir) { $BuildArgs.OutputDir = $OutputDir }
+    if ($CacheDir) { $BuildArgs.CacheDir = $CacheDir }
+    & (Join-Path $PSScriptRoot 'build-windows.ps1') @BuildArgs
+} finally {
+    [System.IO.File]::WriteAllText($LauncherSource, $OriginalSource, [System.Text.UTF8Encoding]::new($false))
+}


### PR DESCRIPTION
Development/test build only; do not merge or publish yet.

Changes under test:
- patch both embedded WebView2 navigation waits from 30 seconds to 60 seconds during the Windows dev build;
- cover both initial workspace opening and post-update workspace reopening;
- update Chinese/English timeout diagnostics to identify the embedded WebView2 layer and clarify that the local backend had already become ready;
- produce an isolated offline Windows self-extractor and ZIP for manual testing without changing the stable release channel.

The development patch is applied only in the CI workspace by `scripts/build-windows-dev.ps1`; `main` and release assets remain untouched until manual validation.