### PR TITLE
Automate preview intake and enforce qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: Build and smoke test
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - automation/verified-dependencies
+      - automation/official-preview
   pull_request:
   workflow_dispatch:
 
@@ -52,7 +55,7 @@ jobs:
         id: preview
         run: |
           node scripts/version-policy.mjs "$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-          node -e "const lock=require('./upstream.preview.lock.json'); console.log('commit='+lock.dsh.reviewedCommit); console.log('version='+lock.dsh.version); console.log('packageManager='+lock.dsh.packageManager)" >> "$GITHUB_OUTPUT"
+          node -e "const lock=require('./upstream.preview.lock.json'); console.log('commit='+lock.dsh.reviewedCommit); console.log('version='+lock.dsh.version); console.log('packageManager='+lock.dsh.packageManager); for (const [family,count] of Object.entries(lock.dsh.packedFamilies)) console.log(family+'Count='+count)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         if: steps.preview.outputs.channel == 'candidate'
         with:
@@ -70,9 +73,9 @@ jobs:
           pnpm --dir upstream run release:pack --family vendor --out dist/npm-vendor --concurrency 8
           mkdir -p upstream/dist/npm-landlock
           pnpm --dir upstream/native/landlock-run/packages/entry pack --pack-destination "$PWD/upstream/dist/npm-landlock"
-          test "$(find upstream/dist/npm -maxdepth 1 -name '*.tgz' | wc -l)" -eq 245
-          test "$(find upstream/dist/npm-vendor -maxdepth 1 -name '*.tgz' | wc -l)" -eq 9
-          test "$(find upstream/dist/npm-landlock -maxdepth 1 -name '*.tgz' | wc -l)" -eq 1
+          test "$(find upstream/dist/npm -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.dshCount }}"
+          test "$(find upstream/dist/npm-vendor -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.vendorCount }}"
+          test "$(find upstream/dist/npm-landlock -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.landlockCount }}"
       - name: Create a stable-channel marker
         if: steps.preview.outputs.channel != 'candidate'
         run: mkdir preview-packed && printf 'stable\n' > preview-packed/STABLE
@@ -787,3 +790,31 @@ jobs:
           chmod +x "artifacts/DeepSeek-Herness-linux-${{ matrix.arch }}.AppImage"
           APPIMAGE_EXTRACT_AND_RUN=1 xvfb-run -a "artifacts/DeepSeek-Herness-linux-${{ matrix.arch }}.AppImage" --diagnostic-root-json | tee "$RUNNER_TEMP/appimage-layout.json"
           grep -q '"mode":"appimage"' "$RUNNER_TEMP/appimage-layout.json"
+
+  product-qualification:
+    name: Product qualification
+    if: ${{ always() }}
+    needs:
+      - workflow-lint
+      - contracts
+      - windows-inno-build
+      - windows-update-smoke
+      - windows-portable-smoke
+      - windows-plugin-smoke
+      - windows-desktop-host
+      - windows-bootstrap-smoke
+      - windows-version-upgrade-smoke
+      - windows-extractor-smoke
+      - macos-portable-smoke
+      - macos-desktop-host
+      - macos-plugin-smoke
+      - linux-portable-smoke
+      - linux-plugin-smoke
+      - linux-desktop-host
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every product gate to succeed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          node -e "const needs=JSON.parse(process.env.NEEDS); if (!Object.values(needs).every(({ result }) => result === 'success')) { console.error(needs); process.exit(1) }"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,7 @@ name: Build and smoke test
 
 on:
   push:
-    branches:
-      - main
-      - automation/verified-dependencies
-      - automation/official-preview
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/merge-verified-dependencies.yml
+++ b/.github/workflows/merge-verified-dependencies.yml
@@ -13,7 +13,8 @@ permissions:
 jobs:
   merge:
     if: >-
-      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.name == 'Build and smoke test' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'automation/verified-dependencies' &&
       github.event.workflow_run.head_repository.full_name == github.repository

