### PR TITLE
Use dsh-portable.js.org as the website domain

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://wsl043.github.io/DSH-Portable/"><strong>Website</strong></a>
+  <a href="https://dsh-portable.js.org/"><strong>Website</strong></a>
   · <a href="https://github.com/WSL043/DSH-Portable/releases/latest"><strong>Download</strong></a>
   · <a href="#start-in-3-steps">Get started</a>
   · <a href="#plugins">Plugins</a>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://wsl043.github.io/DSH-Portable/"><strong>官网</strong></a>
+  <a href="https://dsh-portable.js.org/"><strong>官网</strong></a>
   · <a href="https://github.com/WSL043/DSH-Portable/releases/latest"><strong>下载</strong></a>
   · <a href="#三步启动">开始使用</a>
   · <a href="#插件">插件</a>

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+dsh-portable.js.org

--- a/site/index.html
+++ b/site/index.html
@@ -8,9 +8,9 @@
   <meta property="og:title" content="DSH-Portable">
   <meta property="og:description" content="DeepSeek Harness, wherever you work.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://wsl043.github.io/DSH-Portable/">
-  <meta property="og:image" content="https://wsl043.github.io/DSH-Portable/assets/dsh-interface-zh.png">
-  <link rel="canonical" href="https://wsl043.github.io/DSH-Portable/">
+  <meta property="og:url" content="https://dsh-portable.js.org/">
+  <meta property="og:image" content="https://dsh-portable.js.org/assets/dsh-interface-zh.png">
+  <link rel="canonical" href="https://dsh-portable.js.org/">
   <title>DSH-Portable</title>
   <link rel="icon" href="assets/DSH-Portable.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">

--- a/tests/site-contract.test.mjs
+++ b/tests/site-contract.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 const html = await readFile(new URL("../site/index.html", import.meta.url), "utf8");
 const app = await readFile(new URL("../site/app.js", import.meta.url), "utf8");
 const css = await readFile(new URL("../site/styles.css", import.meta.url), "utf8");
+const cname = await readFile(new URL("../site/CNAME", import.meta.url), "utf8");
 const workflow = await readFile(new URL("../.github/workflows/pages.yml", import.meta.url), "utf8");
 
 test("website uses only stable release asset names that the product publishes", () => {
@@ -67,9 +68,10 @@ test("common desktop widths keep the product proof in the hero composition", () 
   assert.match(css, /@media \(max-width: 1080px\)/);
 });
 
-test("website publishes a canonical Pages domain", () => {
-  assert.match(html, /<link rel="canonical" href="https:\/\/wsl043\.github\.io\/DSH-Portable\/">/);
-  assert.match(html, /<meta property="og:url" content="https:\/\/wsl043\.github\.io\/DSH-Portable\/">/);
+test("website publishes its canonical custom domain", () => {
+  assert.equal(cname.trim(), "dsh-portable.js.org");
+  assert.match(html, /<link rel="canonical" href="https:\/\/dsh-portable\.js\.org\/">/);
+  assert.match(html, /<meta property="og:url" content="https:\/\/dsh-portable\.js\.org\/">/);
 });
 
 test("Pages workflow deploys only the staged website", () => {


### PR DESCRIPTION
## Summary

- publish the JS.ORG CNAME with the staged Pages artifact
- make the custom domain canonical in site metadata
- update the Chinese and English website links

## Verification

- 192 local tests pass
- staged Pages artifact contains the expected CNAME