### PR TITLE
Launch the DSH-Portable website

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Website
+
+on:
+  pull_request:
+    paths:
+      - "site/**"
+      - "assets/DSH-Portable.svg"
+      - "assets/DSH-Portable-512.png"
+      - "assets/dsh-interface-zh.png"
+      - "assets/dsh-interface-en.png"
+      - "scripts/build-site.mjs"
+      - ".github/workflows/pages.yml"
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "assets/DSH-Portable.svg"
+      - "assets/DSH-Portable-512.png"
+      - "assets/dsh-interface-zh.png"
+      - "assets/dsh-interface-en.png"
+      - "scripts/build-site.mjs"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node scripts/build-site.mjs
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/site
+
+  deploy:
+    if: github.event_name == 'push'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /runtime/
 /workspace/
 *.log
+build/

--- a/README.en.md
+++ b/README.en.md
@@ -1,130 +1,104 @@
 <p align="center">
-  <img src="assets/DSH-Portable.svg" width="96" alt="DeepSeek Harness">
+  <img src="assets/DSH-Portable.svg" width="82" alt="DeepSeek Harness">
 </p>
 
 <h1 align="center">DSH-Portable</h1>
 
 <p align="center">
-  Carry DeepSeek Harness, sessions, settings, plugins, and workspace together.<br>
-  Copy one folder to another drive, USB device, or PC and continue working.
+  <strong>Take your entire DeepSeek Harness workspace with you.</strong><br>
+  Sessions, settings, plugins, and workspace stay together. Copy one folder and continue working.
 </p>
 
 <p align="center">
-  <a href="README.md">简体中文</a> · <strong>English</strong>
+  <a href="https://github.com/WSL043/DSH-Portable/releases/latest"><strong>Download</strong></a>
+  · <a href="#start-in-3-steps">Get started</a>
+  · <a href="#plugins">Plugins</a>
+  · <a href="#get-help">Support</a>
+  · <a href="README.md">简体中文</a> · <strong>English</strong>
 </p>
 
 <p align="center">
   <a href="https://github.com/WSL043/DSH-Portable/releases/latest"><img src="https://img.shields.io/github/v/release/WSL043/DSH-Portable?display_name=release&style=flat-square&color=171717" alt="Latest release"></a>
-  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-171717?style=flat-square" alt="Windows, macOS, and Linux">
-  <a href="https://github.com/WSL043/DSH-Portable"><img src="https://img.shields.io/github/stars/WSL043/DSH-Portable?style=flat-square&label=Star&color=171717" alt="Star DSH-Portable on GitHub"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2F855A?style=flat-square" alt="MIT license"></a>
+  <img src="https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Linux-171717?style=flat-square" alt="Windows, macOS, and Linux">
+  <a href="https://github.com/WSL043/DSH-Portable/stargazers"><img src="https://img.shields.io/github/stars/WSL043/DSH-Portable?style=flat-square&label=Star&color=171717" alt="GitHub stars"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2f855a?style=flat-square" alt="MIT license"></a>
 </p>
 
 <p align="center">
   <a href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe"><strong>Download Windows portable (recommended)</strong></a>
-  &nbsp;·&nbsp;
-  <a href="#other-downloads">Other platforms and install modes</a>
 </p>
 
 <p align="center">
-  <img src="assets/dsh-interface-en.png" width="960" alt="DeepSeek Harness in English running inside DSH-Portable">
+  <img src="assets/dsh-interface-en.png" width="1040" alt="DeepSeek Harness workspace in DSH-Portable">
 </p>
 
 > [!NOTE]
-> DeepSeek Harness is currently a developer preview. DSH-Portable is an
-> independent community distribution, not an official DeepSeek desktop app.
+> DSH-Portable is an independent community distribution, not an official DeepSeek desktop app. It packages an adapted and finished-product-tested preview of official DeepSeek Harness.
+
+## Why portable
+
+| One folder | Move and continue | Update without moving data |
+| --- | --- | --- |
+| Sessions, settings, plugins, desktop data, and the default workspace stay together. | Exit, copy to another drive, USB device, or computer, and open it again. | Updates replace reproducible app components while keeping sessions, credentials, plugins, and workspace. |
+
+It still behaves like a desktop product: dedicated window, system tray, recent sessions, task-completion notifications, remembered window placement, and updates that do not interrupt active work.
 
 ## Start in 3 steps
 
 1. Download the [**Windows portable launcher**](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe).
-2. Run it once. It prepares a complete `DSH-Portable` folder beside itself and opens the desktop app.
-3. Connect a model in the interface. Next time, run `DeepSeek-Herness.exe` in that folder.
+2. Run it and choose a location. It prepares a complete `DSH-Portable` folder.
+3. Connect a model in the interface. Next time, run `DeepSeek-Herness.exe` inside that folder.
 
-Closing the window sends the app to the system tray by default, so active tasks keep running.
-Use **Exit DeepSeek Harness** in the tray menu to stop everything, or change **When closing the
-window** to exit directly. The tray follows the DSH language and light/dark appearance, and can
-open a recent session or start a new one directly. Task-completion notifications can be toggled
-from **More** in the same menu.
+The close button sends the app to the system tray by default, so an active task can keep running. To stop everything, right-click the tray icon and choose **Exit DeepSeek Harness**.
 
-The Windows launcher and installer follow the system UI language in Chinese or English. The DSH
-workspace language can also be changed in **Settings**, and that choice is remembered.
-
-## Built for portable use
-
-- **One complete work environment**: sessions, settings, plugins, default workspace, and desktop data move together.
-- **Continue from a new location**: copy the folder to another drive, USB device, or Windows PC.
-- **Simple backup**: exit the app, then copy one folder instead of finding separate data directories.
-- **Native desktop ownership**: a dedicated window, taskbar identity, system tray, and remembered window placement.
-- **Data-safe updates**: tested releases preserve local sessions, credentials, plugins, and workspace.
-- **Online or offline preparation**: use the small launcher normally or a single-file offline extractor on a restricted network.
-
-## Moving, backing up, and syncing
-
-1. Choose **Exit DeepSeek Harness** from the system tray and wait for its icon to disappear.
-2. Copy the entire `DSH-Portable` folder.
-3. Run `DeepSeek-Herness.exe` from the new location.
-
-Managed paths are repaired automatically after a move. External projects keep their original paths.
-When syncing between two computers, exit the app on both before syncing the whole folder.
-
-## Other downloads
+## Downloads
 
 ### Windows
 
-| Use case | Download |
+| Choose this when… | Download |
 | --- | --- |
-| **Portable use (recommended)** | [Portable launcher](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe) — creates a movable folder on first run |
-| **First setup must work offline** | [Single-file offline edition](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.exe) — choose a location and get a complete movable folder |
-| **Manual extraction or managed deployment** | [Complete portable ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip) |
-| **Install like a normal app** | [Windows installer](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-Setup.exe) — Start menu, shortcut, and standard uninstall |
+| You want a movable folder prepared automatically | [**Portable launcher**](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe) (recommended, about 55 KB) |
+| The destination computer is offline, or you need manual extraction | [Complete offline ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip) |
+| You want a conventional install and uninstall flow | [Windows installer](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-Setup.exe) |
 
 ### macOS
 
-| Mac | Portable ZIP | Disk image |
+| Mac | DMG (recommended) | Portable ZIP |
 | --- | --- | --- |
-| Apple Silicon (M1–M4) | [ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-arm64.zip) | [DMG](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-arm64.dmg) |
-| Intel | [ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-x64.zip) | [DMG](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-x64.dmg) |
+| Apple Silicon (M1–M4) | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-arm64.dmg) | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-arm64.zip) |
+| Intel | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-x64.dmg) | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-x64.zip) |
 
-The macOS packages are ad-hoc signed, not notarized by Apple. If first launch is blocked,
-Control-click the app and choose **Open**.
+macOS packages are ad-hoc signed and not notarized by Apple. If first launch is blocked, Control-click the app and choose **Open**.
 
 ### Linux
 
-| Computer | One-click app (recommended) | Complete portable folder |
+| Computer | AppImage (recommended) | Complete portable folder |
 | --- | --- | --- |
-| Common Intel / AMD computer (x64) | [AppImage](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-x64.AppImage) | [tar.gz](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-x64.tar.gz) |
-| ARM64 computer | [AppImage](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-arm64.AppImage) | [tar.gz](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-arm64.tar.gz) |
-
-Make the AppImage executable once, then run it:
+| Intel / AMD (x64) | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-x64.AppImage) | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-x64.tar.gz) |
+| ARM64 | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-arm64.AppImage) | [Download](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-arm64.tar.gz) |
 
 ```bash
 chmod +x DeepSeek-Herness-linux-x64.AppImage
 ./DeepSeek-Herness-linux-x64.AppImage
 ```
 
-The AppImage keeps sessions, settings, plugins, and workspace in a sibling
-`DSH-Portable-data` folder. Move or back up the AppImage and that folder together. The tar.gz
-contains a complete `DSH-Portable` directory; extract it and run `DeepSeek-Herness` inside.
+The AppImage keeps sessions, settings, plugins, and workspace in the sibling `DSH-Portable-data` folder. Move or back up both together.
 
-## Plugin management
+## Move and back up
 