--- a/.github/workflows/official-preview-watch.yml
+++ b/.github/workflows/official-preview-watch.yml
@@ -1,0 +1,63 @@
+name: Official DSH preview intake
+
+on:
+  schedule:
+    - cron: '41 */6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: official-preview-intake
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+      - id: preview
+        name: Discover a newer official alpha package and immutable source tag
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/update-preview-upstream.mjs
+      - name: Run repository contracts before opening the review
+        if: steps.preview.outputs.changed == 'true'
+        run: |
+          npm ci --prefix app --ignore-scripts
+          npm test
+      - name: Open or refresh the official preview review pull request
+        if: steps.preview.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.preview.outputs.version }}
+          COMMIT: ${{ steps.preview.outputs.commit }}
+        run: |
+          set -euo pipefail
+          BRANCH=automation/official-preview
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout -B "$BRANCH"
+          git add upstream.preview.lock.json
+          git commit -m "chore: review official DSH preview ${VERSION}"
+          git push --force origin "$BRANCH"
+          BODY=$(mktemp)
+          cat > "$BODY" <<EOF
+          Reviews official DeepSeek Harness preview `${VERSION}` at immutable commit `${COMMIT}` for the Portable candidate channel.
+
+          The full Windows, macOS, and Linux product qualification runs on this branch. Manual review and merge are required; this workflow never publishes or merges an Alpha automatically.
+          EOF
+          PR=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')
+          if [ -n "$PR" ]; then
+            gh pr edit "$PR" --title "Review official DSH preview ${VERSION}" --body-file "$BODY" --add-assignee WSL043
+          else
+            gh pr create --base main --head "$BRANCH" --title "Review official DSH preview ${VERSION}" --body-file "$BODY" --assignee WSL043
+          fi
+          gh workflow run ci.yml --ref "$BRANCH"

--- a/.github/workflows/official-preview-watch.yml
+++ b/.github/workflows/official-preview-watch.yml
@@ -50,7 +50,7 @@ jobs:
           git push --force origin "$BRANCH"
           BODY=$(mktemp)
           cat > "$BODY" <<EOF
-          Reviews official DeepSeek Harness preview `${VERSION}` at immutable commit `${COMMIT}` for the Portable candidate channel.
+          Reviews official DeepSeek Harness preview ${VERSION} at immutable commit ${COMMIT} for the Portable candidate channel.
 
           The full Windows, macOS, and Linux product qualification runs on this branch. Manual review and merge are required; this workflow never publishes or merges an Alpha automatically.
           EOF

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -33,6 +33,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -147,3 +148,4 @@ jobs:
           else
             gh pr create --base main --head "$BRANCH" --title "Keep verified DSH dependencies current" --body-file "$BODY"
           fi
+          gh workflow run ci.yml --ref "$BRANCH"

