### PR TITLE
docs: improve Portable download landing page

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, rm } from "node:fs/promises";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 const root = path.resolve(import.meta.dirname, "..");
@@ -11,5 +11,42 @@ await cp(path.join(root, "site"), output, { recursive: true });
 for (const asset of ["DSH-Portable.svg", "DSH-Portable-white.svg", "DSH-Portable-512.png", "dsh-interface-zh.png", "dsh-interface-en.png", "hero-atmosphere.png"]) {
   await cp(path.join(root, "assets", asset), path.join(output, "assets", asset));
 }
+
+function replaceRequired(source, from, to) {
+  if (!source.includes(from)) throw new Error(`English site transform could not find: ${from}`);
+  return source.replace(from, to);
+}
+
+let english = await readFile(path.join(output, "index.html"), "utf8");
+for (const [from, to] of [
+  ['<html lang="zh-CN">', '<html lang="en">'],
+  ['<meta name="dsh-page-language" content="zh">', '<meta name="dsh-page-language" content="en">'],
+  ['<meta name="description" content="DSH-Portable：无需 Node.js 的可移动 DeepSeek Harness 桌面版，会话、设置、插件和工作区随文件夹一起移动。">', '<meta name="description" content="DSH-Portable is a portable DeepSeek Harness desktop distribution with no separate Node.js install; sessions, settings, plugins, and workspace move with the folder.">'],
+  ['<meta property="og:title" content="DSH-Portable｜可移动的 DeepSeek Harness 桌面版">', '<meta property="og:title" content="DSH-Portable | Portable DeepSeek Harness desktop">'],
+  ['<meta property="og:description" content="无需 Node.js；会话、设置、插件和工作区随文件夹一起移动。">', '<meta property="og:description" content="No Node.js required; sessions, settings, plugins, and workspace move with the folder.">'],
+  ['<meta property="og:url" content="https://wsl043.github.io/DSH-Portable/">', '<meta property="og:url" content="https://wsl043.github.io/DSH-Portable/en/">'],
+  ['<meta property="og:locale" content="zh_CN">', '<meta property="og:locale" content="en_US">'],
+  ['<meta property="og:image" content="https://wsl043.github.io/DSH-Portable/assets/dsh-interface-zh.png">', '<meta property="og:image" content="https://wsl043.github.io/DSH-Portable/assets/dsh-interface-en.png">'],
+  ['<meta name="twitter:title" content="DSH-Portable｜可移动的 DeepSeek Harness 桌面版">', '<meta name="twitter:title" content="DSH-Portable | Portable DeepSeek Harness desktop">'],
+  ['<meta name="twitter:description" content="无需 Node.js；会话、设置、插件和工作区随文件夹一起移动。">', '<meta name="twitter:description" content="No Node.js required; sessions, settings, plugins, and workspace move with the folder.">'],
+  ['<meta name="twitter:image" content="https://wsl043.github.io/DSH-Portable/assets/dsh-interface-zh.png">', '<meta name="twitter:image" content="https://wsl043.github.io/DSH-Portable/assets/dsh-interface-en.png">'],
+  ['<link rel="canonical" href="https://wsl043.github.io/DSH-Portable/">', '<link rel="canonical" href="https://wsl043.github.io/DSH-Portable/en/">'],
+  ['"description": "无需 Node.js 的可移动 DeepSeek Harness 社区桌面发行版，支持 Windows、macOS 和 Linux。"', '"description": "A portable community desktop distribution of DeepSeek Harness for Windows, macOS, and Linux, with no separate Node.js install."'],
+  ['"url": "https://wsl043.github.io/DSH-Portable/"', '"url": "https://wsl043.github.io/DSH-Portable/en/"'],
+  ['"screenshot": "https://wsl043.github.io/DSH-Portable/assets/dsh-interface-zh.png"', '"screenshot": "https://wsl043.github.io/DSH-Portable/assets/dsh-interface-en.png"'],
+  ['"softwareRequirements": "无需单独安装 Node.js"', '"softwareRequirements": "No separate Node.js installation required"'],
+  ['<title>DSH-Portable｜无需 Node.js 的可移动 DeepSeek Harness 桌面版</title>', '<title>DSH-Portable | Portable DeepSeek Harness desktop</title>'],
+  ['<a class="language-switch" href="en/" hreflang="en" lang="en" aria-label="Switch to English" data-language-switch>EN</a>', '<a class="language-switch" href="../" hreflang="zh-CN" lang="zh-CN" aria-label="切换到中文" data-language-switch>中</a>'],
+  ['src="assets/dsh-interface-zh.png"', 'src="../assets/dsh-interface-en.png"']
+]) english = replaceRequired(english, from, to);
+
+english = english
+  .replaceAll('href="assets/', 'href="../assets/')
+  .replaceAll('src="assets/', 'src="../assets/')
+  .replace('href="styles.css"', 'href="../styles.css"')
+  .replace('src="app.js"', 'src="../app.js"');
+
+await mkdir(path.join(output, "en"), { recursive: true });
+await writeFile(path.join(output, "en", "index.html"), english);
 
 console.log(`Website staged at ${output}`);