-The current candidate includes a visual **Plugin Market** under **Settings → Plugins → Plugin Market**. It browses the thousand-plus
-community catalog maintained by [awesome-dsh-plugin](https://awesome-dsh-plugin.com), with search,
-categories, popularity, and publish-time filters. The same repository is listed only once. Curated
-author screenshots appear directly on cards; other images load only after details are opened. Every
-plugin links to its own project page instead of being copied into a hand-maintained Portable catalog.
+1. Choose **Exit DeepSeek Harness** from the tray and wait for the window and tray icon to disappear.
+2. Copy the entire `DSH-Portable` folder.
+3. Run `DeepSeek-Herness.exe` on Windows or the corresponding entry point on the new platform.
 
-The market follows the DSH language and theme. Install, update, disable, and uninstall actions target
-the current `web` profile, while the Portable shell keeps process ownership and never interrupts an
-active task silently. A fresh install includes the removable
-[permanent session deletion](https://github.com/WSL043/dsh-native-session-delete) extension in **Installed**.
-It is enabled by default, always asks for a second confirmation, and does not replace recoverable
-Archive. Ordinary upgrades never reinstall an extension that an existing user already removed.
+Managed paths repair themselves after a move; external projects remain where you placed them. Exit on both computers before synchronizing the same folder to avoid concurrent session writes.
 
-Plugins, settings, and sessions stay with Portable data when the product is moved or backed up.
-`dsh.exe` remains an advanced command-line tool, not a second desktop launcher; normal desktop use
-starts with `DeepSeek-Herness.exe`. To install a plugin outside the catalog, open PowerShell in the
-DSH-Portable folder:
+## Plugins
+
+Open **Settings → Plugins → Plugin Market** to search, filter, visit a project, and install, update, disable, or remove community plugins. The market follows the DSH language and theme and never interrupts an active task silently.
+
+Fresh installs include the removable [permanent session deletion](https://github.com/WSL043/dsh-native-session-delete) plugin. Permanent deletion always asks for a second confirmation and does not replace recoverable Archive. Normal upgrades do not reinstall a plugin an existing user removed.
+
+`dsh.exe` is the command-line entry point for advanced users, not another desktop launcher:
 
 ```powershell
 .\dsh.exe plugin --profile web add <plugin>
@@ -134,75 +108,42 @@ DSH-Portable folder:
 .\dsh.exe --profile web --dump-config
 ```
 
-In a complete Linux portable folder, use `./dsh`. With the AppImage, use
-`./DeepSeek-Herness-linux-<architecture>.AppImage dsh`:
+Plugin changes never restart a running DSH automatically. They take effect after you restart at a convenient time. Install only plugins you trust.
 
-```bash
-./dsh plugin --profile web add <plugin>
-./dsh plugin --profile web list --depth 0
-./dsh plugin --profile web update <package-name>
-./dsh plugin --profile web remove <package-name>
-./dsh --profile web --dump-config
-```
+## Updates and repair
 
-Plugins and settings travel with the portable data. Plugin changes never restart a running task;
-save your work and restart the app when convenient. Install only plugins you trust.
+- DSH-Portable opens the local workspace first, then checks for updates in the background. Automatic update checks are off by default; check manually or enable **Check for updates at startup** from the tray.
+- The update window distinguishes the DSH-Portable product version from the bundled official DSH version.
+- Every notification names the DSH-Portable product version; the bundled official DSH version and whether it changes are listed separately.
+- A normal update downloads only the changed DSH application component and shows the real download percentage. Sessions, settings, credentials, and workspace remain in place.
+- When the runtime compatibility boundary changes, DSH-Portable downloads the verified complete package and replaces the app in place while preserving user data.
+- Choose Later or **Skip this version**; installation waits for active tasks and a failed update rolls back.
+- **Settings → General → Portable** provides checks, repair, and a support report. Repair keeps user data and rebuilds only reproducible components.
 
-## Updates
-
-Versions without a suffix, such as `0.2.0`, are stable releases. Versions ending in `-rc.N`
-are release candidates, are marked **Pre-release** on GitHub, and are not offered to stable users.
-
-Every notification names the DSH-Portable product version. The update window separately shows the
-current and target bundled official DSH versions and whether the engine changes in that release.
-An official DSH release is adapted and tested as a finished product before it is delivered through
-DSH-Portable; it never bypasses the desktop shell to replace a working environment directly.
-
-DSH-Portable opens the local workspace first, then checks for updates in the background and asks before installing one. Network availability does not block startup. A normal update
-downloads only the changed DSH application component. Sessions, settings, credentials, and workspace remain in place.
-The window shows the real download percentage and transferred size, followed by the
-verification, installation, and reopen stages. A failed launch restores the previous version.
-
-On Windows and Linux, you can **Check for updates** from the system tray; on macOS, use the application menu.
-Automatic update checks are off by default. Turn on **Check for updates at startup** from the same menu if you want them; manual checks remain available.
-The manual check remains available. When an update is available, choose to update, handle it **Later**,
-or **Skip this version**. Windows installs immediately only after it can confirm that no task is running;
-macOS and Linux schedule the component for installation before the next launch. Skipping affects only that release,
-and a running task is never interrupted for an update.
-
-When the runtime compatibility boundary changes, Windows downloads the verified complete package,
-keeps `data` and `workspace`, and replaces the program in place. macOS and Linux clearly request a one-time complete
-package download for the same boundary. Official
-preview updates first become candidate builds and must pass Windows, macOS, and Linux x64/ARM64 finished-product
-tests before they enter the launcher update channel.
-
-Default JSONL sessions upgrade normally. If you explicitly enabled DSH's optional durable SQLite backend,
-back it up before upgrading. DSH-Portable does not delete an old database when an upstream preview changes
-its format without providing a migration.
+An official DSH update never replaces a working environment directly. It reaches the Portable channel only after Windows, macOS, Linux x64, and Linux ARM64 finished-product tests.
 
 ## Portable data
 
-- `data/dsh-home/`: settings, credentials, sessions, and plugins;
-- `data/webview2/`: Windows desktop web data;
-- `workspace/`: default workspace;
-- `data/logs/`: local service logs.
+| Path | Contents |
+| --- | --- |
+| `data/dsh-home/` | Settings, model credentials, sessions, and plugins |
+| `data/webview2/` | Windows desktop web data |
+| `workspace/` | Default workspace |
+| `data/logs/` | Local service and launcher logs |
 
-The installed edition keeps the same data under `%LOCALAPPDATA%\DeepSeek-Herness` and does not
-delete it during uninstall.
-
-## Get help
-
-[**Report a problem**](https://github.com/WSL043/DSH-Portable/issues/new?template=bug-report.yml)
-or [**request an improvement**](https://github.com/WSL043/DSH-Portable/issues/new?template=feature-request.yml).
-Do not paste API keys, login credentials, or private conversations into an issue.
+The installed edition keeps the same data under `%LOCALAPPDATA%\DeepSeek-Herness` and does not remove it during uninstall.
 
 ## Security
 
-DSH is an agent environment with local code-execution capability. Use trusted models, plugins,
-and projects. The service binds only to `127.0.0.1`, and this shell disables DSH telemetry by default.
+DSH can execute local code, so use trusted models, plugins, and projects. The local service binds only to `127.0.0.1`, and the Portable shell disables DSH telemetry by default. `data` may contain API credentials and private conversations; protect it accordingly and prefer NTFS on removable Windows drives.
 
-The `data` directory can contain API credentials and private conversations. Protect it accordingly.
-Use NTFS for removable Windows drives when possible; FAT and exFAT do not provide equivalent permissions.
+## Get help
+
+- [Report a bug](https://github.com/WSL043/DSH-Portable/issues/new?template=bug-report.yml)
+- [Request an improvement](https://github.com/WSL043/DSH-Portable/issues/new?template=feature-request.yml)
+- [Join a discussion](https://github.com/WSL043/DSH-Portable/discussions)
+
+Do not paste API keys, login credentials, or private conversations into an issue.
 
 <details>
 <summary><strong>Build from source</strong></summary>
@@ -213,15 +154,13 @@ Use NTFS for removable Windows drives when possible; FAT and exFAT do not provid
 
 ```bash
 bash scripts/build-macos.sh arm64   # or x64
+bash scripts/build-linux.sh x64     # or arm64
 ```
 
-The repository pins dependencies, release contents, and finished-product tests. The launcher handles
-download verification, so normal users do not need to compare checksums manually.
+Dependencies, release contents, and finished-product tests are pinned by the repository. Normal users do not need to compare checksums manually; `checksums.txt` remains available on each Release.
 
 </details>
 
-If DSH-Portable helps you, consider giving it a
-[**Star**](https://github.com/WSL043/DSH-Portable). It helps more people who need a portable DSH find the project.
+If DSH-Portable helps you, consider leaving a [**Star**](https://github.com/WSL043/DSH-Portable/stargazers). It helps other people looking for a portable DSH discover the project.
 
-DeepSeek Harness, the DeepSeek name, and its marks belong to DeepSeek. DSH-Portable is maintained
-independently by WSL043 and is not endorsed by DeepSeek.
+DeepSeek Harness, the DeepSeek name, and its marks belong to DeepSeek. DSH-Portable is independently maintained by WSL043 and is not endorsed by DeepSeek.

--- a/README.md
+++ b/README.md
@@ -1,140 +1,104 @@
 <p align="center">
-  <img src="assets/DSH-Portable.svg" width="96" alt="DeepSeek Harness">
+  <img src="assets/DSH-Portable.svg" width="82" alt="DeepSeek Harness">
 </p>
 
 <h1 align="center">DSH-Portable</h1>
 
 <p align="center">
-  把 DeepSeek Harness、会话、设置、插件和工作区带在身边。<br>
-  复制整个文件夹，就能放进 U 盘、移动硬盘或另一台电脑继续使用。
+  <strong>把整个 DeepSeek Harness 工作环境带走。</strong><br>
+  会话、设置、插件和工作区放在一起，复制一个文件夹就能继续工作。
 </p>
 
 <p align="center">
-  <strong>简体中文</strong> · <a href="README.en.md">English</a>
+  <a href="https://github.com/WSL043/DSH-Portable/releases/latest"><strong>下载</strong></a>
+  · <a href="#三步启动">开始使用</a>
+  · <a href="#插件">插件</a>
+  · <a href="#获取帮助">帮助</a>
+  · <strong>简体中文</strong> · <a href="README.en.md">English</a>
 </p>
 
 <p align="center">
   <a href="https://github.com/WSL043/DSH-Portable/releases/latest"><img src="https://img.shields.io/github/v/release/WSL043/DSH-Portable?display_name=release&style=flat-square&color=171717" alt="最新版本"></a>
-  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-171717?style=flat-square" alt="Windows、macOS 和 Linux">
-  <a href="https://github.com/WSL043/DSH-Portable"><img src="https://img.shields.io/github/stars/WSL043/DSH-Portable?style=flat-square&label=Star&color=171717" alt="在 GitHub 上 Star DSH-Portable"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2F855A?style=flat-square" alt="MIT 许可证"></a>
+  <img src="https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Linux-171717?style=flat-square" alt="支持 Windows、macOS 和 Linux">
+  <a href="https://github.com/WSL043/DSH-Portable/stargazers"><img src="https://img.shields.io/github/stars/WSL043/DSH-Portable?style=flat-square&label=Star&color=171717" alt="GitHub Star"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2f855a?style=flat-square" alt="MIT 许可证"></a>
 </p>
 
 <p align="center">
   <a href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe"><strong>下载 Windows 便携版（推荐）</strong></a>
-  &nbsp;·&nbsp;
-  <a href="#其他下载">选择其他系统或安装方式</a>
 </p>
 
 <p align="center">
-  <img src="assets/dsh-interface-zh.png" width="960" alt="DSH-Portable 中运行的中文 DeepSeek Harness 工作台">
+  <img src="assets/dsh-interface-zh.png" width="1040" alt="DSH-Portable 中文桌面工作台">
 </p>
 
 > [!NOTE]
-> DeepSeek Harness 目前仍是开发者预览版。DSH-Portable 是独立社区分发项目，
-> 不是 DeepSeek 官方桌面应用。
+> DSH-Portable 是独立社区发行版，不是 DeepSeek 官方桌面应用。它内置经过适配和成品测试的官方 DeepSeek Harness 预览版本。
+
+## 为什么是 Portable
+
+| 一个文件夹 | 换位置继续 | 更新不动数据 |
+| --- | --- | --- |
+| 会话、设置、插件、桌面数据和默认工作区放在一起。 | 退出后复制到另一块硬盘、U 盘或电脑，重新打开即可。 | 更新替换可再生的程序组件，保留你的会话、凭据、插件和工作区。 |
+
+同时保留桌面程序该有的体验：独立窗口、系统托盘、最近会话、任务完成通知、自动恢复窗口位置，以及不打断运行任务的更新流程。
 
 ## 三步启动
 
-1. 下载 [**Windows 便携版**](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe)。
-2. 双击运行。它会在旁边准备一个完整的 `DSH-Portable` 文件夹并打开桌面窗口。
-3. 按界面提示连接模型。以后直接双击文件夹里的 `DeepSeek-Herness.exe`。
+1. 下载 [**Windows 便携启动器**](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe)。
+2. 双击运行并选择位置，它会准备一个完整的 `DSH-Portable` 文件夹。
+3. 在界面中连接模型。以后直接运行文件夹里的 `DeepSeek-Herness.exe`。
 
-默认点击右上角关闭按钮会收进系统托盘，正在执行的任务继续运行。要完全退出，
-右键托盘图标选择 **退出 DeepSeek Harness**；也可以在托盘菜单的 **关闭窗口时**
-改成直接退出。托盘菜单会跟随 DSH 的语言和明暗外观，并可直接打开最近会话或
-新建会话。任务完成时可发送系统通知；这个开关也在托盘的 **更多** 中。
+右上角关闭按钮默认把应用收进系统托盘，运行中的任务会继续。需要完全退出时，右键托盘图标并选择 **退出 DeepSeek Harness**。
 
-Windows 启动器和安装界面会跟随系统显示中文或英文；DSH 工作台也可以在
-**设置**中切换语言，选择会自动保存。
-
-## 为什么适合便携使用
-
-- **一个文件夹就是完整工作环境**：会话、设置、插件、默认工作区和桌面数据一起移动。
-- **换位置继续工作**：复制到另一块硬盘、U 盘或另一台 Windows 电脑，打开后继续使用。
-- **备份简单**：退出应用后复制整个文件夹，不用分别寻找配置和插件目录。
-- **原生桌面体验**：独立应用窗口、任务栏身份和系统托盘，并记住上次窗口大小与位置。
-- **更新不打散数据**：经过测试的更新会保留本地会话、凭据、插件和工作区。
-- **在线与离线都能准备**：日常使用轻量便携启动器；受限网络可用单文件离线版直接准备便携文件夹。
-
-## 迁移、备份与同步
-
-1. 从系统托盘选择 **退出 DeepSeek Harness**，等窗口和托盘图标都消失。
-2. 复制整个 `DSH-Portable` 文件夹。
-3. 在新位置双击 `DeepSeek-Herness.exe`。
-
-启动器会自动修正它管理的旧路径；你主动打开的外部项目仍保留原位置。需要在两台
-电脑之间同步时，也同步整个文件夹，并确保两边都已退出，避免同时改写会话文件。
-
-## 其他下载
+## 下载
 
 ### Windows
 
-| 你想怎么用 | 下载 |
+| 适合你，如果… | 下载 |
 | --- | --- |
-| **便携使用（推荐）** | [便携启动器](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe) — 首次运行后得到可移动文件夹 |
-| **目标电脑首次准备时无法联网** | [单文件离线版](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.exe) — 双击后选择位置，自动准备完整便携文件夹 |
-| **需要手动解压或批量部署** | [便携完整 ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip) |
-| **像普通软件一样安装** | [Windows 安装版](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-Setup.exe) — 开始菜单、桌面快捷方式和标准卸载 |
-
-> [!TIP]
-> **国内网络加速**：GitHub 直连下载在国内可能较慢，可直接下载下方社区镜像的
-> **Windows 离线版完整 ZIP**（适合手动解压或批量部署）。镜像是社区维护的加速
-> 服务，非官方部署；失效时请换用备用路线或 GitHub 原链接，并核对
-> [checksums.txt](https://github.com/WSL043/DSH-Portable/releases/latest/download/checksums.txt)。
-
-| 路线 | 镜像 | 链接 |
-| --- | --- | --- |
-| 主选 | gh-proxy.com | [下载](https://gh-proxy.com/https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip) |
-| 备用 1 | ghfast.top | [下载](https://ghfast.top/https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip) |
-| 备用 2 | gh.ddlc.top | [下载](https://gh.ddlc.top/https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip) |
+| 想要可移动、自动准备的工作文件夹 | [**便携启动器**](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe)（推荐，约 55 KB） |
+| 目标电脑无法联网，或需要手动解压 | [完整离线 ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip) |
+| 想像普通软件一样安装和卸载 | [Windows 安装版](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-Setup.exe) |
 
 ### macOS
 
-| 电脑 | 便携 ZIP | 安装镜像 |
+| 电脑 | DMG（推荐） | 便携 ZIP |
 | --- | --- | --- |
-| Apple Silicon（M1–M4） | [下载 ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-arm64.zip) | [下载 DMG](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-arm64.dmg) |
-| Intel Mac | [下载 ZIP](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-x64.zip) | [下载 DMG](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-x64.dmg) |
+| Apple Silicon（M1–M4） | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-arm64.dmg) | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-arm64.zip) |
+| Intel Mac | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-x64.dmg) | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-x64.zip) |
 
-macOS 包采用临时签名，没有经过 Apple 公证。首次打开若被阻止，请按住 Control
-点按应用，再选择 **打开**。
+macOS 包采用临时签名，尚未经过 Apple 公证。首次打开若被阻止，请按住 Control 点按应用，再选择 **打开**。
 
 ### Linux
 
-| 电脑 | 一键启动（推荐） | 完整便携目录 |
+| 电脑 | AppImage（推荐） | 完整便携目录 |
 | --- | --- | --- |
-| 常见 Intel / AMD 电脑（x64） | [下载 AppImage](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-x64.AppImage) | [下载 tar.gz](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-x64.tar.gz) |
-| ARM64 电脑 | [下载 AppImage](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-arm64.AppImage) | [下载 tar.gz](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-arm64.tar.gz) |
-
-给 AppImage 添加一次执行权限后即可启动：
+| Intel / AMD（x64） | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-x64.AppImage) | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-x64.tar.gz) |
+| ARM64 | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-arm64.AppImage) | [下载](https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-arm64.tar.gz) |
 
 ```bash
 chmod +x DeepSeek-Herness-linux-x64.AppImage
 ./DeepSeek-Herness-linux-x64.AppImage
 ```
 
-AppImage 会把会话、设置、插件和工作区保存在同目录的 `DSH-Portable-data` 文件夹；
-迁移或备份时把 AppImage 与这个文件夹一起复制。tar.gz 是完整的 `DSH-Portable`
-目录，解压后运行其中的 `DeepSeek-Herness`，整个目录可直接移动。
+AppImage 的会话、设置、插件和工作区保存在旁边的 `DSH-Portable-data` 文件夹；移动或备份时把两者一起复制。
 
-## 插件管理
+## 移动与备份
 
-当前候选版内置 **插件市场**：打开 **设置 → 插件 → 插件市场**，即可浏览由
-[awesome-dsh-plugin](https://awesome-dsh-plugin.com) 持续整理的千余个社区插件，按名称、分类、
-热度和更新时间筛选。相同仓库只显示一次；有素材的插件直接显示作者提供的真实截图，
-其他图片只在打开详情后按需加载。每个插件都可以打开自己的项目页面，不由 Portable
-维护一套容易过时的卡片目录。
+1. 从托盘选择 **退出 DeepSeek Harness**，等窗口和托盘图标消失。
+2. 复制整个 `DSH-Portable` 文件夹。
+3. 在新位置运行 `DeepSeek-Herness.exe`（Windows）或对应平台入口。
 
-市场跟随 DSH 的中文/英文与明暗外观，安装、更新、停用和卸载都作用于当前 `web`
-配置。Portable 外壳继续负责程序生命周期，市场不会为了安装插件静默打断正在运行的任务。
-全新安装会在 **已安装** 中提供默认启用、可自行停用或卸载的
-[永久删除会话](https://github.com/WSL043/dsh-native-session-delete) 扩展；删除前必须再次确认，且不会
-取代仍可恢复的“归档”。为了尊重已有配置，普通升级不会把用户已经移除的扩展重新装回。
+启动器会修正它管理的旧路径；你主动打开的外部项目仍保留原位置。两台电脑同步同一目录前，请先在两边完全退出，避免同时写入会话文件。
 
-插件、设置与会话都保存在 Portable 数据目录中，移动或备份时会一起保留。`dsh.exe` 是
-为高级用户保留的命令行工具，不是第二个桌面启动器；日常使用直接运行
-`DeepSeek-Herness.exe`。需要安装目录外的插件时，可在 DSH-Portable 文件夹中打开
-PowerShell：
+## 插件
+
+打开 **设置 → 插件 → 插件市场**，可以搜索、筛选、查看项目主页，并安装、更新、停用或卸载社区插件。市场跟随 DSH 的中文/英文和明暗外观，不会为了安装插件静默中断正在运行的任务。
+
+全新安装包含可停用或卸载的[永久删除会话](https://github.com/WSL043/dsh-native-session-delete)插件。永久删除始终需要二次确认，也不会替代可恢复的“归档”。普通升级不会重新安装用户已经移除的插件。
+
+`dsh.exe` 是高级用户的命令行入口，不是第二个桌面启动器：
 
 ```powershell
 .\dsh.exe plugin --profile web add <插件>
@@ -144,68 +108,42 @@ PowerShell：
 .\dsh.exe --profile web --dump-config
 ```
 
-Linux 完整便携目录使用 `./dsh`；AppImage 使用 `./DeepSeek-Herness-linux-<架构>.AppImage dsh`：
+插件变更不会自动重启正在运行的 DSH，会在你方便时手动重启后生效；只安装你信任的插件。
 
-```bash
-./dsh plugin --profile web add <插件>
-./dsh plugin --profile web list --depth 0
-./dsh plugin --profile web update <插件包名>
-./dsh plugin --profile web remove <插件包名>
-./dsh --profile web --dump-config
-```
+## 更新与修复
 
-`<插件>` 可以是包名、Git 地址、本地目录或压缩包。插件和设置都保存在便携数据中，
-会随整个文件夹迁移。插件变更不会自动打断正在运行的任务；保存工作并手动退出、
-重新打开后生效。只安装你信任的插件。
+- DSH-Portable 会先打开本地工作台，再在后台检查更新。自动检查更新默认关闭；托盘菜单随时可以手动检查或开启**启动时检查更新**。
+- 更新窗口会分别显示 DSH-Portable 产品版本和内置官方 DSH 版本。
+- 每次提示的是 DSH-Portable 的产品版本；内置官方 DSH 的版本和这次是否变化会单独列出。
+- 一般更新只下载变化的 DSH 应用组件，并显示真实下载百分比；会话、设置、凭据和工作区全部保留。
+- 运行环境兼容性变化时，会直接下载经过验证的完整版本并原地更新，仍然保留用户数据。
+- 可以选择稍后或**跳过此版本**；安装前确认没有任务运行，失败时恢复更新前版本。
+- **设置 → 通用设置 → 便携版** 提供检查、修复和支持报告。修复保留用户数据，只重建可再生组件。
 
-## 更新
-
-不带后缀的版本（例如 `0.2.0`）是稳定正式版；带 `-rc.N` 的版本只用于发布前测试，
-会在 GitHub 上明确标为 **Pre-release**，不会作为稳定版推送给普通用户。
-
-每次提示的是 DSH-Portable 的产品版本；更新窗口会单独列出内置官方 DSH 的当前版本、
-目标版本和这次是否变化。官方 DSH 发布新版后，会先经过适配和成品测试，再随
-DSH-Portable 版本交付，不会绕过外壳直接替换你的工作环境。
-
-DSH-Portable 会先打开本地工作台，再在后台检查更新并询问是否安装；网络状态不会阻塞启动。一般更新只下载变化的 DSH
-应用组件；会话、设置、凭据和工作区都会保留。下载时显示真实下载百分比和已下载大小，
-随后依次显示验证、安装与重新打开阶段。若新版不能正常启动，会自动恢复到更新前版本。
-
-Windows 和 Linux 可以从系统托盘手动 **检查更新**，macOS 可以从应用菜单检查。不想接收主动提醒时，
-自动检查更新默认关闭；可在同一菜单里按需开启 **启动时检查更新**，手动检查入口始终保留。发现更新时可以选择
-更新、**稍后** 或 **跳过此版本**。Windows 只在确认没有任务运行时直接更新；macOS 与 Linux
-会把更新安排在下次启动前安装。跳过只对当前版本生效，后续新版仍会正常提示；有任务运行时不会为了更新中断任务。
-
-只有运行环境或启动器出现兼容性变化时才需要完整升级。Windows 会直接下载已验证的完整版本、
-保留 `data` 与 `workspace` 并原地完成替换；macOS 与 Linux 会明确提示下载一次完整新版。官方预览版更新
-会先生成候选版本，经过 Windows、macOS 与 Linux x64/ARM64 成品测试后才进入启动器更新通道，不会把
-未经验证的官方提交直接装到你的工作环境。
-
-默认 JSONL 会话可正常随版本升级。若你曾自行启用 DSH 的可选持久 SQLite 后端，
-请在升级前备份；上游预览版更改数据库格式且未提供迁移时，DSH-Portable 不会删除旧数据库。
+官方 DSH 更新不会直接替换正在使用的工作环境。新版会先经过 Windows、macOS、Linux x64/ARM64 的成品测试，再进入 DSH-Portable 更新通道。
 
 ## 便携数据
 
-- `data/dsh-home/`：设置、模型凭据、会话和插件；
-- `data/webview2/`：Windows 桌面窗口数据；
-- `workspace/`：默认工作区；
-- `data/logs/`：本地服务日志。
+| 路径 | 内容 |
+| --- | --- |
+| `data/dsh-home/` | 设置、模型凭据、会话和插件 |
+| `data/webview2/` | Windows 桌面窗口数据 |
+| `workspace/` | 默认工作区 |
+| `data/logs/` | 本地服务与启动日志 |
 
 安装版把相同数据放在 `%LOCALAPPDATA%\DeepSeek-Herness`，卸载应用时不会自动删除。
 
-## 获取帮助
-
-遇到问题可直接[**提交 Bug 报告**](https://github.com/WSL043/DSH-Portable/issues/new?template=bug-report.yml)，
-有改进想法可[**提交功能建议**](https://github.com/WSL043/DSH-Portable/issues/new?template=feature-request.yml)。
-请勿在 Issue 中粘贴 API Key、登录凭据或私人会话。
-
 ## 安全
 
-DSH 是具备本地代码执行能力的 Agent 运行环境，请只使用可信模型、插件和项目。
-服务只绑定 `127.0.0.1`，便携外壳默认关闭 DSH 遥测。
+DSH 具备本地代码执行能力，请只使用可信模型、插件和项目。本地服务只绑定 `127.0.0.1`，便携外壳默认关闭 DSH 遥测。`data` 可能包含 API 凭据和私人会话；请妥善保管，Windows 移动盘优先使用 NTFS。
 
-`data` 目录可能包含 API 凭据和私人会话，请妥善保管。Windows 移动盘优先使用
-NTFS；FAT 和 exFAT 无法提供同等级权限保护。
+## 获取帮助
+
+- [提交 Bug 报告](https://github.com/WSL043/DSH-Portable/issues/new?template=bug-report.yml)
+- [提出功能建议](https://github.com/WSL043/DSH-Portable/issues/new?template=feature-request.yml)
+- [参与讨论](https://github.com/WSL043/DSH-Portable/discussions)
+
+请勿在 Issue 中粘贴 API Key、登录凭据或私人会话。
 
 <details>
 <summary><strong>从源码构建</strong></summary>
@@ -219,13 +157,10 @@ bash scripts/build-macos.sh arm64   # 或 x64
 bash scripts/build-linux.sh x64     # 或 arm64
 ```
 
-依赖版本、发布内容和成品测试都由仓库固定。下载完整性由启动器处理，普通用户无需
-手动比对校验值。
+依赖、发布内容和成品测试均由仓库固定。普通用户无需手动比较校验值；需要时可从 Release 下载 `checksums.txt`。
 
 </details>
 
-如果 DSH-Portable 对你有帮助，欢迎在 GitHub 上给它点一个
-[**Star**](https://github.com/WSL043/DSH-Portable)。这会帮助更多需要便携 DSH 的用户找到它。
+如果 DSH-Portable 对你有帮助，欢迎点一个 [**Star**](https://github.com/WSL043/DSH-Portable/stargazers)。它会帮助更多需要便携 DSH 的用户找到这个项目。
 
-DeepSeek Harness、DeepSeek 名称与标志归 DeepSeek 所有。DSH-Portable 由 WSL043
-独立维护，未获 DeepSeek 背书。
+DeepSeek Harness、DeepSeek 名称与标志归 DeepSeek 所有。DSH-Portable 由 WSL043 独立维护，未获 DeepSeek 背书。

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "scripts": {
     "test": "node --test tests/*.test.mjs",
+    "site:build": "node scripts/build-site.mjs",
     "check:upstream": "node scripts/check-upstream.mjs",
     "icons": "node scripts/render-icons.mjs app assets/DSH-Portable.svg assets",
     "version:set": "node scripts/set-product-version.mjs"

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -1,0 +1,15 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+const output = path.join(root, "build", "site");
+
+await rm(output, { recursive: true, force: true });
+await mkdir(path.join(output, "assets"), { recursive: true });
+await cp(path.join(root, "site"), output, { recursive: true });
+
+for (const asset of ["DSH-Portable.svg", "DSH-Portable-512.png", "dsh-interface-zh.png", "dsh-interface-en.png"]) {
+  await cp(path.join(root, "assets", asset), path.join(output, "assets", asset));
+}
+
+console.log(`Website staged at ${output}`);

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,136 @@
+const releaseBase = "https://github.com/WSL043/DSH-Portable/releases/latest/download/";
+
+const copy = {
+  en: {
+    skip: "Skip to content", navDownload: "Download", navPortable: "Why portable", navGithub: "GitHub",
+    heroEyebrow: "Community desktop distribution for DeepSeek Harness",
+    heroTitle: "Take your entire DSH workspace to the next computer.",
+    heroLede: "Sessions, settings, plugins, and workspace stay together. Copy one folder and continue on another drive, USB device, or computer.",
+    downloadFor: "Download recommended edition", otherPlatforms: "Other platforms", heroNote: "Free and open source · Windows, macOS, Linux · Your data stays yours",
+    stageCaption: "A dedicated window. Background tasks keep running.",
+    proofOneTitle: "One folder", proofOneText: "Your complete environment", proofTwoTitle: "Three platforms",
+    proofThreeTitle: "Direct updates", proofThreeText: "Your data stays in place", proofFourTitle: "Native plugin market", proofFourText: "Discover, install, manage",
+    portableEyebrow: "Made to move", portableTitle: "Not a web page inside a window.<br>Your working state, inside your folder.",
+    folderMoves: "Move the entire folder", folderData: "Sessions, settings, plugins", folderWorkspace: "Default workspace", folderApp: "Desktop entry point",
+    moveTitle: "Move, then continue", moveText: "Exit the app and copy the whole directory. Managed paths repair themselves; external projects stay where you left them.",
+    updateTitle: "Update the app, not your data", updateText: "Finished-product updates preserve sessions, credentials, plugins, and workspace, with rollback if startup fails.",
+    desktopTitle: "A desktop app where it matters", desktopText: "Dedicated window, system tray, task notifications, and recent sessions. Close the window while a task keeps running.",
+    downloadsEyebrow: "Choose your edition", downloadsTitle: "Download it. Start from here.", downloadsIntro: "We selected your system. Switch platform or choose another installation mode whenever you need.",
+    recommended: "RECOMMENDED", windowsPortable: "Windows portable", windowsPortableText: "A 55 KB launcher. First run prepares a complete, movable workspace beside it.", downloadNow: "Download now",
+    offlineEdition: "Complete offline ZIP", offlineText: "For an offline destination computer or manual extraction", installerEdition: "Installer", installerText: "Start menu, shortcuts, and standard uninstall", completeArchive: "All release files", archiveText: "Release notes and other platforms",
+    macDmg: "macOS disk image", macDmgText: "Drag into Applications. The current build is ad-hoc signed, so first launch may ask for confirmation.", portableZip: "Portable ZIP", portableZipText: "Extract and run; made to move with its folder",
+    linuxAppText: "Grant execute permission once. Portable data lives in the sibling directory.", completeFolder: "Complete portable folder", allDownloads: "All downloads and release notes ↗", checksums: "Checksums",
+    insideEyebrow: "More than a launcher", insideTitle: "The parts you need every day, brought together.",
+    marketTitle: "Plugin market", marketText: "Discover, install, update, or disable community plugins from Settings, in the current DSH language and theme.",
+    trayTitle: "Tray and notifications", trayText: "Return to recent sessions, start a new one, and receive a system notification when work is complete.",
+    repairTitle: "Check and repair", repairText: "Keep user data, rebuild reproducible components, and export a support report without credentials.",
+    testedTitle: "Finished-product validation", testedText: "Install, start, exit, move, and update paths are tested across Windows, macOS, and Linux.",
+    faqTitle: "A few things before you begin.", faqOfficialQ: "Is this an official DeepSeek desktop app?", faqOfficialA: "No. DSH-Portable is an independent community distribution that packages a tested preview of official DeepSeek Harness.",
+    faqNodeQ: "Do I need to install Node.js first?", faqNodeA: "No. The runtime and plugin tools are included and do not modify your system Node.js or PATH.",
+    faqDataQ: "Will copying the folder lose my sessions?", faqDataA: "Fully exit from the tray, then copy the whole DSH-Portable folder. Sessions, settings, plugins, and the default workspace move together.",
+    faqUpdateQ: "Will an update overwrite my data?", faqUpdateA: "No. Updates replace reproducible app components and preserve data and workspace. A failed start rolls back to the previous version.",
+    closingTitle: "Take your workspace with you.", closingText: "Start with one folder. Work wherever you need to.", downloadPortable: "Download portable",
+    footerCommunity: "Independent community distribution", sourceCode: "Source code", support: "Support", community: "Discussions",
+    footerLegal: "DeepSeek Harness, the DeepSeek name, and its marks belong to DeepSeek. DSH-Portable is independently maintained by WSL043 and is not endorsed by DeepSeek."
+  }
+};
+
+const zhCopy = new Map([...document.querySelectorAll("[data-i18n]")].map((element) => [element.dataset.i18n, element.innerHTML]));
+const languageSwitch = document.querySelector("[data-language-switch]");
+const productShot = document.querySelector("[data-product-shot]");
+
+function readSavedLanguage() {
+  try { return localStorage.getItem("dsh-portable-language"); }
+  catch { return null; }
+}
+
+function saveLanguage(language) {
+  try { localStorage.setItem("dsh-portable-language", language); }
+  catch { /* The site remains fully usable when storage is unavailable. */ }
+}
+
+function setLanguage(language) {
+  const lang = language === "en" ? "en" : "zh";
+  document.documentElement.lang = lang === "en" ? "en" : "zh-CN";
+  document.querySelectorAll("[data-i18n]").forEach((element) => {
+    const key = element.dataset.i18n;
+    element.innerHTML = lang === "en" ? copy.en[key] ?? element.innerHTML : zhCopy.get(key) ?? element.innerHTML;
+  });
+  languageSwitch.textContent = lang === "en" ? "中" : "EN";
+  languageSwitch.setAttribute("aria-label", lang === "en" ? "切换到中文" : "Switch to English");
+  productShot.src = lang === "en" ? "assets/dsh-interface-en.png" : "assets/dsh-interface-zh.png";
+  productShot.alt = lang === "en" ? "DeepSeek Harness workspace in DSH-Portable" : "DSH-Portable 中的 DeepSeek Harness 桌面工作台";
+  saveLanguage(lang);
+}
+
+languageSwitch.addEventListener("click", () => setLanguage(document.documentElement.lang.startsWith("en") ? "zh" : "en"));
+
+const platformTabs = [...document.querySelectorAll("[data-platform-tab]")];
+const platformPanels = [...document.querySelectorAll("[data-platform-panel]")];
+
+function selectPlatform(platform) {
+  platformTabs.forEach((tab) => {
+    const selected = tab.dataset.platformTab === platform;
+    tab.setAttribute("aria-selected", String(selected));
+    tab.tabIndex = selected ? 0 : -1;
+  });
+  platformPanels.forEach((panel) => { panel.hidden = panel.dataset.platformPanel !== platform; });
+}
+
+platformTabs.forEach((tab) => tab.addEventListener("click", () => selectPlatform(tab.dataset.platformTab)));
+platformTabs.forEach((tab, index) => tab.addEventListener("keydown", (event) => {
+  let nextIndex = null;
+  if (event.key === "ArrowRight") nextIndex = (index + 1) % platformTabs.length;
+  if (event.key === "ArrowLeft") nextIndex = (index - 1 + platformTabs.length) % platformTabs.length;
+  if (event.key === "Home") nextIndex = 0;
+  if (event.key === "End") nextIndex = platformTabs.length - 1;
+  if (nextIndex === null) return;
+  event.preventDefault();
+  platformTabs[nextIndex].focus();
+  selectPlatform(platformTabs[nextIndex].dataset.platformTab);
+}));
+
+function bindArchitecture(panelName, fileMap) {
+  const panel = document.querySelector(`[data-platform-panel="${panelName}"]`);
+  const buttons = [...panel.querySelectorAll("[data-arch]")];
+  const setArchitecture = (architecture) => {
+    buttons.forEach((button) => button.classList.toggle("is-active", button.dataset.arch === architecture));
+    Object.entries(fileMap).forEach(([selector, filenames]) => {
+      panel.querySelector(selector).href = releaseBase + filenames[architecture];
+    });
+  };
+  buttons.forEach((button) => button.addEventListener("click", () => setArchitecture(button.dataset.arch)));
+  return setArchitecture;
+}
+
+const setMacArchitecture = bindArchitecture("macos", {
+  "[data-mac-download='dmg']": { arm64: "DeepSeek-Herness-macos-arm64.dmg", x64: "DeepSeek-Herness-macos-x64.dmg" },
+  "[data-mac-download='zip']": { arm64: "DSH-Portable-macos-arm64.zip", x64: "DSH-Portable-macos-x64.zip" }
+});
+const setLinuxArchitecture = bindArchitecture("linux", {
+  "[data-linux-download='appimage']": { x64: "DeepSeek-Herness-linux-x64.AppImage", arm64: "DeepSeek-Herness-linux-arm64.AppImage" },
+  "[data-linux-download='archive']": { x64: "DSH-Portable-linux-x64.tar.gz", arm64: "DSH-Portable-linux-arm64.tar.gz" }
+});
+
+function detectedPlatform() {
+  const value = `${navigator.userAgentData?.platform ?? ""} ${navigator.platform ?? ""} ${navigator.userAgent}`.toLowerCase();
+  if (value.includes("mac")) return "macos";
+  if (value.includes("linux") || value.includes("x11")) return "linux";
+  return "windows";
+}
+
+const platform = detectedPlatform();
+selectPlatform(platform);
+const isArm = /arm|aarch64/i.test(`${navigator.userAgentData?.platform ?? ""} ${navigator.platform ?? ""}`);
+setMacArchitecture(platform === "macos" || isArm ? "arm64" : "x64");
+setLinuxArchitecture(isArm ? "arm64" : "x64");
+
+const primaryFiles = {
+  windows: "DSH-Portable-windows-x64.exe",
+  macos: platform === "macos" || isArm ? "DeepSeek-Herness-macos-arm64.dmg" : "DeepSeek-Herness-macos-x64.dmg",
+  linux: isArm ? "DeepSeek-Herness-linux-arm64.AppImage" : "DeepSeek-Herness-linux-x64.AppImage"
+};
+document.querySelectorAll("[data-primary-download]").forEach((link) => { link.href = releaseBase + primaryFiles[platform]; });
+
+const initialLanguage = readSavedLanguage() || (navigator.language?.toLowerCase().startsWith("zh") ? "zh" : "en");
+setLanguage(initialLanguage);

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#f4f4f0">
+    <meta name="description" content="DSH-Portable 把 DeepSeek Harness、会话、设置、插件和工作区放进一个可移动的桌面工作环境。">
+    <meta property="og:title" content="DSH-Portable">
+    <meta property="og:description" content="Your DeepSeek Harness workspace, wherever you go.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/DSH-Portable-512.png">
+    <title>DSH-Portable — DeepSeek Harness, wherever you go</title>
+    <link rel="icon" href="assets/DSH-Portable.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="styles.css">
+    <script src="app.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main" data-i18n="skip">跳到主要内容</a>
+
+    <header class="site-header">
+      <a class="brand" href="#top" aria-label="DSH-Portable home">
+        <img src="assets/DSH-Portable.svg" alt="" width="30" height="30">
+        <span>DSH-Portable</span>
+      </a>
+      <nav class="header-actions" aria-label="Primary navigation">
+        <a class="nav-link" href="#downloads" data-i18n="navDownload">下载</a>
+        <a class="nav-link nav-link-wide" href="#portable" data-i18n="navPortable">为什么便携</a>
+        <a class="nav-link nav-link-wide" href="https://github.com/WSL043/DSH-Portable" data-i18n="navGithub">GitHub</a>
+        <button class="language-switch" type="button" aria-label="Switch language" data-language-switch>EN</button>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="hero" id="top">
+        <div class="hero-copy">
+          <p class="eyebrow" data-i18n="heroEyebrow">DeepSeek Harness 社区桌面发行版</p>
+          <h1 data-i18n="heroTitle">把整个 DSH 工作环境，带到下一台电脑。</h1>
+          <p class="hero-lede" data-i18n="heroLede">会话、设置、插件和工作区放在一起。复制一个文件夹，在另一块硬盘、U 盘或电脑上继续工作。</p>
+          <div class="hero-actions">
+            <a class="button button-primary" data-primary-download href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe">
+              <span data-i18n="downloadFor">下载推荐版本</span>
+              <span aria-hidden="true">↓</span>
+            </a>
+            <a class="button button-quiet" href="#downloads" data-i18n="otherPlatforms">其他平台</a>
+          </div>
+          <p class="hero-note" data-i18n="heroNote">免费开源 · Windows、macOS、Linux · 数据由你保管</p>
+        </div>
+
+        <div class="product-stage" aria-label="DeepSeek Harness desktop interface">
+          <div class="stage-chrome" aria-hidden="true">
+            <span></span><span></span><span></span>
+            <strong>DeepSeek-Herness</strong>
+          </div>
+          <picture>
+            <img data-product-shot src="assets/dsh-interface-zh.png" alt="DSH-Portable 中的 DeepSeek Harness 桌面工作台">
+          </picture>
+          <div class="stage-caption">
+            <span class="status-dot" aria-hidden="true"></span>
+            <span data-i18n="stageCaption">独立窗口。后台任务继续运行。</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="proof-strip" aria-label="Product highlights">
+        <div><strong data-i18n="proofOneTitle">一个文件夹</strong><span data-i18n="proofOneText">完整工作环境</span></div>
+        <div><strong data-i18n="proofTwoTitle">三大平台</strong><span>Windows · macOS · Linux</span></div>
+        <div><strong data-i18n="proofThreeTitle">直接更新</strong><span data-i18n="proofThreeText">保留你的数据</span></div>
+        <div><strong data-i18n="proofFourTitle">原生插件市场</strong><span data-i18n="proofFourText">发现、安装与管理</span></div>
+      </section>
+
+      <section class="portable-story" id="portable">
+        <div class="section-heading">
+          <p class="eyebrow" data-i18n="portableEyebrow">真正为移动而设计</p>
+          <h2 data-i18n="portableTitle">不是把网页装进窗口。<br>是把工作状态放进你的文件夹。</h2>
+        </div>
+
+        <div class="portable-grid">
+          <div class="folder-map" aria-label="Portable folder contents">
+            <div class="folder-title">
+              <img src="assets/DSH-Portable.svg" alt="" width="38" height="38">
+              <div><strong>DSH-Portable</strong><span data-i18n="folderMoves">整个文件夹可移动</span></div>
+            </div>
+            <ul>
+              <li><span>data/</span><small data-i18n="folderData">会话、设置与插件</small></li>
+              <li><span>workspace/</span><small data-i18n="folderWorkspace">默认工作区</small></li>
+              <li><span>DeepSeek-Herness</span><small data-i18n="folderApp">桌面入口</small></li>
+            </ul>
+            <div class="folder-route" aria-hidden="true"><span>PC</span><i></i><span>USB</span><i></i><span>PC</span></div>
+          </div>
+
+          <div class="feature-list">
+            <article>
+              <span>01</span>
+              <div><h3 data-i18n="moveTitle">换个位置，接着做</h3><p data-i18n="moveText">退出应用后复制整个目录。启动器会修正自己管理的路径，外部项目仍留在原处。</p></div>
+            </article>
+            <article>
+              <span>02</span>
+              <div><h3 data-i18n="updateTitle">更新程序，不动数据</h3><p data-i18n="updateText">更新经过成品测试，并保留会话、凭据、插件和工作区；失败时恢复上一版本。</p></div>
+            </article>
+            <article>
+              <span>03</span>
+              <div><h3 data-i18n="desktopTitle">桌面程序该有的体验</h3><p data-i18n="desktopText">独立窗口、系统托盘、任务通知和最近会话。窗口关闭后，任务也可以继续跑。</p></div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="downloads" id="downloads">
+        <div class="section-heading download-heading">
+          <p class="eyebrow" data-i18n="downloadsEyebrow">选择你的版本</p>
+          <h2 data-i18n="downloadsTitle">下载以后，就从这里开始。</h2>
+          <p data-i18n="downloadsIntro">系统已经替你预选。你也可以切换平台或选择其他安装方式。</p>
+        </div>
+
+        <div class="download-shell">
+          <div class="platform-tabs" role="tablist" aria-label="Operating system">
+            <button id="tab-windows" type="button" role="tab" aria-selected="true" aria-controls="panel-windows" data-platform-tab="windows">Windows</button>
+            <button id="tab-macos" type="button" role="tab" aria-selected="false" aria-controls="panel-macos" data-platform-tab="macos">macOS</button>
+            <button id="tab-linux" type="button" role="tab" aria-selected="false" aria-controls="panel-linux" data-platform-tab="linux">Linux</button>
+          </div>
+
+          <div id="panel-windows" class="download-panel" role="tabpanel" aria-labelledby="tab-windows" data-platform-panel="windows">
+            <div class="recommended-download">
+              <div><span class="download-label" data-i18n="recommended">推荐</span><h3 data-i18n="windowsPortable">Windows 便携版</h3><p data-i18n="windowsPortableText">55 KB 启动器。首次运行后在旁边准备完整、可移动的工作文件夹。</p></div>
+              <a class="button button-primary" href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe" data-i18n="downloadNow">立即下载</a>
+            </div>
+            <div class="download-options">
+              <a href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64-offline.zip"><strong data-i18n="offlineEdition">完整离线 ZIP</strong><span data-i18n="offlineText">目标电脑无法联网，或需要手动解压时使用</span></a>
+              <a href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-Setup.exe"><strong data-i18n="installerEdition">安装版</strong><span data-i18n="installerText">开始菜单、快捷方式与标准卸载</span></a>
+              <a href="https://github.com/WSL043/DSH-Portable/releases/latest"><strong data-i18n="completeArchive">所有发布文件</strong><span data-i18n="archiveText">查看版本说明与其他平台</span></a>
+            </div>
+          </div>
+
+          <div id="panel-macos" class="download-panel" role="tabpanel" aria-labelledby="tab-macos" data-platform-panel="macos" hidden>
+            <div class="architecture-switch" role="group" aria-label="Mac architecture">
+              <button type="button" class="is-active" data-arch="arm64">Apple Silicon</button>
+              <button type="button" data-arch="x64">Intel</button>
+            </div>
+            <div class="recommended-download">
+              <div><span class="download-label" data-i18n="recommended">推荐</span><h3 data-i18n="macDmg">macOS 磁盘映像</h3><p data-i18n="macDmgText">拖入应用程序即可使用。当前采用临时签名，首次打开可能需要确认。</p></div>
+              <a class="button button-primary" data-mac-download="dmg" href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-macos-arm64.dmg" data-i18n="downloadNow">立即下载</a>
+            </div>
+            <div class="download-options one-column">
+              <a data-mac-download="zip" href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-macos-arm64.zip"><strong data-i18n="portableZip">便携 ZIP</strong><span data-i18n="portableZipText">解压后直接运行，适合随目录迁移</span></a>
+            </div>
+          </div>
+
+          <div id="panel-linux" class="download-panel" role="tabpanel" aria-labelledby="tab-linux" data-platform-panel="linux" hidden>
+            <div class="architecture-switch" role="group" aria-label="Linux architecture">
+              <button type="button" class="is-active" data-arch="x64">x64</button>
+              <button type="button" data-arch="arm64">ARM64</button>
+            </div>
+            <div class="recommended-download">
+              <div><span class="download-label" data-i18n="recommended">推荐</span><h3>AppImage</h3><p data-i18n="linuxAppText">添加一次执行权限即可启动，数据保存在旁边的便携目录中。</p></div>
+              <a class="button button-primary" data-linux-download="appimage" href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-x64.AppImage" data-i18n="downloadNow">立即下载</a>
+            </div>
+            <div class="download-options one-column">
+              <a data-linux-download="archive" href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-x64.tar.gz"><strong data-i18n="completeFolder">完整便携目录</strong><span>tar.gz</span></a>
+            </div>
+          </div>
+
+          <div class="release-links">
+            <a href="https://github.com/WSL043/DSH-Portable/releases/latest" data-i18n="allDownloads">查看全部下载与版本说明 ↗</a>
+            <a href="https://github.com/WSL043/DSH-Portable/releases/latest/download/checksums.txt" data-i18n="checksums">校验文件</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="inside">
+        <div class="section-heading">
+          <p class="eyebrow" data-i18n="insideEyebrow">不只是一个启动器</p>
+          <h2 data-i18n="insideTitle">日常使用需要的部分，已经放在一起。</h2>
+        </div>
+        <div class="inside-grid">
+          <article><h3 data-i18n="marketTitle">插件市场</h3><p data-i18n="marketText">在设置中发现、安装、更新或停用社区插件，跟随 DSH 的语言与主题。</p></article>
+          <article><h3 data-i18n="trayTitle">托盘与通知</h3><p data-i18n="trayText">快速返回最近会话、开启新会话，并在任务完成时收到系统通知。</p></article>
+          <article><h3 data-i18n="repairTitle">检查与修复</h3><p data-i18n="repairText">出现问题时保留用户数据，重建可再生组件，并生成不含凭据的支持报告。</p></article>
+          <article><h3 data-i18n="testedTitle">成品级验证</h3><p data-i18n="testedText">Windows、macOS 与 Linux 的安装、启动、退出、移动和更新链路都经过自动测试。</p></article>
+        </div>
+      </section>
+
+      <section class="faq">
+        <div class="section-heading"><p class="eyebrow">FAQ</p><h2 data-i18n="faqTitle">开始之前，你可能想知道。</h2></div>
+        <div class="faq-list">
+          <details><summary data-i18n="faqOfficialQ">这是 DeepSeek 官方桌面应用吗？</summary><p data-i18n="faqOfficialA">不是。DSH-Portable 是独立社区发行版，内置经过验证的官方 DeepSeek Harness 预览版本。</p></details>
+          <details><summary data-i18n="faqNodeQ">使用前需要安装 Node.js 吗？</summary><p data-i18n="faqNodeA">不需要。运行环境与插件管理工具包含在产品内，不会修改系统的 Node.js 或 PATH。</p></details>
+          <details><summary data-i18n="faqDataQ">复制文件夹会丢失会话吗？</summary><p data-i18n="faqDataA">先从托盘完全退出，再复制整个 DSH-Portable 文件夹；会话、设置、插件和默认工作区会一起移动。</p></details>
+          <details><summary data-i18n="faqUpdateQ">更新会覆盖我的数据吗？</summary><p data-i18n="faqUpdateA">不会。更新只替换可再生的程序组件，保留数据与工作区；启动失败时会恢复上一版本。</p></details>
+        </div>
+      </section>
+
+      <section class="closing-cta">
+        <img src="assets/DSH-Portable.svg" alt="" width="58" height="58">
+        <div><h2 data-i18n="closingTitle">把工作环境带走。</h2><p data-i18n="closingText">从一个文件夹开始，去任何你需要工作的地方。</p></div>
+        <a class="button button-light" data-primary-download href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe" data-i18n="downloadPortable">下载便携版</a>
+      </section>
+    </main>
+
+    <footer>
+      <div><strong>DSH-Portable</strong><span data-i18n="footerCommunity">独立社区发行版</span></div>
+      <div class="footer-links">
+        <a href="https://github.com/WSL043/DSH-Portable" data-i18n="sourceCode">源代码</a>
+        <a href="https://github.com/WSL043/DSH-Portable/issues" data-i18n="support">问题反馈</a>
+        <a href="https://github.com/WSL043/DSH-Portable/discussions" data-i18n="community">社区讨论</a>
+      </div>
+      <p data-i18n="footerLegal">DeepSeek Harness、DeepSeek 名称与标志归 DeepSeek 所有。本项目由 WSL043 独立维护，未获 DeepSeek 背书。</p>
+    </footer>
+  </body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,205 @@
+:root {
+  color-scheme: light;
+  --paper: #f4f4f0;
+  --surface: #ffffff;
+  --ink: #111312;
+  --muted: #656963;
+  --line: #d9dad4;
+  --soft-line: #e9e9e4;
+  --blue: #4d6fa8;
+  --green: #2f8b57;
+  --black: #121413;
+  --radius: 22px;
+  --page: min(1180px, calc(100vw - 48px));
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; color: var(--ink); background: var(--paper); font-size: 16px; line-height: 1.6; }
+a { color: inherit; text-decoration: none; }
+button, a { -webkit-tap-highlight-color: transparent; }
+button { font: inherit; }
+img { display: block; max-width: 100%; }
+
+.skip-link { position: fixed; top: 10px; left: 10px; z-index: 100; padding: 9px 14px; background: var(--ink); color: white; transform: translateY(-150%); }
+.skip-link:focus { transform: translateY(0); }
+
+.site-header { width: var(--page); height: 78px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid rgba(17, 19, 18, .14); }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 720; letter-spacing: -.02em; }
+.brand img { width: 30px; height: 30px; }
+.header-actions { display: flex; align-items: center; gap: 26px; }
+.nav-link { color: #454943; font-size: 14px; }
+.nav-link:hover { color: var(--ink); }
+.language-switch { min-width: 42px; height: 34px; padding: 0 11px; border: 1px solid #c9cbc4; border-radius: 999px; background: rgba(255,255,255,.5); cursor: pointer; }
+.language-switch:hover { background: white; }
+
+.hero { width: var(--page); margin: 0 auto; padding: 64px 0 42px; display: grid; grid-template-columns: .95fr 1.05fr; align-items: center; gap: 48px; min-height: 660px; }
+.hero-copy { padding-bottom: 44px; }
+.eyebrow { margin: 0 0 20px; color: var(--muted); font-size: 12px; font-weight: 720; letter-spacing: .14em; text-transform: uppercase; }
+h1, h2, h3, p { margin-top: 0; }
+h1 { max-width: 640px; margin-bottom: 24px; font-size: clamp(48px, 5.2vw, 68px); line-height: 1.01; letter-spacing: -.06em; font-weight: 720; }
+.hero-lede { max-width: 550px; margin-bottom: 32px; color: #555952; font-size: 18px; line-height: 1.75; }
+.hero-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; gap: 18px; padding: 0 20px; border: 1px solid transparent; border-radius: 999px; font-size: 14px; font-weight: 650; transition: transform .18s ease, background .18s ease, border-color .18s ease; }
+.button:hover { transform: translateY(-1px); }
+.button-primary { background: var(--black); color: white; }
+.button-primary:hover { background: #292c2a; }
+.button-quiet { border-color: #cfd0cb; background: transparent; }
+.button-quiet:hover { background: white; border-color: #aaa; }
+.button-light { background: white; color: var(--ink); }
+.hero-note { margin: 18px 0 0; color: #7a7d77; font-size: 12px; }
+
+.product-stage { position: relative; overflow: hidden; border: 1px solid #252725; border-radius: 12px; background: #101211; box-shadow: 0 34px 90px rgba(18, 20, 19, .18); transform: perspective(1600px) rotateY(-2.5deg) rotateX(1deg); transform-origin: center left; }
+.stage-chrome { height: 38px; display: flex; align-items: center; gap: 6px; padding: 0 12px; color: #9fa49f; border-bottom: 1px solid #292c2a; font-size: 10px; }
+.stage-chrome span { width: 7px; height: 7px; border-radius: 50%; background: #4a4e4b; }
+.stage-chrome strong { position: absolute; left: 50%; transform: translateX(-50%); font-weight: 500; }
+.product-stage picture, .product-stage picture img { width: 100%; }
+.product-stage picture img { aspect-ratio: 16/9; object-fit: cover; }
+.stage-caption { height: 48px; display: flex; align-items: center; justify-content: center; gap: 9px; color: #c3c7c3; font-size: 11px; letter-spacing: .02em; }
+.status-dot { width: 7px; height: 7px; border-radius: 50%; background: #4dcc7a; box-shadow: 0 0 0 4px rgba(77,204,122,.08); }
+
+.proof-strip { width: var(--page); margin: 0 auto; display: grid; grid-template-columns: repeat(4, 1fr); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.proof-strip div { padding: 25px 24px; border-right: 1px solid var(--line); }
+.proof-strip div:first-child { padding-left: 0; }
+.proof-strip div:last-child { border-right: 0; }
+.proof-strip strong, .proof-strip span { display: block; }
+.proof-strip strong { font-size: 14px; }
+.proof-strip span { color: var(--muted); font-size: 12px; }
+
+.portable-story, .inside, .faq { width: var(--page); margin: 0 auto; padding: 132px 0; }
+.section-heading { max-width: 820px; margin-bottom: 64px; }
+.section-heading h2 { margin-bottom: 0; font-size: clamp(38px, 4.6vw, 64px); line-height: 1.08; letter-spacing: -.052em; font-weight: 690; }
+.portable-grid { display: grid; grid-template-columns: .9fr 1.1fr; gap: 80px; align-items: center; }
+.folder-map { position: relative; padding: 28px; border: 1px solid var(--line); border-radius: var(--radius); background: #eaebe6; }
+.folder-title { display: flex; align-items: center; gap: 14px; padding-bottom: 24px; border-bottom: 1px solid #cfd1cb; }
+.folder-title div { display: flex; flex-direction: column; }
+.folder-title span { color: var(--muted); font-size: 12px; }
+.folder-map ul { margin: 0; padding: 12px 0 24px; list-style: none; }
+.folder-map li { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; padding: 13px 0; border-bottom: 1px solid rgba(18,20,19,.08); }
+.folder-map li span { font-family: "SFMono-Regular", Consolas, monospace; font-size: 13px; }
+.folder-map li small { color: var(--muted); }
+.folder-route { display: grid; grid-template-columns: auto 1fr auto 1fr auto; align-items: center; gap: 10px; color: #3d423e; font-size: 10px; font-weight: 750; letter-spacing: .1em; }
+.folder-route span { display: grid; place-items: center; width: 42px; height: 42px; border: 1px solid #afb2ab; border-radius: 50%; background: var(--paper); }
+.folder-route i { height: 1px; background: #a7aaa3; }
+.feature-list article { display: grid; grid-template-columns: 42px 1fr; gap: 18px; padding: 26px 0; border-bottom: 1px solid var(--line); }
+.feature-list article:first-child { padding-top: 0; }
+.feature-list article > span { color: #969a93; font-size: 12px; font-family: "SFMono-Regular", Consolas, monospace; }
+.feature-list h3 { margin-bottom: 8px; font-size: 22px; letter-spacing: -.025em; }
+.feature-list p { max-width: 570px; margin-bottom: 0; color: var(--muted); }
+
+.downloads { padding: 132px max(24px, calc((100vw - 1180px) / 2)); background: var(--black); color: white; }
+.download-heading { width: min(1180px, 100%); }
+.download-heading .eyebrow, .download-heading p { color: #a9aea9; }
+.download-heading p:last-child { max-width: 580px; margin-top: 22px; }
+.download-shell { overflow: hidden; max-width: 1180px; border: 1px solid #3a3d3b; border-radius: var(--radius); background: #191b1a; }
+.platform-tabs { display: flex; border-bottom: 1px solid #343735; }
+.platform-tabs button { flex: 1; height: 58px; border: 0; border-right: 1px solid #343735; color: #929792; background: transparent; cursor: pointer; }
+.platform-tabs button:last-child { border-right: 0; }
+.platform-tabs button[aria-selected="true"] { color: white; background: #232624; box-shadow: inset 0 -2px white; }
+.download-panel { padding: 38px; }
+.recommended-download { display: flex; align-items: center; justify-content: space-between; gap: 40px; padding-bottom: 34px; }
+.recommended-download h3 { margin: 5px 0 8px; font-size: 28px; letter-spacing: -.03em; }
+.recommended-download p { max-width: 660px; margin: 0; color: #aeb3ae; }
+.download-label { color: #78d49b; font-size: 11px; font-weight: 750; letter-spacing: .12em; }
+.download-shell .button-primary { flex: 0 0 auto; background: white; color: var(--ink); }
+.download-options { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid #343735; }
+.download-options.one-column { grid-template-columns: 1fr; }
+.download-options a { display: flex; flex-direction: column; padding: 24px 22px; border-right: 1px solid #343735; }
+.download-options a:last-child { border-right: 0; }
+.download-options a:hover { background: #222523; }
+.download-options strong { font-size: 14px; }
+.download-options span { color: #939893; font-size: 12px; }
+.architecture-switch { display: inline-flex; margin-bottom: 24px; padding: 3px; border: 1px solid #3a3d3b; border-radius: 999px; }
+.architecture-switch button { padding: 7px 14px; border: 0; border-radius: 999px; color: #9ba09b; background: transparent; cursor: pointer; font-size: 12px; }
+.architecture-switch button.is-active { color: var(--ink); background: white; }
+.release-links { display: flex; justify-content: space-between; padding: 18px 38px; border-top: 1px solid #343735; color: #aeb3ae; font-size: 12px; }
+.release-links a:hover { color: white; }
+
+.inside-grid { display: grid; grid-template-columns: 1fr 1fr; border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
+.inside-grid article { min-height: 205px; padding: 30px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.inside-grid h3 { margin-bottom: 36px; font-size: 19px; letter-spacing: -.02em; }
+.inside-grid p { max-width: 440px; margin: 0; color: var(--muted); }
+
+.faq { padding-top: 24px; }
+.faq-list { border-top: 1px solid var(--line); }
+.faq details { border-bottom: 1px solid var(--line); }
+.faq summary { position: relative; padding: 25px 48px 25px 0; cursor: pointer; list-style: none; font-size: 18px; font-weight: 620; }
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::after { content: "+"; position: absolute; right: 4px; top: 20px; color: #757a74; font-size: 25px; font-weight: 300; }
+.faq details[open] summary::after { content: "−"; }
+.faq details p { max-width: 720px; padding: 0 0 26px; color: var(--muted); }
+
+.closing-cta { width: var(--page); margin: 40px auto 0; display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 28px; padding: 36px 40px; border-radius: var(--radius); background: var(--black); color: white; }
+.closing-cta img { filter: invert(1); }
+.closing-cta h2 { margin-bottom: 2px; font-size: 28px; letter-spacing: -.035em; }
+.closing-cta p { margin: 0; color: #aeb3ae; }
+
+footer { width: var(--page); margin: 0 auto; padding: 80px 0 36px; display: grid; grid-template-columns: 1fr auto; gap: 30px; color: #747871; font-size: 12px; }
+footer > div:first-child { display: flex; flex-direction: column; }
+footer strong { color: var(--ink); font-size: 14px; }
+.footer-links { display: flex; gap: 24px; }
+.footer-links a:hover { color: var(--ink); }
+footer p { grid-column: 1 / -1; max-width: 760px; }
+
+:focus-visible { outline: 3px solid #6b91d3; outline-offset: 3px; }
+[hidden] { display: none !important; }
+
+@media (max-width: 920px) {
+  :root { --page: min(100% - 32px, 720px); }
+  .hero { grid-template-columns: 1fr; gap: 34px; padding-top: 66px; }
+  .hero-copy { padding-bottom: 0; }
+  h1 { max-width: 760px; }
+  .product-stage { transform: none; }
+  .proof-strip { grid-template-columns: 1fr 1fr; }
+  .proof-strip div { border-bottom: 1px solid var(--line); }
+  .proof-strip div:nth-child(2) { border-right: 0; }
+  .proof-strip div:nth-child(3), .proof-strip div:nth-child(4) { border-bottom: 0; }
+  .proof-strip div:first-child { padding-left: 24px; }
+  .portable-grid { grid-template-columns: 1fr; gap: 52px; }
+  .downloads { padding-left: 16px; padding-right: 16px; }
+}
+
+@media (max-width: 640px) {
+  :root { --page: calc(100vw - 28px); }
+  body { font-size: 15px; }
+  .site-header { height: 66px; }
+  .brand span { font-size: 14px; }
+  .nav-link-wide { display: none; }
+  .header-actions { gap: 14px; }
+  .hero { min-height: auto; padding: 56px 0 34px; }
+  h1 { font-size: 47px; }
+  .hero-lede { font-size: 16px; }
+  .hero-actions { align-items: stretch; }
+  .hero-actions .button { width: 100%; }
+  .stage-caption { padding: 0 12px; text-align: center; }
+  .proof-strip { grid-template-columns: 1fr 1fr; }
+  .proof-strip div { padding: 19px 14px; }
+  .proof-strip div:first-child { padding-left: 14px; }
+  .portable-story, .inside, .faq { padding: 90px 0; }
+  .section-heading { margin-bottom: 40px; }
+  .section-heading h2 { font-size: 38px; }
+  .folder-map { padding: 20px; }
+  .folder-map li { align-items: flex-start; flex-direction: column; gap: 0; }
+  .downloads { padding-top: 90px; padding-bottom: 90px; }
+  .platform-tabs button { height: 52px; }
+  .download-panel { padding: 24px 20px; }
+  .recommended-download { align-items: stretch; flex-direction: column; gap: 24px; }
+  .download-options { grid-template-columns: 1fr; }
+  .download-options a { border-right: 0; border-bottom: 1px solid #343735; }
+  .download-options a:last-child { border-bottom: 0; }
+  .release-links { align-items: flex-start; flex-direction: column; gap: 8px; padding: 18px 20px; }
+  .inside-grid { grid-template-columns: 1fr; }
+  .inside-grid article { min-height: auto; }
+  .inside-grid h3 { margin-bottom: 18px; }
+  .closing-cta { grid-template-columns: auto 1fr; padding: 28px 24px; }
+  .closing-cta .button { grid-column: 1 / -1; }
+  footer { grid-template-columns: 1fr; }
+  .footer-links { flex-wrap: wrap; }
+  footer p { grid-column: auto; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition-duration: .01ms !important; animation-duration: .01ms !important; }
+}

--- a/tests/site-contract.test.mjs
+++ b/tests/site-contract.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const html = await readFile(new URL("../site/index.html", import.meta.url), "utf8");
+const app = await readFile(new URL("../site/app.js", import.meta.url), "utf8");
+const workflow = await readFile(new URL("../.github/workflows/pages.yml", import.meta.url), "utf8");
+
+test("website uses only stable release asset names that the product publishes", () => {
+  const assets = [
+    "DSH-Portable-windows-x64.exe",
+    "DSH-Portable-windows-x64-offline.zip",
+    "DeepSeek-Herness-Setup.exe",
+    "DeepSeek-Herness-macos-arm64.dmg",
+    "DeepSeek-Herness-macos-x64.dmg",
+    "DSH-Portable-macos-arm64.zip",
+    "DSH-Portable-macos-x64.zip",
+    "DeepSeek-Herness-linux-x64.AppImage",
+    "DeepSeek-Herness-linux-arm64.AppImage",
+    "DSH-Portable-linux-x64.tar.gz",
+    "DSH-Portable-linux-arm64.tar.gz",
+    "checksums.txt"
+  ];
+
+  for (const asset of assets) assert.match(`${html}\n${app}`, new RegExp(asset.replaceAll(".", "\\.")));
+  assert.doesNotMatch(`${html}\n${app}`, /windows-x64-offline\.exe/);
+});
+
+test("website exposes accessible platform selection and bilingual content", () => {
+  assert.match(html, /role="tablist"/);
+  assert.match(html, /role="tabpanel"/);
+  assert.match(html, /data-language-switch/);
+  assert.match(html, /data-i18n="heroTitle"/);
+  assert.match(app, /setLanguage\(initialLanguage\)/);
+});
+
+test("Pages workflow deploys only the staged website", () => {
+  assert.match(workflow, /node scripts\/build-site\.mjs/);
+  assert.match(workflow, /path: build\/site/);
+  assert.doesNotMatch(workflow, /path:\s*\.\s*$/m);
+});


### PR DESCRIPTION
## What changes
- adds a lightweight bilingual product website with direct platform downloads
- detects the visitor platform while keeping every edition available
- refreshes Chinese-first and English README navigation and download guidance
- deploys only staged site files through GitHub Pages

## Verification
- 187 repository tests passed
- desktop and 390 px mobile layouts checked in a real browser
- language, platform, architecture, and keyboard tab switching checked
- every linked release asset exists in the current stable Release
- browser console has no warnings or errors