### PR TITLE
Stabilize Windows startup transition audit

### DIFF
--- a/scripts/audit-windows-startup-transition.mjs
+++ b/scripts/audit-windows-startup-transition.mjs
@@ -196,16 +196,17 @@ try {
   }
 
   const bootSample = samples.find(sample => sample.bootVisible)
-  const visibleBootSample = samples.find(sample => sample.bootVisible && sample.log.includes('dsh-boot-surface-visible'))
+  const bootLogSample = samples.find(sample => sample.log.includes('dsh-boot-surface-visible'))
   const revealSample = samples.find(sample => sample.log.includes('dsh-first-paint-ready'))
   const workspaceSample = samples.find(sample => revealSample
     && sample.at > revealSample.at
     && !sample.bootVisible
     && sample.bodyText.length > 0)
-  assert.ok(bootSample, 'the official DSH loading state was never observed')
-  assert.ok(visibleBootSample, 'the native window never revealed the official DSH loading surface')
-  assert.ok(visibleBootSample.log.indexOf('dsh-boot-surface-visible') < visibleBootSample.log.indexOf('dsh-first-paint-ready')
-    || !visibleBootSample.log.includes('dsh-first-paint-ready'), 'the workspace was revealed before the DSH loading surface')
+  await writeFile(path.join(output, 'samples.json'), JSON.stringify(samples, null, 2))
+  assert.ok(bootSample || bootLogSample, 'the official DSH loading state was never observed')
+  assert.ok(bootLogSample, 'the native window never revealed the official DSH loading surface')
+  assert.ok(bootLogSample.log.indexOf('dsh-boot-surface-visible') < bootLogSample.log.indexOf('dsh-first-paint-ready')
+    || !bootLogSample.log.includes('dsh-first-paint-ready'), 'the workspace was revealed before the DSH loading surface')
   assert.ok(revealSample, 'the native loading surface never handed off to the settled workspace')
   assert.match(revealSample.log, /surface-ready-message/)
   assert.match(revealSample.log, /surface-handoff:native-bridge/)
@@ -213,7 +214,6 @@ try {
   assert.ok(revealSample.bodyText.length > 0, 'the native surface revealed an empty workspace')
   assert.ok(revealSample.visibleControls >= 2, 'the native surface revealed before primary controls were ready')
   assert.ok(workspaceSample, 'the settled DSH workspace did not remain stable after native handoff')
-  await writeFile(path.join(output, 'samples.json'), JSON.stringify(samples, null, 2))
   console.log(JSON.stringify({
     output,
     samples: samples.length,

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -519,6 +519,16 @@ test('CI release gate verifies native desktop ownership, lifecycle, and applicat
   assert.doesNotMatch(macSmoke, /System Events/)
 })
 
+test('Windows startup audit accepts log-backed loader evidence and persists failures', async () => {
+  const audit = await read('scripts/audit-windows-startup-transition.mjs')
+  assert.match(audit, /const bootLogSample = samples\.find\(sample => sample\.log\.includes\('dsh-boot-surface-visible'\)\)/)
+  assert.match(audit, /assert\.ok\(bootSample \|\| bootLogSample/)
+  assert.ok(
+    audit.indexOf("await writeFile(path.join(output, 'samples.json')") < audit.indexOf("assert.ok(bootSample || bootLogSample"),
+    'startup samples must be uploaded even when the transition assertion fails',
+  )
+})
+
 test('macOS package smokes treat the native app as a long-lived desktop process', async () => {
   const portableSmoke = await read('scripts/smoke-portable.mjs')
 


### PR DESCRIPTION
## Summary

- carry the qualified stable startup-audit fix into the 0.6.0 line
- accept native launcher log evidence when CDP attaches after the short-lived loader DOM
- retain loader ordering, handoff, ready-controls, and settled-workspace assertions
- persist samples before assertions for actionable failure logs

## Verification

- focused contract: 1/1 passed
- the identical patch passed the full 33-job v0.5.4 release qualification on Windows 2022/2025, Linux, and macOS: https://github.com/WSL043/DSH-Portable/actions/runs/33314523482