### PR TITLE
Recover failed desktop renderers without restarting DSH

### DIFF
--- a/launcher/macos/DeepSeek-Herness.swift
+++ b/launcher/macos/DeepSeek-Herness.swift
@@ -50,6 +50,9 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
     private var automaticUpdateMenuItem: NSMenuItem!
     private var productUpdateMenuItem: NSMenuItem!
     private var engineUpdateMenuItem: NSMenuItem!
+    private var webContentRecoveryAttempts = 0
+    private var webContentRecoveryPending = false
+    private var webContentRecoveryFailureShown = false
 
     private var installedMode: Bool {
         Bundle.main.bundleIdentifier == "io.github.wsl043.dsh-portable.installed"
@@ -82,6 +85,38 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
 
     private var launcherSettingsURL: URL {
         productDataRoot.appendingPathComponent("launcher-settings.json")
+    }
+
+    private var launcherLogURL: URL {
+        productDataRoot.appendingPathComponent("logs/launcher.log")
+    }
+
+    private func writeLauncherLog(_ category: String, _ message: String) {
+        let sanitized = message.replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " | ")
+        let line = "\(ISO8601DateFormatter().string(from: Date())) [\(category)] \(sanitized)\n"
+        guard let data = line.data(using: .utf8) else { return }
+        do {
+            let logs = launcherLogURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+            if let size = try? launcherLogURL.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+               size > 2 * 1024 * 1024 {
+                let previous = logs.appendingPathComponent("launcher.log.previous")
+                try? FileManager.default.removeItem(at: previous)
+                try FileManager.default.moveItem(at: launcherLogURL, to: previous)
+            }
+            if !FileManager.default.fileExists(atPath: launcherLogURL.path) {
+                FileManager.default.createFile(atPath: launcherLogURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: launcherLogURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } catch {
+            if let diagnostic = ("DSH-Portable launcher log failed: \(error.localizedDescription)\n").data(using: .utf8) {
+                FileHandle.standardError.write(diagnostic)
+            }
+        }
     }
 
     private let nativeBridgeScript = """
@@ -908,6 +943,40 @@ private final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelega
         }
         if target.scheme == "http" || target.scheme == "https" { NSWorkspace.shared.open(target) }
         decisionHandler(.cancel)
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        writeLauncherLog("webview", "web-content-process-terminated")
+        guard backendStarted, !shuttingDown, !allowingClose else {
+            writeLauncherLog("webview-recovery", "ignored-during-shutdown")
+            return
+        }
+        guard !webContentRecoveryPending, webContentRecoveryAttempts < 1 else {
+            writeLauncherLog("webview-recovery", "failed reason=repeated-content-process-termination")
+            if !webContentRecoveryFailureShown {
+                webContentRecoveryFailureShown = true
+                let alert = NSAlert()
+                alert.messageText = L("工作台界面无法恢复", "The workspace interface could not recover")
+                alert.informativeText = L(
+                    "DeepSeek Harness 后端仍保持运行。请导出支持报告后重新打开应用。",
+                    "The DeepSeek Harness backend remains running. Export a support report, then reopen the app.")
+                alert.runModal()
+            }
+            return
+        }
+
+        webContentRecoveryPending = true
+        webContentRecoveryAttempts += 1
+        writeLauncherLog("webview-recovery", "begin mode=reload reason=content-process-terminated")
+        webView.reload()
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard webContentRecoveryPending else { return }
+        webContentRecoveryPending = false
+        webContentRecoveryAttempts = 0
+        webContentRecoveryFailureShown = false
+        writeLauncherLog("webview-recovery", "complete")
     }
 
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -346,6 +346,7 @@ namespace DshPortable
         private const int WebViewGracefulShutdownMs = 1500;
         private const int WebViewResourceInUseHResult = unchecked((int)0x800700AA);
         private const int WebViewInitializationMaxAttempts = 4;
+        private const int WebViewUnresponsivePromptThreshold = 2;
 
         private static string L(string chinese, string english)
         {
@@ -420,6 +421,10 @@ namespace DshPortable
         private TaskCompletionSource<CoreWebView2BrowserProcessExitedEventArgs> webViewBrowserExited;
         private int ownedWebViewBrowserProcessId;
         private bool testWebViewBusyInjected;
+        private bool testWebViewCrashInjected;
+        private bool webViewRecoveryRunning;
+        private bool webViewUnresponsivePromptVisible;
+        private int webViewUnresponsiveCount;
 
         internal LauncherWindow(string[] args, string selectedEnvironmentId, string selectedStateRoot, int environmentRestoreMessage, int environmentExitMessage)
         {
@@ -1915,6 +1920,9 @@ namespace DshPortable
         {
             RecordWebViewPhase("browser-exited:" + eventArgs.BrowserProcessExitKind);
             if (webViewBrowserExited != null) webViewBrowserExited.TrySetResult(eventArgs);
+            if (desktopReady && !shutdownRunning && !allowClose
+                && String.Equals(eventArgs.BrowserProcessExitKind.ToString(), "Failed", StringComparison.OrdinalIgnoreCase))
+                ScheduleWebViewRecovery(true, "browser-process-exited");
         }
 
         private async Task WaitForWebViewExitAsync(int timeoutMs)
@@ -2958,11 +2966,110 @@ namespace DshPortable
             string failure = eventArgs.ProcessFailedKind + "/" + eventArgs.Reason
                 + " exit=" + eventArgs.ExitCode
                 + (String.IsNullOrWhiteSpace(eventArgs.ProcessDescription) ? "" : " " + eventArgs.ProcessDescription);
-            RecordWebViewPhase("process-failed:" + failure);
+            if (desktopReady) WriteLauncherLog("webview", "process-failed:" + failure);
+            else RecordWebViewPhase("process-failed:" + failure);
             if (webViewProcessFailure != null) webViewProcessFailure.TrySetResult(failure);
+            if (!desktopReady || shutdownRunning || allowClose) return;
+
+            if (eventArgs.ProcessFailedKind == CoreWebView2ProcessFailedKind.RenderProcessExited)
+                ScheduleWebViewRecovery(false, "renderer-process-exited");
+            else if (eventArgs.ProcessFailedKind == CoreWebView2ProcessFailedKind.BrowserProcessExited)
+                ScheduleWebViewRecovery(true, "browser-process-exited");
+            else if (eventArgs.ProcessFailedKind == CoreWebView2ProcessFailedKind.RenderProcessUnresponsive)
+                ScheduleWebViewUnresponsivePrompt(failure);
         }
 
-        private async Task NavigateWorkspaceAsync(string url, bool updated)
+        private void ScheduleWebViewRecovery(bool recreate, string reason)
+        {
+            if (!IsHandleCreated || IsDisposed || Disposing || shutdownRunning || allowClose) return;
+            if (InvokeRequired)
+            {
+                try { BeginInvoke(new Action<bool, string>(ScheduleWebViewRecovery), recreate, reason); }
+                catch (InvalidOperationException) { }
+                return;
+            }
+            if (webViewRecoveryRunning) return;
+            Task ignored = RecoverWebViewAsync(recreate, reason);
+        }
+
+        private void ScheduleWebViewUnresponsivePrompt(string failure)
+        {
+            if (!IsHandleCreated || IsDisposed || Disposing || shutdownRunning || allowClose) return;
+            if (InvokeRequired)
+            {
+                try { BeginInvoke(new Action<string>(ScheduleWebViewUnresponsivePrompt), failure); }
+                catch (InvalidOperationException) { }
+                return;
+            }
+            webViewUnresponsiveCount += 1;
+            WriteLauncherLog("webview-unresponsive", "observation="
+                + webViewUnresponsiveCount.ToString(CultureInfo.InvariantCulture) + " " + failure);
+            if (webViewUnresponsiveCount < WebViewUnresponsivePromptThreshold
+                || webViewUnresponsivePromptVisible
+                || webViewRecoveryRunning) return;
+
+            webViewUnresponsivePromptVisible = true;
+            try
+            {
+                DialogResult decision = MessageBox.Show(this,
+                    L(
+                        "工作台持续无响应。可以继续等待，或只重新加载界面；正在运行的 DeepSeek Harness 后端和会话不会重启。\r\n\r\n是否重新加载界面？",
+                        "The workspace remains unresponsive. You can keep waiting or reload only the interface; the running DeepSeek Harness backend and sessions will not restart.\r\n\r\nReload the interface?"),
+                    L("DeepSeek Harness 无响应", "DeepSeek Harness is not responding"),
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Warning,
+                    MessageBoxDefaultButton.Button2);
+                if (decision == DialogResult.Yes) ScheduleWebViewRecovery(false, "renderer-unresponsive");
+                else WriteLauncherLog("webview-unresponsive", "user-kept-waiting");
+            }
+            finally { webViewUnresponsivePromptVisible = false; }
+        }
+
+        private async Task RecoverWebViewAsync(bool recreate, string reason)
+        {
+            if (webViewRecoveryRunning || shutdownRunning || allowClose) return;
+            Uri target = applicationUri;
+            if (target == null || !IsTrustedLoopbackUrl(target.AbsoluteUri)) return;
+
+            webViewRecoveryRunning = true;
+            WriteLauncherLog("webview-recovery", "begin mode=" + (recreate ? "recreate" : "reload") + " reason=" + reason);
+            try
+            {
+                launchPanel.Visible = true;
+                launchPanel.BringToFront();
+                statusLabel.Text = L("正在恢复工作台界面…", "Recovering the workspace interface…");
+                progressDetail.Visible = false;
+                activityRing.Indeterminate = true;
+                activityRing.Visible = true;
+
+                if (recreate)
+                {
+                    Task browserExited = webViewBrowserExited == null
+                        ? (Task)Task.FromResult<object>(null)
+                        : webViewBrowserExited.Task;
+                    await Task.WhenAny(browserExited, Task.Delay(5000));
+                    ResetWebViewAfterInitializationFailure();
+                    await InitializeWebViewAsync();
+                    await NavigateWorkspaceAsync(target.AbsoluteUri, false, false);
+                }
+                else await NavigateWorkspaceAsync(target.AbsoluteUri, false, true);
+
+                webViewUnresponsiveCount = 0;
+                WriteLauncherLog("webview-recovery", "complete mode=" + (recreate ? "recreate" : "reload") + " reason=" + reason);
+            }
+            catch (Exception error)
+            {
+                string message = error.GetBaseException().Message.Replace("\r", " ").Replace("\n", " | ");
+                WriteLauncherLog("webview-recovery", "failed mode=" + (recreate ? "recreate" : "reload")
+                    + " reason=" + reason + " error=" + error.GetBaseException().GetType().Name + ":" + message);
+                ShowFailure(L(
+                    "工作台界面恢复失败。DeepSeek Harness 后端仍保持运行；请导出支持报告后重新打开应用。\r\n",
+                    "The workspace interface could not recover. The DeepSeek Harness backend remains running; export a support report, then reopen the app.\r\n") + message);
+            }
+            finally { webViewRecoveryRunning = false; }
+        }
+
+        private async Task NavigateWorkspaceAsync(string url, bool updated, bool reload = false)
         {
             TaskCompletionSource<CoreWebView2NavigationCompletedEventArgs> navigation =
                 new TaskCompletionSource<CoreWebView2NavigationCompletedEventArgs>();
@@ -2999,8 +3106,16 @@ namespace DshPortable
                 if (launchPanel.Visible) launchPanel.BringToFront();
             }
             else launchPanel.BringToFront();
-            RecordWebViewPhase("navigation-start:" + SafeWorkspaceUrl(url));
-            webView.CoreWebView2.Navigate(url);
+            if (reload)
+            {
+                RecordWebViewPhase("navigation-reload:" + SafeWorkspaceUrl(url));
+                webView.CoreWebView2.Reload();
+            }
+            else
+            {
+                RecordWebViewPhase("navigation-start:" + SafeWorkspaceUrl(url));
+                webView.CoreWebView2.Navigate(url);
+            }
             Task timeout = Task.Delay(WorkspaceNavigationTimeoutMs);
             Task winner = await Task.WhenAny(workspaceUsable.Task, navigation.Task, webViewProcessFailure.Task, timeout);
             if (winner == navigation.Task)
@@ -3065,6 +3180,11 @@ namespace DshPortable
             catch (DllNotFoundException) { }
             catch (EntryPointNotFoundException) { }
             launchPanel.Visible = false;
+            if (webViewRecoveryRunning)
+            {
+                WriteLauncherLog("webview-recovery", "surface-ready");
+                return;
+            }
             WriteLauncherLog("startup", "dsh-first-paint-ready");
             AppendStartupTrace("native-host", "interactive-ready", null);
             bool updateHealthReady = WriteUpdateHealthMarker();
@@ -3080,6 +3200,31 @@ namespace DshPortable
                 ShowInTaskbar = true;
                 if (Opacity < 1) Opacity = 1;
             }
+            InjectTestWebViewCrashAfterReady();
+        }
+
+        private void InjectTestWebViewCrashAfterReady()
+        {
+            if (testWebViewCrashInjected
+                || (!hiddenForAutomation
+                    && !String.Equals(Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_AUTOMATION"), "1", StringComparison.Ordinal))
+                || !String.Equals(Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_WEBVIEW2_CRASH_AFTER_READY"), "1", StringComparison.Ordinal)
+                || webView == null
+                || webView.CoreWebView2 == null) return;
+            testWebViewCrashInjected = true;
+            BeginInvoke(new Action(async delegate
+            {
+                await Task.Delay(500);
+                try
+                {
+                    WriteLauncherLog("webview-test", "renderer-crash-requested");
+                    await webView.CoreWebView2.CallDevToolsProtocolMethodAsync("Page.crash", "{}");
+                }
+                catch (Exception error)
+                {
+                    WriteLauncherLog("webview-test", "renderer-crash-call-ended " + error.GetBaseException().GetType().Name);
+                }
+            }));
         }
 
         private bool WriteUpdateHealthMarker()

--- a/scripts/smoke-windows-desktop-host.ps1
+++ b/scripts/smoke-windows-desktop-host.ps1
@@ -151,6 +151,8 @@ try {
     $StartInfo.UseShellExecute = $false
     $StartInfo.EnvironmentVariables['DSH_PORTABLE_SKIP_UPDATE_CHECK'] = '1'
     $StartInfo.EnvironmentVariables['DSH_PORTABLE_STARTUP_HOLD_MS'] = '1200'
+    $StartInfo.EnvironmentVariables['DSH_PORTABLE_TEST_AUTOMATION'] = '1'
+    $StartInfo.EnvironmentVariables['DSH_PORTABLE_TEST_WEBVIEW2_CRASH_AFTER_READY'] = '1'
     $Process = [System.Diagnostics.Process]::Start($StartInfo)
 
     $StartupDeadline = [DateTime]::UtcNow.AddSeconds(20)
@@ -205,6 +207,24 @@ try {
     }
     if ($EmbeddedRenderers.Count -eq 0) { throw 'The native window did not initialize its embedded WebView2 renderer.' }
     $ColdStartClock.Stop()
+
+    $BackendPidBeforeRecovery = (Get-Content -Raw -LiteralPath $ProcessState | ConvertFrom-Json).pid
+    $RecoveryDeadline = [DateTime]::UtcNow.AddSeconds(30)
+    do {
+        Start-Sleep -Milliseconds 100
+        $Process.Refresh()
+        if ($Process.HasExited) { throw "Desktop host exited during renderer recovery: $($Process.ExitCode)" }
+        $RecoveryLog = Get-LauncherLogSinceStart
+    } while ($RecoveryLog -notmatch 'webview-recovery\] complete mode=reload reason=renderer-process-exited' -and [DateTime]::UtcNow -lt $RecoveryDeadline)
+    if ($RecoveryLog -notmatch 'webview-recovery\] complete mode=reload reason=renderer-process-exited') {
+        throw "The native desktop did not recover its crashed WebView2 renderer:`n$RecoveryLog"
+    }
+    $BackendPidAfterRecovery = (Get-Content -Raw -LiteralPath $ProcessState | ConvertFrom-Json).pid
+    if ($BackendPidAfterRecovery -ne $BackendPidBeforeRecovery) {
+        throw "WebView2 renderer recovery restarted the DSH backend ($BackendPidBeforeRecovery -> $BackendPidAfterRecovery)."
+    }
+    if ((Get-ProductStatus).Status -ne 'running') { throw 'WebView2 renderer recovery stopped the DSH backend.' }
+    $StartInfo.EnvironmentVariables.Remove('DSH_PORTABLE_TEST_WEBVIEW2_CRASH_AFTER_READY')
 
     # Resize through Win32 without desktop input. Closing to the tray must save
     # these bounds so a later native-host process can restore them.

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -413,6 +413,38 @@ test('macOS GUI is a native WKWebView app rather than a Chrome app-mode launcher
   assert.match(build, /swiftc[\s\S]+DeepSeek-Herness\.swift/)
 })
 
+test('native desktop hosts diagnose renderer failures and recover without restarting DSH', async () => {
+  const [windowsHost, windowsSmoke, macHost] = await Promise.all([
+    read('launcher/windows/DSH-Portable.cs'),
+    read('scripts/smoke-windows-desktop-host.ps1'),
+    read('launcher/macos/DeepSeek-Herness.swift'),
+  ])
+
+  const windowsFailure = windowsHost.slice(
+    windowsHost.indexOf('private void OnWebViewProcessFailed'),
+    windowsHost.indexOf('private async Task NavigateWorkspaceAsync'),
+  )
+  assert.match(windowsFailure, /CoreWebView2ProcessFailedKind\.RenderProcessExited/)
+  assert.match(windowsFailure, /CoreWebView2ProcessFailedKind\.BrowserProcessExited/)
+  assert.match(windowsFailure, /CoreWebView2ProcessFailedKind\.RenderProcessUnresponsive/)
+  assert.match(windowsFailure, /desktopReady[^\n]+WriteLauncherLog\(["]webview["], ["]process-failed:/)
+  assert.match(windowsFailure, /RecoverWebViewAsync/)
+  assert.match(windowsFailure, /MessageBoxButtons\.YesNo/)
+  assert.match(windowsHost, /webview-recovery["], ["]begin/)
+  assert.match(windowsHost, /webview-recovery["], ["]complete/)
+  assert.match(windowsHost, /webViewRecoveryRunning/)
+  assert.match(windowsHost, /ResetWebViewAfterInitializationFailure\(\)[\s\S]+InitializeWebViewAsync\(\)/)
+  assert.match(windowsHost, /CoreWebView2\.Reload\(\)/)
+  assert.match(windowsSmoke, /DSH_PORTABLE_TEST_WEBVIEW2_CRASH_AFTER_READY/)
+  assert.match(windowsSmoke, /webview-recovery.+complete/)
+  assert.match(windowsSmoke, /renderer recovery restarted the DSH backend/i)
+
+  assert.match(macHost, /func webViewWebContentProcessDidTerminate\(_ webView: WKWebView\)/)
+  assert.match(macHost, /webContentRecoveryAttempts/)
+  assert.match(macHost, /webView\.reload\(\)/)
+  assert.match(macHost, /writeLauncherLog\(["]webview-recovery["], ["]complete["]\)/)
+})
+
 test('CI release gate verifies native desktop ownership, lifecycle, and application identity', async () => {
   const [workflow, windowsSmoke, detachedUpdaterSmoke, traySmoke, nativeDownloadSmoke, nativeWorkspacePickerSmoke, parallelRootsSmoke, macSmoke] = await Promise.all([
     read('.github/workflows/ci.yml'),


### PR DESCRIPTION
## Summary
- recover a crashed Windows WebView2 renderer without restarting the running DSH backend or session
- recreate the Windows WebView after a failed browser process and offer a user-controlled reload after repeated unresponsive events
- recover a terminated macOS WKWebView content process once per incident and write bounded recovery diagnostics
- exercise the Windows renderer-crash path in the finished-product desktop smoke test

## Verification
- `node --test tests/*.test.mjs` — 364/364 passed
- Windows launcher contract compiled successfully as part of the test suite
- local packaged Windows smoke injected a real renderer crash, recovered the workspace, and confirmed the DSH backend PID did not change