--- a/site/app.js
+++ b/site/app.js
@@ -5,14 +5,14 @@ const releaseBase = "https://github.com/WSL043/DSH-Portable/releases/latest/down
 const copy = {
   en: {
     skip: "Skip to content", brandEdition: "Community portable edition", navPortable: "Portable", navDownload: "Download", navGithub: "GitHub", headerDownload: "Download",
-    heroKicker: "DeepSeek Harness · continue anywhere", heroTitle: "DeepSeek Harness,<br>wherever you work.", heroLede: "Sessions, settings, plugins, and workspace move together in one directory. Exit, copy, and continue on another computer.",
+    heroKicker: "DeepSeek Harness · continue anywhere", heroTitle: "DeepSeek Harness,<br>wherever you work.", heroLede: "No Node.js required. Sessions, settings, plugins, and workspace move together in one folder; exit, copy, and continue on another computer.",
     downloadFor: "Download for Windows", downloadMeta: "Latest stable · Portable · No install", otherPlatforms: "Other platforms", heroNote: "Open-source community project · Windows / macOS / Linux", stageCaption: "DeepSeek Harness running in DSH-Portable", scrollCue: "See how it moves",
     portableKicker: "Works where you do", portableTitle: "One directory. Any machine.", portableIntro: "Work normally. When it is time to move, exit fully from the tray and copy the whole DSH-Portable folder.", migrationGuide: "Read the complete migration guide",
-    factLauncher: "Windows portable launcher", factFiles: "Files in the complete package", factTargetsValue: "3 systems · 5 targets", factTargets: "Finished-product move tests",
+    factNodeValue: "No Node.js required", factLauncher: "Runtime included", factFiles: "User data and default workspace", factTargetsValue: "3 systems · 5 targets", factTargets: "Finished-product move tests",
     journeyDesktop: "Work on this computer", journeyDesktopText: "Sessions, plugins, and workspace keep saving inside the portable directory.", journeyMove: "Copy the whole directory", journeyMoveText: "Put it on a portable drive, USB drive, or any location you choose.", journeyContinue: "Continue on another computer", journeyContinueText: "Open it again and the app repairs paths it owns.",
     downloadsKicker: "Get DSH-Portable", downloadsTitle: "Choose your platform", downloadsIntro: "Your system is selected automatically. Each platform keeps a portable entry point and a complete offline package.", recommended: "Recommended",
     windowsPortable: "Windows portable", windowsPortableText: "Place the small bootstrap where you want the product; it prepares the complete folder beside itself.", downloadNow: "Download", offlineEdition: "Complete offline ZIP", offlineText: "For an offline computer or manual extraction", completeArchive: "All files", archiveText: "Release notes and other builds",
-    portableZip: "Portable ZIP", portableZipText: "Extract and run. Data stays in the same directory.", linuxAppText: "Grant execute permission and run. Data stays in the adjacent directory.", completeFolder: "Complete portable directory", downloadTrust: "Windows files are currently unsigned; the project is applying for open-source code signing provided by SignPath Foundation. <a href=\"https://github.com/WSL043/DSH-Portable/blob/main/CODE_SIGNING.md\">Read the code-signing policy</a>.", allDownloads: "View Release", checksums: "Checksums",
+    portableZip: "Portable ZIP", portableZipText: "Extract and run. Data stays in the same directory.", linuxAppText: "Grant execute permission and run. Data stays in the adjacent directory.", completeFolder: "Complete portable directory", downloadTrust: "Windows files are currently unsigned and may trigger SmartScreen; the project is applying for open-source code signing provided by SignPath Foundation. User data stays in <code>data/</code> and the default workspace in <code>workspace/</code>. <a href=\"https://github.com/WSL043/DSH-Portable/blob/main/CODE_SIGNING.md\">Read the code-signing policy</a>.", allDownloads: "View Release", checksums: "Checksums",
     insideKicker: "Ready when opened", insideTitle: "A desktop experience without extra setup.", insideIntro: "Portable does not mean stripped down. The window, tray, notifications, plugin market, updates, and repair tools stay in the product.",
     marketTitle: "Plugin market", marketText: "Browse, install, update, and disable community plugins from DSH Settings.", trayTitle: "Tray and notifications", trayText: "Return to recent sessions, create a new one, and receive a notification when work completes.", repairTitle: "Check and repair", repairText: "Preserve user data, rebuild reproducible components, and export a credential-free support report.", testedTitle: "Finished-product tests", testedText: "Install, start, exit, move, plugin, and update paths are continuously verified on all three platforms.",
     faqTitle: "Common questions", faqOfficialQ: "Is this an official DeepSeek desktop app?", faqOfficialA: "No. DSH-Portable is an independent community distribution that packages a product-tested preview of official DeepSeek Harness.", faqNodeQ: "Do I need Node.js first?", faqNodeA: "No. The runtime and plugin tools are included and do not modify the system PATH.", faqDataQ: "Will copying the folder lose my sessions?", faqDataA: "Fully exit from the tray, then copy the whole DSH-Portable folder. Sessions, settings, plugins, and the default workspace move together.", faqUpdateQ: "Will an update overwrite my data?", faqUpdateA: "No. Updates replace application components while user data and workspace remain in place.",
@@ -72,16 +72,6 @@ systemMotionPreference.addEventListener("change", () => {
   if (!readSavedMotion()) applyMotion("auto");
 });
 
-function readSavedLanguage() {
-  try { return localStorage.getItem("dsh-portable-language"); }
-  catch { return null; }
-}
-
-function saveLanguage(language) {
-  try { localStorage.setItem("dsh-portable-language", language); }
-  catch { /* Storage is an enhancement, not a requirement. */ }
-}
-
 function primaryLabel(language, currentPlatform) {
   const labels = language === "en"
     ? { windows: "Download for Windows", macos: "Download for macOS", linux: "Download for Linux" }
@@ -99,16 +89,17 @@ function setLanguage(language) {
   document.querySelector("[data-i18n='downloadFor']").textContent = primaryLabel(lang, platform);
   languageSwitch.textContent = lang === "en" ? "中" : "EN";
   languageSwitch.setAttribute("aria-label", lang === "en" ? "切换到中文" : "Switch to English");
+  languageSwitch.href = lang === "en" ? "../" : "en/";
+  languageSwitch.hreflang = lang === "en" ? "zh-CN" : "en";
+  languageSwitch.lang = lang === "en" ? "zh-CN" : "en";
   updateMotionControlCopy();
-  productShot.src = lang === "en" ? "assets/dsh-interface-en.png" : "assets/dsh-interface-zh.png";
+  const assetBase = lang === "en" ? "../assets/" : "assets/";
+  productShot.src = `${assetBase}${lang === "en" ? "dsh-interface-en.png" : "dsh-interface-zh.png"}`;
   productShot.alt = lang === "en" ? "DeepSeek Harness workspace in DSH-Portable" : "DSH-Portable 中的 DeepSeek Harness 桌面工作台";
   migrationGuide.href = lang === "en"
     ? "https://github.com/WSL043/DSH-Portable/blob/main/docs/move-between-computers.en.md"
     : "https://github.com/WSL043/DSH-Portable/blob/main/docs/move-between-computers.md";
-  saveLanguage(lang);
 }
-
-languageSwitch.addEventListener("click", () => setLanguage(document.documentElement.lang.startsWith("en") ? "zh" : "en"));
 
 const platformTabs = [...document.querySelectorAll("[data-platform-tab]")];
 const platformPanels = [...document.querySelectorAll("[data-platform-panel]")];
@@ -230,7 +221,7 @@ if ("IntersectionObserver" in window && motionEnabled()) {
   document.querySelectorAll(".reveal").forEach((element) => element.classList.add("is-visible"));
 }
 
-const initialLanguage = readSavedLanguage() || (navigator.language?.toLowerCase().startsWith("zh") ? "zh" : "en");
+const initialLanguage = document.querySelector("meta[name='dsh-page-language']")?.content === "en" ? "en" : "zh";
 setLanguage(initialLanguage);
 updateScrollState();
 requestAnimationFrame(() => document.documentElement.classList.add("is-ready"));

--- a/site/index.html
+++ b/site/index.html
@@ -4,34 +4,41 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#050607">
-  <meta name="description" content="DSH-Portable：把 DeepSeek Harness、会话、设置、插件和工作区放进一个可移动目录。">
-  <meta property="og:title" content="DSH-Portable">
-  <meta property="og:description" content="DeepSeek Harness, wherever you work.">
+  <meta name="dsh-page-language" content="zh">
+  <meta name="description" content="DSH-Portable：无需 Node.js 的可移动 DeepSeek Harness 桌面版，会话、设置、插件和工作区随文件夹一起移动。">
+  <meta property="og:title" content="DSH-Portable｜可移动的 DeepSeek Harness 桌面版">
+  <meta property="og:description" content="无需 Node.js；会话、设置、插件和工作区随文件夹一起移动。">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://wsl043.github.io/DSH-Portable/">
+  <meta property="og:locale" content="zh_CN">
   <meta property="og:image" content="https://wsl043.github.io/DSH-Portable/assets/dsh-interface-zh.png">
   <meta property="og:image:alt" content="DSH-Portable desktop workspace">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="DSH-Portable">
-  <meta name="twitter:description" content="DeepSeek Harness, wherever you work.">
+  <meta name="twitter:title" content="DSH-Portable｜可移动的 DeepSeek Harness 桌面版">
+  <meta name="twitter:description" content="无需 Node.js；会话、设置、插件和工作区随文件夹一起移动。">
   <meta name="twitter:image" content="https://wsl043.github.io/DSH-Portable/assets/dsh-interface-zh.png">
   <link rel="canonical" href="https://wsl043.github.io/DSH-Portable/">
+  <link rel="alternate" hreflang="zh-CN" href="https://wsl043.github.io/DSH-Portable/">
+  <link rel="alternate" hreflang="en" href="https://wsl043.github.io/DSH-Portable/en/">
+  <link rel="alternate" hreflang="x-default" href="https://wsl043.github.io/DSH-Portable/">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "DSH-Portable",
-    "description": "A portable desktop distribution of DeepSeek Harness for Windows, macOS, and Linux.",
+    "description": "无需 Node.js 的可移动 DeepSeek Harness 社区桌面发行版，支持 Windows、macOS 和 Linux。",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Windows, macOS, Linux",
     "license": "https://github.com/WSL043/DSH-Portable/blob/main/LICENSE",
     "url": "https://wsl043.github.io/DSH-Portable/",
-    "downloadUrl": "https://github.com/WSL043/DSH-Portable/releases/latest",
+    "downloadUrl": "https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe",
     "codeRepository": "https://github.com/WSL043/DSH-Portable",
+    "screenshot": "https://wsl043.github.io/DSH-Portable/assets/dsh-interface-zh.png",
+    "softwareRequirements": "无需单独安装 Node.js",
     "inLanguage": ["zh-CN", "en"]
   }
   </script>
-  <title>DSH-Portable</title>
+  <title>DSH-Portable｜无需 Node.js 的可移动 DeepSeek Harness 桌面版</title>
   <link rel="icon" href="assets/DSH-Portable.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">
   <script src="app.js" defer></script>
@@ -45,7 +52,7 @@
       <a class="nav-link nav-link-wide" href="#downloads" data-i18n="navDownload">下载</a>
       <a class="nav-link nav-link-wide" href="https://github.com/WSL043/DSH-Portable" data-i18n="navGithub">GitHub</a>
       <button class="motion-control" type="button" aria-pressed="false" data-motion-control>动效</button>
-      <button class="language-switch" type="button" aria-label="Switch language" data-language-switch>EN</button>
+      <a class="language-switch" href="en/" hreflang="en" lang="en" aria-label="Switch to English" data-language-switch>EN</a>
       <a class="header-download" data-primary-download href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe" data-i18n="headerDownload">下载</a>
     </nav>
   </header>
@@ -57,7 +64,7 @@
         <div class="hero-copy" data-hero-copy>
           <p class="hero-kicker" data-i18n="heroKicker">DeepSeek Harness · 随处继续</p>
           <h1 data-i18n="heroTitle">把 DeepSeek Harness<br>带到任何地方。</h1>
-          <p class="hero-lede" data-i18n="heroLede">会话、设置、插件和工作区跟着同一个目录走。退出、复制，到另一台电脑继续。</p>
+          <p class="hero-lede" data-i18n="heroLede">无需 Node.js。会话、设置、插件和工作区跟着同一个文件夹走；退出、复制，到另一台电脑继续。</p>
           <div class="hero-actions">
             <a class="download-button" data-primary-download href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-windows-x64.exe"><span><strong data-i18n="downloadFor">下载 Windows 便携版</strong><small data-i18n="downloadMeta">最新稳定版 · 便携 · 无需安装</small></span></a>
             <a class="text-link" href="#downloads" data-i18n="otherPlatforms">其他平台</a>
@@ -65,7 +72,7 @@
           <p class="hero-note" data-i18n="heroNote">开源社区项目 · Windows / macOS / Linux</p>
         </div>
         <div class="product-stage" data-product-stage>
-          <ol class="path-stack" aria-hidden="true"><li>DSH-Portable/workspace/</li><li>DSH-Portable/plugins/</li><li>DSH-Portable/settings/</li><li>DSH-Portable/sessions/</li></ol>
+          <ol class="path-stack" aria-hidden="true"><li>DSH-Portable/workspace/</li><li>DSH-Portable/data/dsh-home/</li><li>DSH-Portable/data/webview2/</li><li>DSH-Portable/data/logs/</li></ol>
           <figure class="product-window"><img data-product-shot src="assets/dsh-interface-zh.png" alt="DSH-Portable 中的 DeepSeek Harness 桌面工作台"><figcaption data-i18n="stageCaption">DeepSeek Harness 运行在 DSH-Portable 中</figcaption></figure>
         </div>
       </div>
@@ -79,8 +86,8 @@
         <p data-i18n="portableIntro">平时照常工作。需要迁移时，从托盘完全退出，再复制整个 DSH-Portable 文件夹。</p>
         <a class="story-guide" data-migration-guide href="https://github.com/WSL043/DSH-Portable/blob/main/docs/move-between-computers.md" data-i18n="migrationGuide">查看完整迁移指南</a>
         <dl class="portable-facts" aria-label="Portable verification">
-          <div><dt>≈ 55 KB</dt><dd data-i18n="factLauncher">Windows 便携启动器</dd></div>
-          <div><dt>−15%</dt><dd data-i18n="factFiles">完整包文件数</dd></div>
+          <div><dt data-i18n="factNodeValue">无需 Node.js</dt><dd data-i18n="factLauncher">运行环境已内置</dd></div>
+          <div><dt>data/ + workspace/</dt><dd data-i18n="factFiles">用户数据与默认工作区</dd></div>
           <div><dt data-i18n="factTargetsValue">3 系统 · 5 架构</dt><dd data-i18n="factTargets">成品迁移测试</dd></div>
         </dl>
       </div>
@@ -108,7 +115,7 @@
           <div class="recommended-download"><div><span data-i18n="recommended">推荐</span><h3>AppImage</h3><p data-i18n="linuxAppText">添加执行权限后直接启动，数据保存在旁边的目录中。</p></div><a class="panel-download" data-linux-download="appimage" href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DeepSeek-Herness-linux-x64.AppImage" data-i18n="downloadNow">下载</a></div>
           <div class="download-options one-column"><a data-linux-download="archive" href="https://github.com/WSL043/DSH-Portable/releases/latest/download/DSH-Portable-linux-x64.tar.gz"><strong data-i18n="completeFolder">完整便携目录</strong><span>tar.gz</span></a></div>
         </div>
-        <p class="download-trust" data-i18n="downloadTrust">Windows 文件目前尚未签名；项目正在申请 SignPath Foundation 提供的开源代码签名。<a href="https://github.com/WSL043/DSH-Portable/blob/main/CODE_SIGNING.md">查看代码签名策略</a></p>
+        <p class="download-trust" data-i18n="downloadTrust">Windows 文件目前尚未签名，可能触发 SmartScreen；项目正在申请 SignPath Foundation 提供的开源代码签名。用户数据位于便携目录的 <code>data/</code>，默认工作区位于 <code>workspace/</code>。<a href="https://github.com/WSL043/DSH-Portable/blob/main/CODE_SIGNING.md">查看代码签名策略</a></p>
         <div class="release-links"><a href="https://github.com/WSL043/DSH-Portable/releases/latest" data-i18n="allDownloads">查看 Release</a><a href="https://github.com/WSL043/DSH-Portable/releases/latest/download/checksums.txt" data-i18n="checksums">校验文件</a></div>
       </div>
     </section>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://wsl043.github.io/DSH-Portable/</loc>
+    <xhtml:link rel="alternate" hreflang="zh-CN" href="https://wsl043.github.io/DSH-Portable/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://wsl043.github.io/DSH-Portable/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://wsl043.github.io/DSH-Portable/" />
+  </url>
+  <url>
+    <loc>https://wsl043.github.io/DSH-Portable/en/</loc>
+    <xhtml:link rel="alternate" hreflang="zh-CN" href="https://wsl043.github.io/DSH-Portable/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://wsl043.github.io/DSH-Portable/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://wsl043.github.io/DSH-Portable/" />
   </url>
 </urlset>

--- a/site/styles.css
+++ b/site/styles.css
@@ -38,7 +38,7 @@ h1, h2, h3, p { margin-top: 0; }
 .header-actions { display: flex; align-items: center; gap: 28px; }
 .nav-link { color: #a4a6aa; font-size: 12px; transition: color .18s ease; }
 .nav-link:hover { color: white; }
-.language-switch, .motion-control { min-width: 36px; height: 30px; padding: 0 9px; border: 1px solid var(--line-strong); border-radius: 7px; background: rgba(255, 255, 255, .035); cursor: pointer; font-size: 11px; transition: color .18s ease, background .18s ease, border-color .18s ease; }
+.language-switch, .motion-control { min-width: 36px; height: 30px; display: inline-flex; align-items: center; justify-content: center; padding: 0 9px; border: 1px solid var(--line-strong); border-radius: 7px; background: rgba(255, 255, 255, .035); cursor: pointer; font-size: 11px; transition: color .18s ease, background .18s ease, border-color .18s ease; }
 .motion-control { min-width: 54px; color: #8f9296; }
 .motion-control[aria-pressed="true"] { color: #f1f1ee; border-color: rgba(255, 255, 255, .34); }
 .language-switch:hover, .motion-control:hover { border-color: rgba(255, 255, 255, .4); background: rgba(255, 255, 255, .08); }

--- a/tests/site-contract.test.mjs
+++ b/tests/site-contract.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { access, readFile } from "node:fs/promises";
+import { promisify } from "node:util";
 import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = new URL("../", import.meta.url);
 
 const html = await readFile(new URL("../site/index.html", import.meta.url), "utf8");
 const app = await readFile(new URL("../site/app.js", import.meta.url), "utf8");
@@ -35,6 +40,28 @@ test("website exposes accessible platform selection and bilingual content", () =
   assert.match(html, /data-language-switch/);
   assert.match(html, /data-i18n="heroTitle"/);
   assert.match(app, /setLanguage\(initialLanguage\)/);
+});
+
+test("website defaults to Chinese and builds an indexable English route", async () => {
+  assert.match(html, /<meta name="dsh-page-language" content="zh">/);
+  assert.match(html, /hreflang="zh-CN" href="https:\/\/wsl043\.github\.io\/DSH-Portable\/"/);
+  assert.match(html, /hreflang="en" href="https:\/\/wsl043\.github\.io\/DSH-Portable\/en\/"/);
+  assert.match(html, /hreflang="x-default" href="https:\/\/wsl043\.github\.io\/DSH-Portable\/"/);
+  assert.match(app, /meta\[name=['"]dsh-page-language['"]\]/);
+  assert.doesNotMatch(app, /navigator\.language/);
+
+  await execFileAsync(process.execPath, ["scripts/build-site.mjs"], {
+    cwd: repositoryRoot,
+    windowsHide: true
+  });
+  const english = await readFile(new URL("../build/site/en/index.html", import.meta.url), "utf8");
+  assert.match(english, /<html lang="en">/);
+  assert.match(english, /<meta name="dsh-page-language" content="en">/);
+  assert.match(english, /<link rel="canonical" href="https:\/\/wsl043\.github\.io\/DSH-Portable\/en\/">/);
+  assert.match(english, /<title>DSH-Portable[^<]*Portable DeepSeek Harness/);
+  assert.match(english, /class="language-switch" href="\.\.\/" hreflang="zh-CN"/);
+  assert.match(english, /href="\.\.\/styles\.css"/);
+  assert.match(english, /src="\.\.\/assets\/dsh-interface-en\.png"/);
 });
 
 test("website ships its cinematic product stage with motion safeguards", () => {
@@ -82,10 +109,22 @@ test("website publishes only through the currently verified Pages domain", async
 test("website exposes search-engine metadata without duplicating release files", () => {
   assert.match(html, /<meta name="twitter:card" content="summary_large_image">/);
   assert.match(html, /<script type="application\/ld\+json">[\s\S]*"@type":\s*"SoftwareApplication"/);
-  assert.match(html, /"downloadUrl":\s*"https:\/\/github\.com\/WSL043\/DSH-Portable\/releases\/latest"/);
+  assert.match(html, /"downloadUrl":\s*"https:\/\/github\.com\/WSL043\/DSH-Portable\/releases\/latest\/download\/DSH-Portable-windows-x64\.exe"/);
   assert.match(robots, /User-agent:\s*\*[\s\S]*Allow:\s*\/[\s\S]*Sitemap:\s*https:\/\/wsl043\.github\.io\/DSH-Portable\/sitemap\.xml/);
   assert.match(sitemap, /<loc>https:\/\/wsl043\.github\.io\/DSH-Portable\/<\/loc>/);
+  assert.match(sitemap, /<loc>https:\/\/wsl043\.github\.io\/DSH-Portable\/en\/<\/loc>/);
+  assert.match(sitemap, /xhtml:link rel="alternate" hreflang="zh-CN"/);
+  assert.match(sitemap, /xhtml:link rel="alternate" hreflang="en"/);
   assert.doesNotMatch(`${robots}\n${sitemap}`, /releases\/latest\/download/);
+});
+
+test("hero and trust copy use durable portable-product facts", () => {
+  assert.match(html, /无需 Node\.js/);
+  assert.match(app, /No Node\.js required/);
+  assert.doesNotMatch(html, /≈\s*55\s*KB|−15%/);
+  assert.match(`${html}\n${app}`, /SmartScreen/);
+  assert.match(`${html}\n${app}`, /data\/.*workspace\/|data and workspace/);
+  assert.doesNotMatch(`${html}\n${app}`, /google-analytics|googletagmanager|plausible|segment\.com/i);
 });
 
 test("Pages workflow deploys only the staged website", () => {


### PR DESCRIPTION
## Summary
- make Chinese the default landing page and generate an indexable English route from the same site
- add durable download, metadata, screenshot, data-location, and unsigned Windows guidance
- keep stable latest-download links and add bilingual sitemap alternates

## Verification
- 353 repository tests pass
- site build emits root and /en/ pages
- no product version or release changes