--- a/scripts/update-preview-upstream.mjs
+++ b/scripts/update-preview-upstream.mjs
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto'
+import { appendFile, readFile, rename, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { evaluatePreviewUpstream } from './upstream-state.mjs'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const headers = {
+  accept: 'application/vnd.github+json',
+  'user-agent': 'DSH-Portable-official-preview',
+  ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+}
+
+async function json(url) {
+  const response = await fetch(url, {
+    headers: url.startsWith('https://registry.npmjs.org/')
+      ? { ...headers, accept: 'application/json' }
+      : headers,
+  })
+  if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`)
+  return response.json()
+}
+
+async function officialTagCommit(version) {
+  const ref = await json(`https://api.github.com/repos/deepseek-ai/deepseek-harness/git/ref/tags/dsh-v${version}`)
+  let object = ref?.object
+  if (object?.type === 'tag') {
+    const annotated = await json(`https://api.github.com/repos/deepseek-ai/deepseek-harness/git/tags/${object.sha}`)
+    object = annotated?.object
+  }
+  if (object?.type !== 'commit' || !/^[0-9a-f]{40}$/.test(object.sha ?? '')) {
+    throw new Error(`official tag dsh-v${version} does not resolve to a commit`)
+  }
+  return { sha: object.sha }
+}
+
+const lockPath = path.join(root, 'upstream.preview.lock.json')
+const [registry, lock] = await Promise.all([
+  json('https://registry.npmjs.org/@deepseek-ai%2Fdsh'),
+  readFile(lockPath, 'utf8').then(JSON.parse),
+])
+const alphaVersion = registry?.['dist-tags']?.alpha
+const provisional = evaluatePreviewUpstream({
+  lock,
+  registry,
+  packageCommit: { sha: lock.dsh.reviewedCommit },
+})
+const packageCommit = provisional.changed
+  ? await officialTagCommit(alphaVersion)
+  : { sha: lock.dsh.reviewedCommit }
+const state = evaluatePreviewUpstream({ lock, registry, packageCommit })
+
+if (state.changed) {
+  const noticesResponse = await fetch(
+    `https://raw.githubusercontent.com/deepseek-ai/deepseek-harness/${state.commit}/THIRD_PARTY_NOTICES.md`,
+    { headers },
+  )
+  if (!noticesResponse.ok) throw new Error(`official notices returned HTTP ${noticesResponse.status}`)
+  const noticesSha256 = createHash('sha256')
+    .update(Buffer.from(await noticesResponse.arrayBuffer()))
+    .digest('hex')
+
+  lock.dsh.version = state.version
+  lock.dsh.tag = `dsh-v${state.version}`
+  lock.dsh.npmIntegrity = state.integrity
+  lock.dsh.reviewedCommit = state.commit
+  lock.dsh.noticesSha256 = noticesSha256
+  const temporary = `${lockPath}.tmp`
+  await writeFile(temporary, `${JSON.stringify(lock, null, 2)}\n`, 'utf8')
+  await rename(temporary, lockPath)
+}
+
+console.log(JSON.stringify(state, null, 2))
+if (process.env.GITHUB_OUTPUT) {
+  await appendFile(process.env.GITHUB_OUTPUT, [
+    `changed=${state.changed}`,
+    `version=${state.version}`,
+    `commit=${state.commit}`,
+    '',
+  ].join('\n'))
+}

--- a/scripts/upstream-state.mjs
+++ b/scripts/upstream-state.mjs
@@ -32,6 +32,38 @@ function compareSemver(leftValue, rightValue) {
   return 0
 }
 
+export function evaluatePreviewUpstream({ lock, registry, packageCommit }) {
+  const version = registry?.['dist-tags']?.alpha
+  const published = registry?.versions?.[version]
+  const integrity = published?.dist?.integrity
+  if (!version || !integrity) {
+    throw new Error('official npm alpha tag has no verifiable package integrity')
+  }
+  if (!/-alpha(?:\.|$)/.test(version)) {
+    throw new Error(`official npm alpha tag does not point to an alpha prerelease: ${version}`)
+  }
+
+  const currentVersion = lock.dsh.version
+  const comparison = compareSemver(version, currentVersion)
+  if (comparison === 0 && integrity !== lock.dsh.npmIntegrity) {
+    throw new Error(`integrity changed for the pinned official alpha ${version}`)
+  }
+  if (comparison <= 0) {
+    return {
+      changed: false,
+      version: currentVersion,
+      integrity: lock.dsh.npmIntegrity,
+      commit: lock.dsh.reviewedCommit,
+    }
+  }
+
+  const commit = packageCommit?.sha
+  if (!/^[0-9a-f]{40}$/.test(commit ?? '')) {
+    throw new Error(`official tag dsh-v${version} does not resolve to a commit`)
+  }
+  return { changed: true, version, integrity, commit }
+}
+
 export function evaluateUpstream({ lock, registry, commit, packageCommit, requestedTag = 'next' }) {
   const tags = registry?.['dist-tags'] ?? {}
   const selectedTag = requestedTag === 'latest'

--- a/tests/update-governance.test.mjs
+++ b/tests/update-governance.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const read = (relative) => readFile(new URL(`../${relative}`, import.meta.url), 'utf8')
+
+test('official DSH alpha discovery opens a review-only pull request', async () => {
+  const [workflow, updater] = await Promise.all([
+    read('.github/workflows/official-preview-watch.yml'),
+    read('scripts/update-preview-upstream.mjs'),
+  ])
+
+  assert.match(workflow, /cron:\s*['"]41 \*\/6 \* \* \*['"]/)
+  assert.match(workflow, /node scripts\/update-preview-upstream\.mjs/)
+  assert.match(workflow, /automation\/official-preview/)
+  assert.match(workflow, /gh pr (?:create|edit)/)
+  assert.match(workflow, /manual review/i)
+  assert.match(workflow, /gh workflow run ci\.yml[^\n]+--ref "\$BRANCH"/)
+  assert.match(workflow, /actions:\s*write/)
+  assert.doesNotMatch(workflow, /gh pr merge|workflow_run:/)
+  assert.match(updater, /dist-tags/)
+  assert.match(updater, /officialTagCommit/)
+  assert.match(updater, /upstream\.preview\.lock\.json/)
+  assert.doesNotMatch(updater, /upstream\.lock\.json/)
+})
+
+test('bot dependency branches run without pull-request workflow approval and merge only after qualification', async () => {
+  const [ci, merge] = await Promise.all([
+    read('.github/workflows/ci.yml'),
+    read('.github/workflows/merge-verified-dependencies.yml'),
+  ])
+
+  assert.match(ci, /push:[\s\S]+branches:[\s\S]+main[\s\S]+automation\/verified-dependencies[\s\S]+automation\/official-preview/)
+  assert.match(ci, /^  product-qualification:/m)
+  assert.match(ci, /name:\s*Product qualification/)
+  assert.match(ci, /if:\s*\$\{\{ always\(\) \}\}/)
+  assert.match(ci, /toJSON\(needs\)/)
+  assert.match(ci, /every\(\(\{ result \}\) => result === 'success'\)/)
+  assert.match(merge, /workflow_run\.event == 'workflow_dispatch'/)
+  assert.match(merge, /workflow_run\.name == 'Build and smoke test'/)
+  assert.match(merge, /head_branch == 'automation\/verified-dependencies'/)
+})

--- a/tests/update-governance.test.mjs
+++ b/tests/update-governance.test.mjs
@@ -25,12 +25,13 @@ test('official DSH alpha discovery opens a review-only pull request', async () =
 })
 
 test('bot dependency branches run without pull-request workflow approval and merge only after qualification', async () => {
-  const [ci, merge] = await Promise.all([
+  const [ci, merge, stableIntake] = await Promise.all([
     read('.github/workflows/ci.yml'),
     read('.github/workflows/merge-verified-dependencies.yml'),
+    read('.github/workflows/upstream-watch.yml'),
   ])
 
-  assert.match(ci, /push:[\s\S]+branches:[\s\S]+main[\s\S]+automation\/verified-dependencies[\s\S]+automation\/official-preview/)
+  assert.match(ci, /push:\s*\n\s+branches:\s*\[main\]/)
   assert.match(ci, /^  product-qualification:/m)
   assert.match(ci, /name:\s*Product qualification/)
   assert.match(ci, /if:\s*\$\{\{ always\(\) \}\}/)
@@ -39,4 +40,6 @@ test('bot dependency branches run without pull-request workflow approval and mer
   assert.match(merge, /workflow_run\.event == 'workflow_dispatch'/)
   assert.match(merge, /workflow_run\.name == 'Build and smoke test'/)
   assert.match(merge, /head_branch == 'automation\/verified-dependencies'/)
+  assert.match(stableIntake, /actions:\s*write/)
+  assert.match(stableIntake, /gh workflow run ci\.yml[^\n]+--ref "\$BRANCH"/)
 })

--- a/tests/upstream-monitor.test.mjs
+++ b/tests/upstream-monitor.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { readFile } from 'node:fs/promises'
 
-import { evaluateUpstream } from '../scripts/upstream-state.mjs'
+import { evaluatePreviewUpstream, evaluateUpstream } from '../scripts/upstream-state.mjs'
 
 test('the upstream refresher supports both standard and bundled Windows Node layouts', async () => {
   const source = await readFile(new URL('../scripts/update-upstream.mjs', import.meta.url), 'utf8')
@@ -110,4 +110,62 @@ test('same-version integrity drift fails closed instead of silently replacing th
     registry: registry({ integrity: 'sha512-replaced' }),
     commit: { sha: 'b'.repeat(40) },
   }), /integrity changed for the pinned DSH version/i)
+})
+
+const previewLock = {
+  dsh: {
+    version: '0.1.2-alpha.2',
+    npmIntegrity: 'sha512-preview-current',
+    reviewedCommit: 'd'.repeat(40),
+  },
+}
+
+function previewRegistry({ alpha = '0.1.2-alpha.2', integrity = 'sha512-preview-current' } = {}) {
+  return {
+    'dist-tags': { alpha },
+    versions: {
+      [alpha]: { dist: { integrity } },
+    },
+  }
+}
+
+test('a newer official alpha becomes a review-only preview candidate', () => {
+  const result = evaluatePreviewUpstream({
+    lock: previewLock,
+    registry: previewRegistry({ alpha: '0.1.2-alpha.3', integrity: 'sha512-preview-next' }),
+    packageCommit: { sha: 'e'.repeat(40) },
+  })
+
+  assert.equal(result.changed, true)
+  assert.equal(result.version, '0.1.2-alpha.3')
+  assert.equal(result.integrity, 'sha512-preview-next')
+  assert.equal(result.commit, 'e'.repeat(40))
+})
+
+test('the official alpha monitor never downgrades the reviewed preview lock', () => {
+  const result = evaluatePreviewUpstream({
+    lock: previewLock,
+    registry: previewRegistry({ alpha: '0.1.2-alpha.1', integrity: 'sha512-preview-old' }),
+    packageCommit: { sha: 'c'.repeat(40) },
+  })
+
+  assert.equal(result.changed, false)
+  assert.equal(result.version, '0.1.2-alpha.2')
+  assert.equal(result.commit, 'd'.repeat(40))
+})
+
+test('same-version official alpha integrity drift fails closed', () => {
+  assert.throws(() => evaluatePreviewUpstream({
+    lock: previewLock,
+    registry: previewRegistry({ integrity: 'sha512-preview-replaced' }),
+    packageCommit: { sha: 'd'.repeat(40) },
+  }), /integrity changed for the pinned official alpha/i)
+})
+
+test('the official alpha monitor rejects a stable version on the alpha tag', () => {
+  assert.throws(() => evaluatePreviewUpstream({
+    lock: previewLock,
+    registry: previewRegistry({ alpha: '0.1.2', integrity: 'sha512-not-alpha' }),
+    packageCommit: { sha: 'e'.repeat(40) },
+  }), /does not point to an alpha prerelease/i)
 })

--- a/upstream.preview.lock.json
+++ b/upstream.preview.lock.json
@@ -5,6 +5,7 @@
     "package": "@deepseek-ai/dsh",
     "version": "0.1.2-alpha.2",
     "tag": "dsh-v0.1.2-alpha.2",
+    "npmIntegrity": "sha512-4TvTC5kRKlgtSU2UTBv+cID9a2Z+6+m6mpvjXWJfVzuTkflCff6s4MsQpFJTCmwFh/k7zNWe7qFXcLYMV/5VvA==",
     "sourceRepository": "https://github.com/deepseek-ai/deepseek-harness",
     "reviewedCommit": "0a53fb55bea101816fa226bb964ae2bed71c343b",
     "noticesSha256": "45c3d5ad23ea58fe6aaa2703488f74f03ea53cc0fa80c1024c24d63670570779",


### PR DESCRIPTION
Closes the remaining update-governance gaps without changing product versions or publishing an unreviewed DSH Alpha.\n\n- discovers the official npm alpha tag every six hours and opens a manual-review PR pinned to package integrity, source commit, and notices\n- explicitly dispatches the full product workflow for automation branches, avoiding pull-request workflow approval stalls\n- adds one fixed Product qualification check covering every Windows, macOS, and Linux leaf gate\n- keeps stable dependency auto-merge limited to a successful dispatched qualification; preview PRs remain manual\n\nLocal verification: 364/364 repository tests passed; live alpha monitor is a no-op on the current 0.1.2-alpha.2 lock.