### PR TITLE
Fix core update compatibility and recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
         with:
           name: windows-x64-build
           path: artifacts
-      - name: Upgrade a running published release through the complete-package boundary
+      - name: Upgrade the immediate prior same-channel release through its declared delivery path
         shell: powershell
         env:
           GH_TOKEN: ${{ github.token }}
@@ -423,32 +423,23 @@ jobs:
               -not $_.isPrerelease -and $_.tagName -match '^v\d+\.\d+\.\d+$' -and $_.tagName -ne "v$CandidateVersion"
             } | Sort-Object publishedAt -Descending
           }
-          $PriorTag = $null
-          $PriorZip = $null
-          foreach ($Release in $Eligible) {
-            $TagDir = Join-Path $env:RUNNER_TEMP ("prior-release-" + $Release.tagName.TrimStart('v'))
-            New-Item -ItemType Directory -Force -Path $TagDir | Out-Null
-            gh release download $Release.tagName --repo "$env:GITHUB_REPOSITORY" `
-              --pattern 'DSH-Portable-windows-x64-offline.zip' --dir $TagDir
-            $Zip = Join-Path $TagDir 'DSH-Portable-windows-x64-offline.zip'
-            $ComponentsJson = tar.exe -xOf $Zip DSH-Portable/licenses/COMPONENTS.json
-            if ($LASTEXITCODE -ne 0 -or -not $ComponentsJson) {
-              throw "Could not read COMPONENTS.json from $($Release.tagName)."
-            }
-            $Components = $ComponentsJson | ConvertFrom-Json
-            $CrossesBoundary = [int]$Components.shellSchema -lt [int]$Target.requiredShellSchema `
-              -or [string]$Components.runtimeLayout -ne [string]$Target.targetRuntimeLayout
-            if ($CrossesBoundary) {
-              $PriorTag = $Release.tagName
-              $PriorZip = $Zip
-              break
-            }
-          }
+          $Prior = $Eligible | Select-Object -First 1
+          $PriorTag = $Prior.tagName
           if (-not $PriorTag) {
-            Write-Host 'No published release crosses this complete-package boundary; nothing to test.'
+            Write-Host 'No immediate prior release exists for this channel; nothing to test.'
             exit 0
           }
-          Write-Host "Testing complete-package upgrade from $PriorTag to $CandidateVersion."
+          $TagDir = Join-Path $env:RUNNER_TEMP ("prior-release-" + $PriorTag.TrimStart('v'))
+          New-Item -ItemType Directory -Force -Path $TagDir | Out-Null
+          gh release download $PriorTag --repo "$env:GITHUB_REPOSITORY" `
+            --pattern 'DSH-Portable-windows-x64-offline.zip' --dir $TagDir
+          $PriorZip = Join-Path $TagDir 'DSH-Portable-windows-x64-offline.zip'
+          $ComponentsJson = tar.exe -xOf $PriorZip DSH-Portable/licenses/COMPONENTS.json
+          if ($LASTEXITCODE -ne 0 -or -not $ComponentsJson) {
+            throw "Could not read COMPONENTS.json from $PriorTag."
+          }
+          $Components = $ComponentsJson | ConvertFrom-Json
+          Write-Host "Testing declared upgrade path from $PriorTag to $CandidateVersion."
           $UpgradeArguments = @(
             'scripts/smoke-windows-version-upgrade.mjs',
             $PriorZip,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../desktop-bridge": {
       "name": "@wsl043/dsh-portable-desktop-bridge",
-      "version": "0.6.0-rc.2",
+      "version": "0.6.0-rc.3",
       "license": "Apache-2.0"
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.6.0-rc.2"
+  #define AppVersion "0.6.0-rc.3"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.6.0.2
+VersionInfoVersion=0.6.0.3
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/launcher/diagnostic-policy.mjs
+++ b/launcher/diagnostic-policy.mjs
@@ -21,6 +21,7 @@ export function classifyPortableError(error) {
   const source = String(error?.stack ?? error?.message ?? error ?? '')
   if (/restored but could not restart|previous version could not be restarted/i.test(source)) return 'UPDATE_RECOVERY_FAILED'
   if (/rolled back[\s\S]*previous version was restored and restarted/i.test(source)) return 'UPDATE_ROLLED_BACK'
+  if (/Another portable launcher is already starting or stopping DSH/i.test(source)) return 'LAUNCH_IN_PROGRESS'
   if (/Close the other Portable environment/i.test(source)) return 'SHARED_COMPONENTS_BUSY'
   if (/EADDRINUSE|address already in use/i.test(source)) return 'PORT_IN_USE'
   if (/DeepSeek Harness failed to start|DSH runtime did not pass|workspace did not become ready/i.test(source)) return 'DSH_START_FAILED'
@@ -35,6 +36,7 @@ export function portablePublicError(error) {
     UPDATE_RECOVERY_FAILED: 'The update failed and the previous version could not be restarted. Reopen DSH-Portable and export a support report.',
     PORT_IN_USE: 'The local DSH service port is already in use. Close the other DSH instance and try again.',
     DSH_START_FAILED: 'DeepSeek Harness did not become ready. Reopen DSH-Portable and export a support report.',
+    LAUNCH_IN_PROGRESS: 'DSH-Portable is already starting or stopping. Try again in a moment.',
     SHARED_COMPONENTS_BUSY: 'Close the other running DSH-Portable environments before changing shared components.',
     UPDATE_FAILED: 'The update could not be completed. The installation was left in a recoverable state; export a support report for details.',
     PORTABLE_COMMAND_FAILED: 'DSH-Portable could not complete the requested operation. Export a support report for details.',

--- a/launcher/diagnostic-policy.mjs
+++ b/launcher/diagnostic-policy.mjs
@@ -1,0 +1,73 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+const MAX_DIAGNOSTIC_BYTES = 256 * 1024
+const MAX_ERROR_DETAIL_CHARS = 32 * 1024
+
+export function redactDiagnosticText(source) {
+  let value = String(source ?? '')
+  value = value.replace(/(["'](?:[^"']*(?:token|password|secret|authorization|cookie|api[_-]?key)[^"']*)["']\s*:\s*)["'][^"']*["']/gi, '$1"[REDACTED]"')
+  value = value.replace(/\b(Bearer\s+)[^\s"']+/gi, '$1[REDACTED]')
+  value = value.replace(/\b([A-Za-z0-9_.-]*(?:token|password|secret|authorization|cookie|api[_-]?key)[A-Za-z0-9_.-]*)\b\s*[:=]\s*([^\s,;}&]+)/gi, '$1=[REDACTED]')
+  value = value.replace(/([?&](?:token|access_token|auth|authorization)=)[^&#\s]+/gi, '$1[REDACTED]')
+  value = value.replace(/\bsk-[A-Za-z0-9_-]{6,}\b/g, '[REDACTED]')
+  const home = os.homedir()
+  if (home) value = value.replaceAll(home, '<USER_HOME>')
+  return value
+}
+
+export function classifyPortableError(error) {
+  const source = String(error?.stack ?? error?.message ?? error ?? '')
+  if (/restored but could not restart|previous version could not be restarted/i.test(source)) return 'UPDATE_RECOVERY_FAILED'
+  if (/rolled back[\s\S]*previous version was restored and restarted/i.test(source)) return 'UPDATE_ROLLED_BACK'
+  if (/Close the other Portable environment/i.test(source)) return 'SHARED_COMPONENTS_BUSY'
+  if (/EADDRINUSE|address already in use/i.test(source)) return 'PORT_IN_USE'
+  if (/DeepSeek Harness failed to start|DSH runtime did not pass|workspace did not become ready/i.test(source)) return 'DSH_START_FAILED'
+  if (/\bupdate\b/i.test(source)) return 'UPDATE_FAILED'
+  return 'PORTABLE_COMMAND_FAILED'
+}
+
+export function portablePublicError(error) {
+  const code = classifyPortableError(error)
+  const messages = {
+    UPDATE_ROLLED_BACK: 'The update did not pass startup validation. The previous version was restored and restarted. Details were saved to the support log.',
+    UPDATE_RECOVERY_FAILED: 'The update failed and the previous version could not be restarted. Reopen DSH-Portable and export a support report.',
+    PORT_IN_USE: 'The local DSH service port is already in use. Close the other DSH instance and try again.',
+    DSH_START_FAILED: 'DeepSeek Harness did not become ready. Reopen DSH-Portable and export a support report.',
+    SHARED_COMPONENTS_BUSY: 'Close the other running DSH-Portable environments before changing shared components.',
+    UPDATE_FAILED: 'The update could not be completed. The installation was left in a recoverable state; export a support report for details.',
+    PORTABLE_COMMAND_FAILED: 'DSH-Portable could not complete the requested operation. Export a support report for details.',
+  }
+  return { code, message: messages[code] }
+}
+
+export async function recordPortableDiagnostic(logsDir, { operation = 'unknown', error } = {}) {
+  if (!logsDir) return null
+  try {
+    await mkdir(logsDir, { recursive: true })
+    const filename = path.join(logsDir, 'portable-errors.jsonl')
+    const previous = `${filename}.previous`
+    let existing = Buffer.alloc(0)
+    try { existing = await readFile(filename) } catch (readError) {
+      if (readError?.code !== 'ENOENT') throw readError
+    }
+    const detail = redactDiagnosticText(error?.stack ?? error?.message ?? error ?? '').slice(0, MAX_ERROR_DETAIL_CHARS)
+    const entry = Buffer.from(`${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      operation,
+      code: classifyPortableError(error),
+      detail,
+    })}\n`, 'utf8')
+    if (existing.length + entry.length > MAX_DIAGNOSTIC_BYTES) {
+      await rm(previous, { force: true })
+      if (existing.length) await rename(filename, previous)
+      existing = Buffer.alloc(0)
+    }
+    const next = existing.length ? Buffer.concat([existing, entry]) : entry
+    await writeFile(filename, next, { mode: 0o600 })
+    return filename
+  } catch {
+    return null
+  }
+}

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.6.0-rc.2",
+      "version": "0.6.0-rc.3",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.6.0-rc.2</string>
+	<string>0.6.0-rc.3</string>
   <key>CFBundleVersion</key>
-	<string>6000002</string>
+	<string>6000003</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/portable-cli.mjs
+++ b/launcher/portable-cli.mjs
@@ -44,6 +44,7 @@ import { diagnosePortable, exportPortableSupportReport, repairPortable } from '.
 import { createDataArchive, inspectDataArchive, restoreDataArchive } from './data-transfer.mjs'
 import { cleanUnusedRuntimeCaches, ensureRuntimeCapsule, runtimeCacheStatus } from './runtime-capsule.mjs'
 import { appendStartupTrace, beginStartupTrace, traceFromEnvironment } from './startup-trace.mjs'
+import { portablePublicError, recordPortableDiagnostic } from './diagnostic-policy.mjs'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const baseStateRoot = process.env.DSH_PORTABLE_STATE_ROOT || root
@@ -55,6 +56,7 @@ let layout = layoutForRoot(
 )
 let startupTrace = traceFromEnvironment(layout.logsDir)
 let startupProgressJson = false
+let activeOptions = null
 const BROWSER_GRACEFUL_SHUTDOWN_MS = 5000
 const BROWSER_FORCE_SHUTDOWN_MS = 15000
 
@@ -755,6 +757,7 @@ async function update(options) {
     await deferUpdate(layout, { scope: options.updateScope }).catch(() => {})
     let recovery = null
     try {
+      reportProgress({ phase: 'restarting-previous' })
       const restored = await ensureRuntimeCapsule(root)
       layout = layoutForRoot(
         root,
@@ -764,6 +767,7 @@ async function update(options) {
         layout.environmentId,
       )
       recovery = await start(options.noBrowser)
+      reportProgress({ phase: 'recovered' })
     } catch (recoveryError) {
       throw new Error(`${error?.message ?? error}\nThe previous version was restored but could not restart: ${recoveryError?.message ?? recoveryError}`, { cause: error })
     }
@@ -794,6 +798,7 @@ function print(result, json) {
 async function main() {
   if (!['win32', 'darwin', 'linux'].includes(process.platform)) throw new Error('DSH-Portable supports Windows, macOS, and Linux.')
   const options = parseCli(process.argv.slice(2))
+  activeOptions = options
   startupProgressJson = options.command === 'start' && options.progressJson
   const environmentId = options.environment || process.env.DSH_PORTABLE_ENVIRONMENT || 'default'
   const stateRoot = environmentStateRoot(baseStateRoot, environmentId, process.platform)
@@ -862,7 +867,13 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error?.stack ?? String(error))
+main().catch(async (error) => {
+  await recordPortableDiagnostic(layout?.logsDir, {
+    operation: activeOptions?.command || 'unknown',
+    error,
+  })
+  const publicError = portablePublicError(error)
+  if (activeOptions?.json) console.error(JSON.stringify({ type: 'portable-error', schemaVersion: 1, ...publicError }))
+  else console.error(publicError.message)
   process.exitCode = 1
 })

--- a/launcher/repair-core.mjs
+++ b/launcher/repair-core.mjs
@@ -12,6 +12,7 @@ import {
   inspectPackagedDshRuntime,
   repairManagedProfileModuleFallback,
 } from './portable-core.mjs'
+import { redactDiagnosticText } from './diagnostic-policy.mjs'
 
 const REPORT_SCHEMA = 1
 const LOG_TAIL_BYTES = 64 * 1024
@@ -22,6 +23,8 @@ const LOG_NAMES = Object.freeze([
   'launcher.log.previous',
   'dsh.stdout.log',
   'dsh.stderr.log',
+  'portable-errors.jsonl',
+  'portable-errors.jsonl.previous',
 ])
 const execFileAsync = promisify(execFile)
 const WINDOWS_DIAGNOSTIC_PROCESSES = Object.freeze([
@@ -133,21 +136,10 @@ export async function repairPortable(layout, { running = false } = {}) {
   return { ...after, deferred: false, actions }
 }
 
-function redact(source) {
-  let value = String(source ?? '')
-  value = value.replace(/(["'](?:api[_-]?key|token|password|secret|authorization|cookie)["']\s*:\s*)["'][^"']*["']/gi, '$1"[REDACTED]"')
-  value = value.replace(/\b(Bearer\s+)[^\s"']+/gi, '$1[REDACTED]')
-  value = value.replace(/\b(api[_-]?key|token|password|secret|authorization|cookie)\b\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]')
-  value = value.replace(/\bsk-[A-Za-z0-9_-]{6,}\b/g, '[REDACTED]')
-  const home = os.homedir()
-  if (home) value = value.replaceAll(home, '<USER_HOME>')
-  return value
-}
-
 async function logTail(filename) {
   try {
     const source = await readFile(filename)
-    return redact(source.subarray(Math.max(0, source.length - LOG_TAIL_BYTES)).toString('utf8'))
+    return redactDiagnosticText(source.subarray(Math.max(0, source.length - LOG_TAIL_BYTES)).toString('utf8'))
   } catch (error) {
     if (error?.code === 'ENOENT') return ''
     return `unreadable: ${error?.code || error?.message || 'unknown'}`

--- a/launcher/update-core.mjs
+++ b/launcher/update-core.mjs
@@ -100,6 +100,9 @@ function assertManifestShape(manifest) {
   if (manifest.updateKind != null && !['product', 'engine'].includes(manifest.updateKind)) {
     throw new Error(`Unsupported update kind: ${manifest.updateKind}`)
   }
+  if (manifest.requiredShellFingerprint != null && !/^[a-f0-9]{64}$/i.test(String(manifest.requiredShellFingerprint))) {
+    throw new Error('Update manifest shell fingerprint is invalid.')
+  }
 }
 
 export function evaluateUpdate(manifest, installed, platform) {
@@ -157,6 +160,7 @@ export function evaluateUpdate(manifest, installed, platform) {
   const component = manifest.component
   if (
     Number(manifest.requiredShellSchema ?? 0) > Number(installed.shellSchema ?? 0)
+    || (manifest.requiredShellFingerprint && manifest.requiredShellFingerprint !== installed.shellFingerprint)
     || (manifest.targetRuntimeLayout && manifest.targetRuntimeLayout !== (installed.runtimeLayout || 'expanded-v1'))
     || !component.requiredNodeVersion
     || component.requiredNodeVersion !== installed.nodeVersion
@@ -172,6 +176,7 @@ export function evaluateUpdate(manifest, installed, platform) {
     platform: manifest.platform,
     minimumUpdaterSchema: Number(manifest.minimumUpdaterSchema),
     requiredShellSchema: Number(manifest.requiredShellSchema),
+    requiredShellFingerprint: manifest.requiredShellFingerprint || null,
     component,
   }
 }
@@ -529,7 +534,7 @@ export async function resetManagedProfileModuleFallback(layout) {
   return fallback
 }
 
-export async function applyStagedAppUpdate({ layout, stagedRoot, healthCheck, beforeRollback = async () => {} }) {
+export async function applyStagedAppUpdate({ layout, stagedRoot, healthCheck, beforeRollback = async () => {}, onProgress = () => {} }) {
   if (await readJson(layout.updateJournal, null)) throw new Error('A prior update must be recovered before another update can start.')
   const metadata = await readJson(path.join(stagedRoot, 'component.json'), null)
   if (metadata?.schemaVersion !== UPDATE_SCHEMA_VERSION || metadata.kind !== 'dsh-app') throw new Error('Staged update metadata is invalid.')
@@ -568,13 +573,16 @@ export async function applyStagedAppUpdate({ layout, stagedRoot, healthCheck, be
     await resetManagedProfileModuleFallback(layout)
     await writeJournal(layout, { operationId, phase: 'testing', hadLicenses })
 
+    onProgress({ phase: 'validating' })
     const healthy = await healthCheck(metadata)
     if (!healthy) throw new Error('The updated DSH runtime did not pass its health check.')
     await writeJournal(layout, { operationId, phase: 'committed', hadLicenses })
   } catch (error) {
     if (error?.leavePending) throw error
+    onProgress({ phase: 'rolling-back' })
     await beforeRollback(error)
     await rollbackPendingAppUpdate(layout)
+    onProgress({ phase: 'rollback-complete' })
     throw new Error(`Update failed and was rolled back: ${error?.message ?? error}`, { cause: error })
   }
   let cleanupPending = false
@@ -587,7 +595,7 @@ export async function applyStagedAppUpdate({ layout, stagedRoot, healthCheck, be
   return { status: 'updated', portableVersion: metadata.portableVersion, dshVersion: metadata.dshVersion, cleanupPending }
 }
 
-export async function applyStagedCapsuleUpdate({ layout, stagedRoot, healthCheck, beforeRollback = async () => {} }) {
+export async function applyStagedCapsuleUpdate({ layout, stagedRoot, healthCheck, beforeRollback = async () => {}, onProgress = () => {} }) {
   if (await readJson(layout.updateJournal, null)) throw new Error('A prior update must be recovered before another update can start.')
   if (!layout.capsuleMode) throw new Error('A compact runtime update cannot be applied to an expanded installation.')
   const metadata = await readJson(path.join(stagedRoot, 'component.json'), null)
@@ -643,12 +651,15 @@ export async function applyStagedCapsuleUpdate({ layout, stagedRoot, healthCheck
       await rename(path.join(stagedLicenses, name), rootFile)
     }
     await writeJournal(layout, { operationId, kind: metadata.kind, phase: 'testing', hadLicenses })
+    onProgress({ phase: 'validating' })
     if (!await healthCheck(metadata)) throw new Error('The updated compact DSH runtime did not pass its health check.')
     await writeJournal(layout, { operationId, kind: metadata.kind, phase: 'committed', hadLicenses })
   } catch (error) {
     if (error?.leavePending) throw error
+    onProgress({ phase: 'rolling-back' })
     await beforeRollback(error)
     await rollbackPendingAppUpdate(layout)
+    onProgress({ phase: 'rollback-complete' })
     throw new Error(`Update failed and was rolled back: ${error?.message ?? error}`, { cause: error })
   }
   let cleanupPending = false
@@ -709,10 +720,13 @@ export async function installAvailableAppUpdate({
       || Number(components.shellSchema) < Number(update.requiredShellSchema)) {
       throw new Error('Downloaded component compatibility metadata does not match its manifest.')
     }
+    if (update.requiredShellFingerprint && components.shellFingerprint !== update.requiredShellFingerprint) {
+      throw new Error('Downloaded component shell fingerprint does not match its manifest.')
+    }
     onProgress({ phase: 'installing' })
     const applied = metadata.kind === 'dsh-runtime-capsule'
-      ? await applyStagedCapsuleUpdate({ layout, stagedRoot, healthCheck, beforeRollback })
-      : await applyStagedAppUpdate({ layout, stagedRoot, healthCheck, beforeRollback })
+      ? await applyStagedCapsuleUpdate({ layout, stagedRoot, healthCheck, beforeRollback, onProgress })
+      : await applyStagedAppUpdate({ layout, stagedRoot, healthCheck, beforeRollback, onProgress })
     onProgress({ phase: 'complete', percent: 100 })
     return { ...applied, updateKind: update.updateKind || 'product' }
   } catch (error) {

--- a/launcher/update-core.mjs
+++ b/launcher/update-core.mjs
@@ -345,6 +345,7 @@ export async function readInstalledUpdateState(layout) {
     dshVersion: components.dshVersion,
     updaterSchema: Number(components.updaterSchema ?? 0),
     shellSchema: Number(components.shellSchema ?? 0),
+    shellFingerprint: components.shellFingerprint ?? '',
     nodeVersion: components.nodeVersion ?? '',
     runtimeLayout: components.runtimeLayout || 'expanded-v1',
   }

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -24,8 +24,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.6.0.2")]
-[assembly: System.Reflection.AssemblyFileVersion("0.6.0.2")]
+[assembly: System.Reflection.AssemblyVersion("0.6.0.3")]
+[assembly: System.Reflection.AssemblyFileVersion("0.6.0.3")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -8,8 +8,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.6.0.2")]
-[assembly: AssemblyFileVersion("0.6.0.2")]
+[assembly: AssemblyVersion("0.6.0.3")]
+[assembly: AssemblyFileVersion("0.6.0.3")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -4195,7 +4195,8 @@ namespace DshPortable
                 }
                 process.WaitForExit();
                 stderr.Wait();
-                string message = RedactSensitiveText((stderr.Result + Environment.NewLine + String.Join(Environment.NewLine, stdout)).Trim());
+                string rawMessage = (stderr.Result + Environment.NewLine + String.Join(Environment.NewLine, stdout)).Trim();
+                string message = process.ExitCode == 0 ? rawMessage : RedactSensitiveText(rawMessage);
                 return Tuple.Create(process.ExitCode, message);
             }
         }

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -26,8 +26,8 @@ using Microsoft.Web.WebView2.WinForms;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.6.0.2")]
-[assembly: AssemblyFileVersion("0.6.0.2")]
+[assembly: AssemblyVersion("0.6.0.3")]
+[assembly: AssemblyFileVersion("0.6.0.3")]
 
 namespace DshPortable
 {
@@ -2799,7 +2799,10 @@ namespace DshPortable
             if (updated.Item1 != 0)
             {
                 await RestoreDesktopAfterUpdateAttemptAsync();
-                throw new InvalidOperationException(updated.Item2);
+                string code = JsonString(updated.Item2, "code");
+                string safeDetail = RedactSensitiveText(updated.Item2);
+                WriteLauncherLog("portable-cli-error", safeDetail.Length > 4096 ? safeDetail.Substring(0, 4096) : safeDetail);
+                throw new InvalidOperationException(FriendlyPortableUpdateError(code));
             }
             string url = JsonString(updated.Item2, "url");
             if (!IsTrustedLoopbackUrl(url))
@@ -4025,6 +4028,10 @@ namespace DshPortable
                 activityRing.Indeterminate = true;
                 if (phase == "verifying") statusLabel.Text = L("正在验证 DSH-Portable 更新…", "Verifying the DSH-Portable update…");
                 else if (phase == "installing") statusLabel.Text = L("正在安装 DSH-Portable 更新…", "Installing the DSH-Portable update…");
+                else if (phase == "validating") statusLabel.Text = L("正在验证新版本能否启动…", "Checking that the new version can start…");
+                else if (phase == "rolling-back") statusLabel.Text = L("新版本未通过验证，正在恢复原版本…", "The new version did not pass validation; restoring the previous version…");
+                else if (phase == "rollback-complete" || phase == "restarting-previous") statusLabel.Text = L("已恢复原版本，正在重新启动…", "The previous version was restored and is restarting…");
+                else if (phase == "recovered") statusLabel.Text = L("原版本已恢复，正在重新打开工作台…", "The previous version is ready; reopening the workspace…");
                 else if (phase == "complete") statusLabel.Text = L("正在重新打开工作台…", "Reopening the workspace…");
                 progressDetail.Text = phase == "complete" ? "100%" : L("会话、设置、插件和工作区保持不变", "Sessions, settings, plugins, and workspace stay in place");
             }
@@ -4069,6 +4076,31 @@ namespace DshPortable
             Match match = Regex.Match(json ?? String.Empty, "\\\"" + Regex.Escape(name) + "\\\"\\s*:\\s*(?<value>-?\\d+)");
             long value;
             return match.Success && Int64.TryParse(match.Groups["value"].Value, out value) ? value : 0;
+        }
+
+        private string FriendlyPortableUpdateError(string code)
+        {
+            if (String.Equals(code, "UPDATE_ROLLED_BACK", StringComparison.Ordinal)) return L(
+                "新版本未通过启动验证，已恢复并重新启动原版本。详细信息已写入支持日志。",
+                "The new version did not pass startup validation. The previous version was restored and restarted. Details were saved to the support log.");
+            if (String.Equals(code, "UPDATE_RECOVERY_FAILED", StringComparison.Ordinal)) return L(
+                "更新失败，原版本也未能自动重启。请重新打开 DSH-Portable 并导出支持报告。",
+                "The update failed and the previous version could not restart automatically. Reopen DSH-Portable and export a support report.");
+            return L(
+                "更新未能完成。安装仍可恢复；请导出支持报告以便排查。",
+                "The update could not be completed. The installation remains recoverable; export a support report for details.");
+        }
+
+        private static string RedactSensitiveText(string source)
+        {
+            string value = source ?? String.Empty;
+            value = Regex.Replace(value, "(?i)(Bearer\\s+)[^\\s\\\"']+", "$1[REDACTED]");
+            value = Regex.Replace(value,
+                "(?i)([\\\"']?[^\\s\\\"']*(?:token|password|secret|authorization|cookie|api[_-]?key)[^\\s\\\"']*[\\\"']?\\s*[:=]\\s*)[\\\"']?[^\\s,;}&\\\"']+",
+                "$1[REDACTED]");
+            value = Regex.Replace(value, "(?i)([?&](?:token|access_token|auth|authorization)=)[^&#\\s]+", "$1[REDACTED]");
+            value = Regex.Replace(value, "\\bsk-[A-Za-z0-9_-]{6,}\\b", "[REDACTED]");
+            return value;
         }
 
         private void HandleFailure(int exitCode, string message)
@@ -4163,7 +4195,7 @@ namespace DshPortable
                 }
                 process.WaitForExit();
                 stderr.Wait();
-                string message = (stderr.Result + Environment.NewLine + String.Join(Environment.NewLine, stdout)).Trim();
+                string message = RedactSensitiveText((stderr.Result + Environment.NewLine + String.Join(Environment.NewLine, stdout)).Trim());
                 return Tuple.Create(process.ExitCode, message);
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/release-notes/v0.6.0-rc.3.json
+++ b/release-notes/v0.6.0-rc.3.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.6.0-rc.3",
+  "zh": {
+    "summary": "修复 Beta 内核更新可能长时间停留在安装界面的问题，并加强回滚、诊断和发布前升级验证。",
+    "highlights": [
+      "当新版 DeepSeek Harness 需要更新桌面壳时，Portable 会改用完整包更新，不再让旧壳尝试不兼容的内核组件。",
+      "更新界面现在会区分下载、安装、启动验证、恢复原版本和重新启动，不再长时间停在同一条安装提示。",
+      "更新失败时继续自动恢复原版本；错误窗口只显示可操作的简短说明，详细信息写入经过脱敏且有大小上限的支持日志。",
+      "发布门禁会从同一通道的紧邻上一版本执行真实升级并启动验证，覆盖组件更新和完整包更新两条路径。",
+      "继续内置官方 DeepSeek Harness 0.1.2-alpha.2；Beta 与稳定更新通道保持分离。"
+    ]
+  },
+  "en": {
+    "summary": "Fixes Beta core updates that could remain on the installing screen for an extended time, with stronger rollback, diagnostics, and pre-release upgrade validation.",
+    "highlights": [
+      "Uses a complete-package update when a newer DeepSeek Harness runtime also requires a newer desktop shell, instead of asking an older shell to install an incompatible core component.",
+      "Shows distinct download, install, startup validation, previous-version restore, and restart phases instead of remaining on one installing message.",
+      "Continues to restore the previous version automatically after a failed update; dialogs show a concise actionable message while bounded, redacted details go to the support log.",
+      "Upgrades and starts the immediate prior release from the same channel before publication, covering both component and complete-package delivery paths.",
+      "Continues to bundle official DeepSeek Harness 0.1.2-alpha.2 while keeping Beta and Stable update channels separate."
+    ]
+  }
+}

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -80,11 +80,13 @@ fi
 NODE_EXE="$NODE_FOLDER/bin/node"
 NPM_CLI="$NODE_FOLDER/lib/node_modules/npm/bin/npm-cli.js"
 [[ -x "$NODE_EXE" && -f "$NPM_CLI" ]] || { echo "Pinned Node archive is incomplete" >&2; exit 1; }
+SHELL_FINGERPRINT="$("$NODE_EXE" "$PROJECT_ROOT/scripts/shell-fingerprint.mjs" linux)"
+[[ "$SHELL_FINGERPRINT" =~ ^[a-f0-9]{64}$ ]] || { echo "Linux shell fingerprint generation failed" >&2; exit 1; }
 
 cp "$PROJECT_ROOT/app/package.json" "$STAGE/app/package.json"
 cp "$PROJECT_ROOT/app/package-lock.json" "$STAGE/app/package-lock.json"
 cp -R "$PROJECT_ROOT/app/vendor" "$STAGE/app/vendor"
-for file in portable-core.mjs portable-cli.mjs portable-host.mjs update-core.mjs dsh-cli.mjs http-readiness.mjs default-plugins.mjs repair-core.mjs data-transfer.mjs runtime-capsule.mjs startup-trace.mjs; do
+for file in portable-core.mjs portable-cli.mjs portable-host.mjs update-core.mjs dsh-cli.mjs http-readiness.mjs default-plugins.mjs repair-core.mjs diagnostic-policy.mjs data-transfer.mjs runtime-capsule.mjs startup-trace.mjs; do
   cp "$PROJECT_ROOT/launcher/$file" "$STAGE/launcher/$file"
 done
 cp "$PROJECT_ROOT/templates/DATA-MIGRATION.zh-CN.txt" "$STAGE/DATA-MIGRATION.zh-CN.txt"
@@ -176,7 +178,8 @@ cat > "$STAGE/licenses/COMPONENTS.json" <<EOF
   "nodeSha256": "$NODE_SHA256",
   "runtimeLayout": "$(if [[ -n "$PREVIEW_APP_SOURCE" ]]; then printf official-source-pack; else printf npm-lock; fi)",
   "updaterSchema": 1,
-  "shellSchema": 10
+  "shellSchema": 11,
+  "shellFingerprint": "$SHELL_FINGERPRINT"
 }
 EOF
 
@@ -214,7 +217,8 @@ cat > "$UPDATE_MANIFEST" <<EOF
   "releaseChannel": "$RELEASE_CHANNEL",
   "platform": "linux-$ARCH",
   "minimumUpdaterSchema": 1,
-  "requiredShellSchema": 10,
+  "requiredShellSchema": 11,
+  "requiredShellFingerprint": "$SHELL_FINGERPRINT",
   "component": {
     "kind": "dsh-app",
     "dshVersion": "$DSH_VERSION",
@@ -236,7 +240,8 @@ cat > "$ENGINE_UPDATE_MANIFEST" <<EOF
   "releaseChannel": "$RELEASE_CHANNEL",
   "platform": "linux-$ARCH",
   "minimumUpdaterSchema": 1,
-  "requiredShellSchema": 10,
+  "requiredShellSchema": 11,
+  "requiredShellFingerprint": "$SHELL_FINGERPRINT",
   "component": {
     "kind": "dsh-app",
     "dshVersion": "$DSH_VERSION",

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -75,6 +75,8 @@ fi
 NODE_EXE="$NODE_FOLDER/bin/node"
 NPM_CLI="$NODE_FOLDER/lib/node_modules/npm/bin/npm-cli.js"
 [[ -x "$NODE_EXE" && -f "$NPM_CLI" ]] || { echo "Pinned Node archive is incomplete" >&2; exit 1; }
+SHELL_FINGERPRINT="$("$NODE_EXE" "$PROJECT_ROOT/scripts/shell-fingerprint.mjs" macos)"
+[[ "$SHELL_FINGERPRINT" =~ ^[a-f0-9]{64}$ ]] || { echo "macOS shell fingerprint generation failed" >&2; exit 1; }
 
 cp "$PROJECT_ROOT/app/package.json" "$STAGE/app/package.json"
 cp "$PROJECT_ROOT/app/package-lock.json" "$STAGE/app/package-lock.json"
@@ -82,6 +84,7 @@ cp -R "$PROJECT_ROOT/app/vendor" "$STAGE/app/vendor"
 cp "$PROJECT_ROOT/launcher/portable-core.mjs" "$STAGE/launcher/portable-core.mjs"
 cp "$PROJECT_ROOT/launcher/portable-cli.mjs" "$STAGE/launcher/portable-cli.mjs"
 cp "$PROJECT_ROOT/launcher/repair-core.mjs" "$STAGE/launcher/repair-core.mjs"
+cp "$PROJECT_ROOT/launcher/diagnostic-policy.mjs" "$STAGE/launcher/diagnostic-policy.mjs"
 cp "$PROJECT_ROOT/launcher/portable-host.mjs" "$STAGE/launcher/portable-host.mjs"
 cp "$PROJECT_ROOT/launcher/update-core.mjs" "$STAGE/launcher/update-core.mjs"
 cp "$PROJECT_ROOT/launcher/dsh-cli.mjs" "$STAGE/launcher/dsh-cli.mjs"
@@ -177,7 +180,8 @@ cat > "$STAGE/licenses/COMPONENTS.json" <<EOF
   "nodeSha256": "$NODE_SHA256",
   "runtimeLayout": "$(if [[ -n "$PREVIEW_APP_SOURCE" ]]; then printf official-source-pack; else printf npm-lock; fi)",
   "updaterSchema": 1,
-  "shellSchema": 18
+  "shellSchema": 19,
+  "shellFingerprint": "$SHELL_FINGERPRINT"
 }
 EOF
 
@@ -237,7 +241,8 @@ cat > "$UPDATE_MANIFEST" <<EOF
   "releaseChannel": "$RELEASE_CHANNEL",
   "platform": "macos-$ARCH",
   "minimumUpdaterSchema": 1,
-  "requiredShellSchema": 18,
+  "requiredShellSchema": 19,
+  "requiredShellFingerprint": "$SHELL_FINGERPRINT",
   "component": {
     "kind": "dsh-app",
     "dshVersion": "$DSH_VERSION",
@@ -259,7 +264,8 @@ cat > "$ENGINE_UPDATE_MANIFEST" <<EOF
   "releaseChannel": "$RELEASE_CHANNEL",
   "platform": "macos-$ARCH",
   "minimumUpdaterSchema": 1,
-  "requiredShellSchema": 18,
+  "requiredShellSchema": 19,
+  "requiredShellFingerprint": "$SHELL_FINGERPRINT",
   "component": {
     "kind": "dsh-app",
     "dshVersion": "$DSH_VERSION",

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -66,7 +66,7 @@ function Copy-PortableSources([string]$Target) {
     Copy-Item (Join-Path $ProjectRoot 'app\package.json') (Join-Path $Target 'app\package.json')
     Copy-Item (Join-Path $ProjectRoot 'app\package-lock.json') (Join-Path $Target 'app\package-lock.json')
     Copy-Item -Recurse (Join-Path $ProjectRoot 'app\vendor') (Join-Path $Target 'app\vendor')
-    foreach ($File in @('portable-core.mjs', 'portable-cli.mjs', 'portable-host.mjs', 'update-core.mjs', 'dsh-cli.mjs', 'http-readiness.mjs', 'default-plugins.mjs', 'repair-core.mjs', 'data-transfer.mjs', 'runtime-capsule.mjs', 'runtime-entry.mjs', 'startup-trace.mjs')) {
+    foreach ($File in @('portable-core.mjs', 'portable-cli.mjs', 'portable-host.mjs', 'update-core.mjs', 'dsh-cli.mjs', 'http-readiness.mjs', 'default-plugins.mjs', 'repair-core.mjs', 'diagnostic-policy.mjs', 'data-transfer.mjs', 'runtime-capsule.mjs', 'runtime-entry.mjs', 'startup-trace.mjs')) {
         Copy-Item (Join-Path $ProjectRoot "launcher\$File") (Join-Path $Target "launcher\$File")
     }
     Copy-Item (Join-Path $ProjectRoot 'templates\DATA-MIGRATION.zh-CN.txt') (Join-Path $Target 'DATA-MIGRATION.zh-CN.txt')
@@ -156,6 +156,8 @@ try {
     if ($ReleaseChannel -eq 'stable' -and $PreviewAppSource) {
         throw 'Stable builds must not consume -PreviewAppSource.'
     }
+    $ShellFingerprint = (& $NodeExe (Join-Path $ProjectRoot 'scripts\shell-fingerprint.mjs') windows).Trim()
+    if ($LASTEXITCODE -ne 0 -or $ShellFingerprint -notmatch '^[a-f0-9]{64}$') { throw 'Windows shell fingerprint generation failed.' }
 
     Copy-PortableSources $Stage
     if ($PreviewAppSource) {
@@ -254,7 +256,8 @@ try {
         webView2Version = $Lock.webview2.version
         webView2Sha256 = $Lock.webview2.sha256
         updaterSchema = 1
-        shellSchema = 23
+        shellSchema = 24
+        shellFingerprint = $ShellFingerprint
     }
     [System.IO.File]::WriteAllText(
         (Join-Path $Stage 'licenses\COMPONENTS.json'),
@@ -350,7 +353,8 @@ try {
             releaseChannel = $ReleaseChannel
             platform = 'windows-x64'
             minimumUpdaterSchema = 1
-            requiredShellSchema = 23
+            requiredShellSchema = 24
+            requiredShellFingerprint = $ShellFingerprint
             targetRuntimeLayout = 'capsule-v1'
             component = [ordered]@{
                 kind = 'dsh-runtime-capsule'
@@ -376,7 +380,8 @@ try {
             releaseChannel = $ReleaseChannel
             platform = 'windows-x64'
             minimumUpdaterSchema = 1
-            requiredShellSchema = 23
+            requiredShellSchema = 24
+            requiredShellFingerprint = $ShellFingerprint
             targetRuntimeLayout = 'capsule-v1'
             component = [ordered]@{
                 kind = 'dsh-runtime-capsule'

--- a/scripts/shell-fingerprint.mjs
+++ b/scripts/shell-fingerprint.mjs
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto'
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const root = path.resolve(import.meta.dirname, '..')
+const platform = process.argv[2]
+const platformDirectories = {
+  windows: 'launcher/windows',
+  macos: 'launcher/macos',
+  linux: 'launcher/linux',
+}
+if (!platformDirectories[platform]) throw new Error('Usage: node scripts/shell-fingerprint.mjs <windows|macos|linux>')
+
+async function filesBelow(relativeDirectory) {
+  const directory = path.join(root, relativeDirectory)
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = []
+  for (const entry of entries) {
+    const relative = path.posix.join(relativeDirectory.replaceAll('\\', '/'), entry.name)
+    if (entry.isDirectory()) files.push(...await filesBelow(relative))
+    else if (entry.isFile()) files.push(relative)
+  }
+  return files
+}
+
+const shared = (await readdir(path.join(root, 'launcher'), { withFileTypes: true }))
+  .filter((entry) => entry.isFile() && entry.name.endsWith('.mjs'))
+  .map((entry) => `launcher/${entry.name}`)
+const files = [...shared, ...await filesBelow(platformDirectories[platform])].sort()
+const digest = createHash('sha256')
+for (const filename of files) {
+  digest.update(filename)
+  digest.update('\0')
+  digest.update(await readFile(path.join(root, filename)))
+  digest.update('\0')
+}
+process.stdout.write(`${digest.digest('hex')}\n`)

--- a/scripts/smoke-portable.mjs
+++ b/scripts/smoke-portable.mjs
@@ -63,7 +63,8 @@ async function waitForPortableStatus(root, expected, nativeHost, timeoutMs = 90_
     const result = await invokeCli(root, 'status', '--json')
     if (result.code !== 0) {
       const details = `${result.stderr}\n${result.stdout}`
-      if (details.includes('Another portable launcher is already starting or stopping DSH')) {
+      const errorCode = parseCliJson(details)?.code
+      if (errorCode === 'LAUNCH_IN_PROGRESS') {
         await delay(250)
         continue
       }

--- a/scripts/smoke-update-artifact.mjs
+++ b/scripts/smoke-update-artifact.mjs
@@ -168,7 +168,10 @@ async function main() {
       assert.fail('The rollback probe unexpectedly succeeded.')
     } catch (error) {
       rollbackDiagnostic = `${error?.stderr ?? ''}\n${error?.stdout ?? ''}`
-      assert.match(rollbackDiagnostic, /Update failed and was rolled back/i)
+      const rollbackError = JSON.parse(rollbackDiagnostic.trim().split(/\r?\n/).filter(Boolean).at(-1))
+      assert.equal(rollbackError.type, 'portable-error')
+      assert.equal(rollbackError.code, 'UPDATE_ROLLED_BACK')
+      assert.doesNotMatch(rollbackDiagnostic, /(?:token|authorization|cookie)=/i)
     }
     const rollbackStatus = JSON.parse((await execFileAsync(node, [...cliPrefix, 'status', '--json'], {
       encoding: 'utf8', timeout: 30000, windowsHide: true,

--- a/scripts/smoke-windows-desktop-host.ps1
+++ b/scripts/smoke-windows-desktop-host.ps1
@@ -136,7 +136,7 @@ function Get-ProductStatus {
                 Status = ($Raw | ConvertFrom-Json).status
             }
         }
-        if ($Raw -notmatch 'Another portable launcher is already starting or stopping DSH' -or [DateTime]::UtcNow -ge $Deadline) {
+        if ($Raw -notmatch 'Another portable launcher is already starting or stopping DSH|"code":"LAUNCH_IN_PROGRESS"' -or [DateTime]::UtcNow -ge $Deadline) {
             return [pscustomobject]@{ ExitCode = $ExitCode; Raw = $Raw; Status = '' }
         }
         Start-Sleep -Milliseconds 100

--- a/scripts/smoke-windows-plugins.ps1
+++ b/scripts/smoke-windows-plugins.ps1
@@ -69,7 +69,7 @@ function Product-Status {
     do {
         $Raw = (& $Node $RuntimeEntry 'portable-cli.mjs' status --json 2>&1 | Out-String).Trim()
         if ($LASTEXITCODE -eq 0) { return ($Raw | ConvertFrom-Json) }
-        if ($Raw -notmatch 'Another portable launcher' -or [DateTime]::UtcNow -ge $Deadline) {
+        if ($Raw -notmatch 'Another portable launcher|"code":"LAUNCH_IN_PROGRESS"' -or [DateTime]::UtcNow -ge $Deadline) {
             throw "portable status failed: $Raw"
         }
         Start-Sleep -Milliseconds 100

--- a/scripts/smoke-windows-version-upgrade.mjs
+++ b/scripts/smoke-windows-version-upgrade.mjs
@@ -15,14 +15,16 @@ const allowChannelMigration = process.argv.includes('--allow-channel-migration')
 const runningHostUpgrade = process.argv.includes('--running-host')
 const simulateWebViewBusy = process.argv.includes('--simulate-webview-busy')
 const newArchive = path.join(artifacts, 'DSH-Portable-windows-x64-offline.zip')
+const componentArchive = path.join(artifacts, 'DSH-Portable-update-windows-x64.zip')
 const fullManifestPath = path.join(artifacts, 'portable-manifest.json')
 const componentManifestPath = path.join(artifacts, 'portable-update-windows-x64.json')
 
 assert.equal(process.platform, 'win32', 'the release upgrade smoke requires Windows')
 assert.ok(oldArchive, 'pass the prior Windows offline ZIP as the first argument')
 
-const [newArchiveBytes, fullManifestSource, componentManifestSource] = await Promise.all([
+const [newArchiveBytes, componentArchiveBytes, fullManifestSource, componentManifestSource] = await Promise.all([
   readFile(newArchive),
+  readFile(componentArchive),
   readFile(fullManifestPath, 'utf8').then(JSON.parse),
   readFile(componentManifestPath, 'utf8').then(JSON.parse),
 ])
@@ -78,6 +80,11 @@ const server = createServer((request, response) => {
     response.end(newArchiveBytes)
     return
   }
+  if (request.url === '/component.zip') {
+    response.writeHead(200, { 'content-type': 'application/zip', 'content-length': componentArchiveBytes.length })
+    response.end(componentArchiveBytes)
+    return
+  }
   response.writeHead(404).end()
 })
 
@@ -86,13 +93,6 @@ try {
   await rename(extracted, destination)
   const oldComponents = JSON.parse(await readFile(path.join(destination, 'licenses', 'COMPONENTS.json'), 'utf8'))
   assert.notEqual(oldComponents.portableVersion, fullManifestSource.version, 'the prior package must differ from the target release')
-  const oldRuntimeLayout = oldComponents.runtimeLayout || 'expanded-v1'
-  assert.ok(
-    Number(oldComponents.shellSchema) < Number(componentManifestSource.requiredShellSchema)
-      || oldRuntimeLayout !== (componentManifestSource.targetRuntimeLayout || oldRuntimeLayout),
-    'the prior package does not exercise a complete-package compatibility boundary',
-  )
-
   const markers = new Map([
     [path.join(destination, 'data', 'dsh-home', 'settings.yaml'), 'locale:\n  preference: zh\n'],
     [path.join(destination, 'data', 'dsh-home', 'portable-upgrade-session.marker'), 'keep-session\n'],
@@ -112,28 +112,8 @@ try {
   }))
   componentManifestBody = Buffer.from(JSON.stringify({
     ...componentManifestSource,
-    component: { ...componentManifestSource.component, urls: [`${origin}/unused-component.zip`] },
+    component: { ...componentManifestSource.component, urls: [`${origin}/component.zip`] },
   }))
-
-  let launcherLogOffset = 0
-  if (runningHostUpgrade) {
-    const oldExecutable = path.join(destination, 'DeepSeek-Herness.exe')
-    oldHost = spawn(oldExecutable, [], {
-      cwd: destination,
-      env: {
-        ...process.env,
-        DSH_PORTABLE_SKIP_UPDATE_CHECK: '1',
-        DSH_PORTABLE_TEST_HIDDEN: '1',
-      },
-      windowsHide: true,
-      stdio: 'ignore',
-    })
-    await waitFor(
-      async () => (await launcherLog()).includes('environment-ready:'),
-      'the old native desktop host did not initialize WebView2 before the update',
-    )
-    launcherLogOffset = (await launcherLog()).length
-  }
 
   let decision = { status: 'full-package-required', delivery: 'full-package' }
   if (!allowChannelMigration) {
@@ -152,8 +132,8 @@ try {
       '--json',
     ], { timeout: 60 * 1000, windowsHide: true })
     decision = JSON.parse(decisionText)
-    assert.equal(decision.status, 'full-package-required')
-    assert.equal(decision.delivery, 'full-package')
+    assert.ok(['available', 'full-package-required'].includes(decision.status), `unexpected update decision: ${decision.status}`)
+    assert.equal(decision.delivery, decision.status === 'available' ? 'component' : 'full-package')
   } else {
     assert.notEqual(
       oldComponents.releaseChannel,
@@ -162,31 +142,72 @@ try {
     )
   }
 
-  try {
-    const updaterArguments = [
-      '--upgrade-existing',
-      '--manifest', `${origin}/portable-manifest.json`,
-      '--destination', destination,
+  let launcherLogOffset = 0
+  if (decision.delivery === 'full-package') {
+    if (runningHostUpgrade) {
+      const oldExecutable = path.join(destination, 'DeepSeek-Herness.exe')
+      oldHost = spawn(oldExecutable, [], {
+        cwd: destination,
+        env: {
+          ...process.env,
+          DSH_PORTABLE_SKIP_UPDATE_CHECK: '1',
+          DSH_PORTABLE_TEST_HIDDEN: '1',
+        },
+        windowsHide: true,
+        stdio: 'ignore',
+      })
+      await waitFor(
+        async () => (await launcherLog()).includes('environment-ready:'),
+        'the old native desktop host did not initialize WebView2 before the update',
+      )
+      launcherLogOffset = (await launcherLog()).length
+    }
+    try {
+      const updaterArguments = [
+        '--upgrade-existing',
+        '--manifest', `${origin}/portable-manifest.json`,
+        '--destination', destination,
+        '--allow-http',
+        '--result', resultPath,
+      ]
+      if (!runningHostUpgrade) updaterArguments.push('--no-launch')
+      await execFileAsync(path.join(destination, 'launcher', 'DSH-FullUpdater.exe'), updaterArguments, {
+        timeout: 10 * 60 * 1000,
+        windowsHide: true,
+        env: runningHostUpgrade ? {
+          ...process.env,
+          DSH_PORTABLE_SKIP_UPDATE_CHECK: '1',
+          DSH_PORTABLE_TEST_HIDDEN: '1',
+        } : process.env,
+      })
+    } catch (error) {
+      const diagnostic = await readFile(resultPath, 'utf8').catch(() => 'no updater result was written')
+      throw new Error(`the prior full updater failed: ${diagnostic}`, { cause: error })
+    }
+    const result = JSON.parse(await readFile(resultPath, 'utf8'))
+    assert.equal(result.status, 'updated')
+    assert.equal(result.version, fullManifestSource.version)
+  } else {
+    const oldNode = path.join(destination, 'runtime', 'node', 'node.exe')
+    const oldCli = path.join(destination, 'launcher', 'portable-cli.mjs')
+    const oldEntry = await stat(path.join(destination, 'runtime-capsule.json')).then(
+      () => [path.join(destination, 'launcher', 'runtime-entry.mjs'), 'portable-cli.mjs'],
+      () => [oldCli],
+    )
+    const { stdout } = await execFileAsync(oldNode, [
+      ...oldEntry,
+      'update',
+      '--update-manifest', `${origin}/portable-update-windows-x64.json`,
       '--allow-http',
-      '--result', resultPath,
-    ]
-    if (!runningHostUpgrade) updaterArguments.push('--no-launch')
-    await execFileAsync(path.join(destination, 'launcher', 'DSH-FullUpdater.exe'), updaterArguments, {
-      timeout: 10 * 60 * 1000,
-      windowsHide: true,
-      env: runningHostUpgrade ? {
-        ...process.env,
-        DSH_PORTABLE_SKIP_UPDATE_CHECK: '1',
-        DSH_PORTABLE_TEST_HIDDEN: '1',
-      } : process.env,
-    })
-  } catch (error) {
-    const diagnostic = await readFile(resultPath, 'utf8').catch(() => 'no updater result was written')
-    throw new Error(`the prior full updater failed: ${diagnostic}`, { cause: error })
+      '--force',
+      '--no-browser',
+      '--json',
+      '--progress-json',
+    ], { timeout: 5 * 60 * 1000, windowsHide: true })
+    const records = stdout.trim().split(/\r?\n/).map(JSON.parse)
+    assert.equal(records.at(-1)?.status, 'updated', 'the prior shell did not finish the compatible component update')
+    assert.ok(records.some((entry) => entry.phase === 'validating'), 'the prior shell did not validate the updated runtime')
   }
-  const result = JSON.parse(await readFile(resultPath, 'utf8'))
-  assert.equal(result.status, 'updated')
-  assert.equal(result.version, fullManifestSource.version)
 
   const newComponents = JSON.parse(await readFile(path.join(destination, 'licenses', 'COMPONENTS.json'), 'utf8'))
   assert.equal(newComponents.portableVersion, fullManifestSource.version)
@@ -199,7 +220,7 @@ try {
   for (const [filename, value] of markers) assert.equal(await readFile(filename, 'utf8'), value)
   assert.ok((await stat(path.join(destination, 'DeepSeek-Herness.exe'))).isFile())
 
-  if (runningHostUpgrade) {
+  if (runningHostUpgrade && decision.delivery === 'full-package') {
     await waitFor(async () => {
       const currentLog = await launcherLog()
       return currentLog.slice(launcherLogOffset).includes('dsh-first-paint-ready')

--- a/scripts/verify-update-artifact.mjs
+++ b/scripts/verify-update-artifact.mjs
@@ -55,6 +55,9 @@ async function main() {
     || !Number.isSafeInteger(requiredShellSchema) || requiredShellSchema < 1) {
     fail('Update compatibility metadata is incomplete.')
   }
+  if (manifest.requiredShellFingerprint != null && !/^[a-f0-9]{64}$/i.test(String(manifest.requiredShellFingerprint))) {
+    fail('Update shell fingerprint is invalid.')
+  }
   const component = manifest.component
   if (!component || !['dsh-app', 'dsh-runtime-capsule'].includes(component.kind) || !component.requiredNodeVersion) {
     fail('Update component metadata is incomplete.')
@@ -116,7 +119,8 @@ async function main() {
     || components.nodeVersion !== component.requiredNodeVersion
     || (component.runtimeLayout && components.runtimeLayout !== component.runtimeLayout)
     || Number(components.updaterSchema) < Number(manifest.minimumUpdaterSchema)
-    || Number(components.shellSchema) < Number(manifest.requiredShellSchema)) {
+    || Number(components.shellSchema) < Number(manifest.requiredShellSchema)
+    || (manifest.requiredShellFingerprint && components.shellFingerprint !== manifest.requiredShellFingerprint)) {
     fail('Installed component metadata does not match the update manifest.')
   }
 

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -576,7 +576,7 @@ test('macOS package smokes treat the native app as a long-lived desktop process'
   assert.match(portableSmoke, /['"]\/usr\/bin\/open['"]/)
   assert.match(portableSmoke, /['"]-n['"], ['"]-W['"], app, ['"]--args['"], ['"]--skip-update-check['"]/)
   assert.match(portableSmoke, /waitForPortableStatus/)
-  assert.match(portableSmoke, /Another portable launcher is already starting or stopping DSH/)
+  assert.match(portableSmoke, /LAUNCH_IN_PROGRESS/)
   assert.match(portableSmoke, /requestMacAppQuit/)
 })
 

--- a/tests/diagnostic-policy.test.mjs
+++ b/tests/diagnostic-policy.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  classifyPortableError,
+  recordPortableDiagnostic,
+  redactDiagnosticText,
+} from '../launcher/diagnostic-policy.mjs'
+
+test('diagnostic policy redacts credential-like keys and loopback authentication URLs', () => {
+  const source = [
+    'controlToken=control-secret',
+    '{"workspaceAuthToken":"workspace-secret","cookie":"cookie-secret"}',
+    'Authorization: Bearer bearer-secret',
+    'dsh web: http://127.0.0.1:3080/?token=url-secret&view=home',
+    'normal diagnostic',
+  ].join('\n')
+  const redacted = redactDiagnosticText(source)
+  assert.match(redacted, /normal diagnostic/)
+  assert.doesNotMatch(redacted, /control-secret|workspace-secret|cookie-secret|bearer-secret|url-secret/)
+  assert.match(redacted, /\[REDACTED\]/)
+})
+
+test('rolled-back update failures have a stable machine-readable code', () => {
+  assert.equal(classifyPortableError(new Error('Update failed and was rolled back: boot failed\nThe previous version was restored and restarted.')), 'UPDATE_ROLLED_BACK')
+  assert.equal(classifyPortableError(new Error('The previous version was restored but could not restart: boot failed')), 'UPDATE_RECOVERY_FAILED')
+  assert.equal(classifyPortableError(new Error('Close the other Portable environment before changing shared components: research.')), 'SHARED_COMPONENTS_BUSY')
+})
+
+test('full diagnostics are stored redacted and bounded outside the user-facing error', async (t) => {
+  const logsDir = await mkdtemp(path.join(os.tmpdir(), 'dsh-diagnostic-policy-'))
+  t.after(() => rm(logsDir, { recursive: true, force: true }))
+  await recordPortableDiagnostic(logsDir, {
+    operation: 'update',
+    error: new Error('failed http://127.0.0.1:3080/?token=private-token'),
+  })
+  const source = await readFile(path.join(logsDir, 'portable-errors.jsonl'), 'utf8')
+  assert.match(source, /UPDATE_FAILED|update/)
+  assert.doesNotMatch(source, /private-token/)
+  assert.ok(Buffer.byteLength(source) < 256 * 1024)
+})

--- a/tests/diagnostic-policy.test.mjs
+++ b/tests/diagnostic-policy.test.mjs
@@ -27,6 +27,7 @@ test('diagnostic policy redacts credential-like keys and loopback authentication
 test('rolled-back update failures have a stable machine-readable code', () => {
   assert.equal(classifyPortableError(new Error('Update failed and was rolled back: boot failed\nThe previous version was restored and restarted.')), 'UPDATE_ROLLED_BACK')
   assert.equal(classifyPortableError(new Error('The previous version was restored but could not restart: boot failed')), 'UPDATE_RECOVERY_FAILED')
+  assert.equal(classifyPortableError(new Error('Another portable launcher is already starting or stopping DSH.')), 'LAUNCH_IN_PROGRESS')
   assert.equal(classifyPortableError(new Error('Close the other Portable environment before changing shared components: research.')), 'SHARED_COMPONENTS_BUSY')
 })
 

--- a/tests/linux-packaging-contract.test.mjs
+++ b/tests/linux-packaging-contract.test.mjs
@@ -29,8 +29,10 @@ test('Linux uses architecture-specific component update channels', () => {
 
 test('Linux requires a compatible native shell before installing the app component', async () => {
   const source = await read('scripts/build-linux.sh')
-  assert.match(source, /"shellSchema": 10/)
-  assert.match(source, /"requiredShellSchema": 10/)
+  assert.match(source, /"shellSchema": 11/)
+  assert.match(source, /"requiredShellSchema": 11/)
+  assert.match(source, /"shellFingerprint": "\$SHELL_FINGERPRINT"/)
+  assert.match(source, /"requiredShellFingerprint": "\$SHELL_FINGERPRINT"/)
 })
 
 test('Linux shell is a native Tauri window over the official local DSH server', async () => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -883,7 +883,9 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.match(workflow, /verify-update-artifact\.mjs/)
   assert.match(workflow, /smoke-update-artifact\.mjs/)
   assert.match(updateSmoke, /rollbackVerified/)
-  assert.match(updateSmoke, /Update failed and was rolled back|rolled back/i)
+  assert.match(updateSmoke, /UPDATE_ROLLED_BACK/)
+  assert.match(updateSmoke, /portable-error/)
+  assert.match(updateSmoke, /authorization\|cookie/)
   assert.ok(
     workflow.indexOf('node scripts/smoke-update-artifact.mjs') < workflow.indexOf('node scripts/smoke-portable.mjs'),
     'the update smoke must run before the movable-root smoke renames the package',

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -530,6 +530,7 @@ test('Windows package exposes real GUI executables with matching icon and an iso
   assert.match(source, /HandleUpdateProgress/)
   assert.match(source, /FriendlyPortableUpdateError/)
   assert.match(source, /RedactSensitiveText/)
+  assert.match(source, /process\.ExitCode\s*==\s*0\s*\?\s*rawMessage\s*:\s*RedactSensitiveText\(rawMessage\)/)
   assert.match(source, /portable-cli-error/)
   assert.doesNotMatch(source, /throw new InvalidOperationException\(updated\.Item2\)/)
   assert.match(source, /phase == "validating"/)

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -528,6 +528,13 @@ test('Windows package exposes real GUI executables with matching icon and an iso
   assert.match(source, /full-package-required/)
   assert.match(source, /--progress-json/)
   assert.match(source, /HandleUpdateProgress/)
+  assert.match(source, /FriendlyPortableUpdateError/)
+  assert.match(source, /RedactSensitiveText/)
+  assert.match(source, /portable-cli-error/)
+  assert.doesNotMatch(source, /throw new InvalidOperationException\(updated\.Item2\)/)
+  assert.match(source, /phase == "validating"/)
+  assert.match(source, /phase == "rolling-back"/)
+  assert.match(source, /phase == "restarting-previous"/)
   assert.match(source, /HandleStartupProgress/)
   const startupProgress = source.slice(
     source.indexOf('private void HandleStartupProgress'),
@@ -563,8 +570,11 @@ test('Windows package exposes real GUI executables with matching icon and an iso
   assert.match(build, /dsh-core-update-windows-x64\.json/)
   assert.match(build, /updaterSchema/)
   assert.match(build, /shellSchema/)
-  assert.match(build, /shellSchema\s*=\s*23/)
-  assert.match(build, /requiredShellSchema\s*=\s*23/)
+  assert.match(build, /shellSchema\s*=\s*24/)
+  assert.match(build, /requiredShellSchema\s*=\s*24/)
+  assert.match(build, /shell-fingerprint\.mjs/)
+  assert.match(build, /shellFingerprint\s*=\s*\$ShellFingerprint/)
+  assert.match(build, /requiredShellFingerprint\s*=\s*\$ShellFingerprint/)
   assert.match(source, new RegExp(`AssemblyFileVersion\\("${regexEscape(policy.windowsVersion)}"\\)`))
   assert.match(bootstrap, /ZipArchive/)
   assert.match(bootstrap, /internal sealed class BootstrapActivityRing : Control/)
@@ -782,8 +792,8 @@ test('macOS package is a movable signed app shell for both supported architectur
   assert.match(build, /DSH-Portable-update-macos-\$ARCH\.zip/)
   assert.match(build, /portable-update-macos-\$ARCH\.json/)
   assert.match(build, /dsh-core-update-macos-\$ARCH\.json/)
-  assert.match(build, /"shellSchema": 18/)
-  assert.match(build, /"requiredShellSchema": 18/)
+  assert.match(build, /"shellSchema": 19/)
+  assert.match(build, /"requiredShellSchema": 19/)
   assert.match(plist, new RegExp(`<key>CFBundleVersion<\\/key>\\s*<string>${regexEscape(policy.macBuildVersion)}<\\/string>`, 's'))
   assert.match(app, /check-update/)
   assert.match(app, /Check for Updates|检查更新/)
@@ -928,7 +938,7 @@ test('CI executes contracts and real package smoke tests on Windows and both Mac
   assert.match(macDesktopHostSmoke, /--no-browser/)
 })
 
-test('CI upgrades a running published Windows product and injects the WebView2 restart race', async () => {
+test('CI upgrades the immediate prior Windows release through the declared component or full-package path', async () => {
   const [workflow, smoke] = await Promise.all([
     read('.github/workflows/ci.yml'),
     read('scripts/smoke-windows-version-upgrade.mjs'),
@@ -939,15 +949,19 @@ test('CI upgrades a running published Windows product and injects the WebView2 r
   assert.match(workflow, /Groups\[['"]base['"]\]\.Value[\s\S]+Groups\[['"]rc['"]\]\.Value/)
   assert.match(workflow, /-not \$_\.isPrerelease[\s\S]+\$_\.tagName -match '\^v\\d\+[\s\S]+\$_\.tagName -ne "v\$CandidateVersion"/)
   assert.doesNotMatch(workflow, /gh release view --repo "\$env:GITHUB_REPOSITORY" --json tagName/)
-  assert.match(workflow, /gh release download \$Release\.tagName/)
+  assert.match(workflow, /\$Prior\s*=\s*\$Eligible \| Select-Object -First 1/)
+  assert.match(workflow, /gh release download \$PriorTag/)
   assert.match(workflow, /COMPONENTS\.json/)
-  assert.match(workflow, /Components\.shellSchema[\s\S]+Target\.requiredShellSchema/)
-  assert.match(workflow, /Components\.runtimeLayout[\s\S]+Target\.targetRuntimeLayout/)
   assert.match(workflow, /smoke-windows-version-upgrade\.mjs[\s\S]+--running-host[\s\S]+--simulate-webview-busy/)
   assert.match(workflow, /Components\.releaseChannel[\s\S]+Target\.releaseChannel[\s\S]+--allow-channel-migration/)
   assert.match(smoke, /\['stable', 'candidate'\]\.includes\(fullManifestSource\.releaseChannel\)/)
   assert.match(smoke, /componentManifestSource\.releaseChannel, fullManifestSource\.releaseChannel/)
   assert.match(smoke, /oldComponents\.portableVersion, fullManifestSource\.version/)
+  assert.match(smoke, /\['available', 'full-package-required'\]\.includes\(decision\.status\)/)
+  assert.match(smoke, /decision\.delivery === 'full-package'/)
+  assert.match(smoke, /decision\.status === 'available' \? 'component' : 'full-package'/)
+  assert.match(smoke, /component\.zip/)
+  assert.match(smoke, /phase === 'validating'/)
 })
 
 test('Node runtime lock covers Windows, macOS, and both Linux CPU families', async () => {

--- a/tests/repair-core.test.mjs
+++ b/tests/repair-core.test.mjs
@@ -138,7 +138,7 @@ test('repair never mutates generated runtime state while DSH is running', async 
 test('support report is bounded, useful, and removes credentials and conversation content', async (t) => {
   const layout = await fixture(t)
   await mkdir(layout.logsDir, { recursive: true })
-  await writeFile(path.join(layout.logsDir, 'launcher.log'), `${'x'.repeat(200000)}\nBearer secret-token\napi_key=sk-private\ndsh web: http://127.0.0.1:3080/?token=workspace-secret\nnormal line`)
+  await writeFile(path.join(layout.logsDir, 'launcher.log'), `${'x'.repeat(200000)}\nBearer secret-token\napi_key=sk-private\ncontrolToken=portable-control-secret\n{"workspaceAuthToken":"workspace-auth-secret"}\ndsh web: http://127.0.0.1:3080/?token=workspace-secret\nnormal line`)
   await writeFile(path.join(layout.logsDir, 'launcher.log.previous'), 'previous startup phase')
   await writeFile(path.join(layout.logsDir, 'startup-latest.jsonl'), '{"startupId":"latest","phase":"complete","token":"startup-secret"}\n')
   await writeFile(path.join(layout.logsDir, 'startup-previous.jsonl'), '{"startupId":"previous","phase":"host-wait-begin"}\n')
@@ -154,7 +154,7 @@ test('support report is bounded, useful, and removes credentials and conversatio
   assert.match(source, /startup-previous\.jsonl/)
   assert.match(source, /host-wait-begin/)
   assert.match(source, /runtimeProcesses/)
-  assert.doesNotMatch(source, /secret-token|sk-private|workspace-secret|startup-secret|private conversation/)
+  assert.doesNotMatch(source, /secret-token|sk-private|portable-control-secret|workspace-auth-secret|workspace-secret|startup-secret|private conversation/)
   assert.match(source, /\[REDACTED\]/)
 })
 

--- a/tests/tray-bridge.test.mjs
+++ b/tests/tray-bridge.test.mjs
@@ -409,10 +409,12 @@ test('portable launch and packages compose the bridge as a private official DSH 
   assert.match(cli, /'--patch',\s*layout\.desktopBridgePatch/)
   assert.match(windowsBuild, /desktop-bridge/)
   assert.match(macBuild, /desktop-bridge/)
-  assert.match(windowsBuild, /shellSchema\s*=\s*23/)
-  assert.match(windowsBuild, /requiredShellSchema\s*=\s*23/)
-  assert.match(macBuild, /"shellSchema": 18/)
-  assert.match(macBuild, /"requiredShellSchema": 18/)
+  assert.match(windowsBuild, /shellSchema\s*=\s*24/)
+  assert.match(windowsBuild, /requiredShellSchema\s*=\s*24/)
+  assert.match(macBuild, /"shellSchema": 19/)
+  assert.match(macBuild, /"requiredShellSchema": 19/)
+  assert.match(macBuild, /"shellFingerprint": "\$SHELL_FINGERPRINT"/)
+  assert.match(macBuild, /"requiredShellFingerprint": "\$SHELL_FINGERPRINT"/)
 })
 
 test('Portable maintenance is a native General settings item backed by same-origin product routes', async () => {

--- a/tests/update-cli.test.mjs
+++ b/tests/update-cli.test.mjs
@@ -113,7 +113,7 @@ test('portable CLI upgrades the app component, health-checks it, and leaves DSH 
     await mkdir(path.join(root, 'licenses'), { recursive: true })
     await mkdir(path.join(root, 'data'), { recursive: true })
     await copyFile(process.execPath, runtimeNode)
-    for (const name of ['portable-core.mjs', 'portable-cli.mjs', 'portable-host.mjs', 'update-core.mjs', 'http-readiness.mjs', 'default-plugins.mjs', 'repair-core.mjs', 'data-transfer.mjs', 'runtime-capsule.mjs', 'startup-trace.mjs']) {
+    for (const name of ['portable-core.mjs', 'portable-cli.mjs', 'portable-host.mjs', 'update-core.mjs', 'http-readiness.mjs', 'default-plugins.mjs', 'repair-core.mjs', 'diagnostic-policy.mjs', 'data-transfer.mjs', 'runtime-capsule.mjs', 'startup-trace.mjs']) {
       await copyFile(path.join(projectRoot, 'launcher', name), path.join(root, 'launcher', name))
     }
     if (process.platform === 'win32') await compileUpdateExtractor(path.join(root, 'launcher', 'DSH-UpdateExtractor.exe'))
@@ -181,7 +181,10 @@ test('portable CLI upgrades the app component, health-checks it, and leaves DSH 
         timeout: 30000,
         windowsHide: true,
       }),
-      (error) => /Close the other Portable environment before changing shared components: research\./.test(error.stderr),
+      (error) => {
+        const payload = JSON.parse(error.stderr.trim())
+        return payload.type === 'portable-error' && payload.code === 'SHARED_COMPONENTS_BUSY'
+      },
     )
     await execFileAsync(runtimeNode, [cli, 'stop', '--environment', 'research', '--no-browser', '--json'], {
       timeout: 30000,

--- a/tests/update-core.test.mjs
+++ b/tests/update-core.test.mjs
@@ -23,6 +23,7 @@ import {
   ignoreUpdate,
   installAvailableAppUpdate,
   platformUpdateKey,
+  readInstalledUpdateState,
   rollbackPendingAppUpdate,
   validateArchiveEntries,
 } from '../launcher/update-core.mjs'
@@ -126,6 +127,28 @@ test('update evaluation distinguishes current, component update, full package, a
   const missingCompatibility = updateManifest()
   delete missingCompatibility.minimumUpdaterSchema
   assert.throws(() => evaluateUpdate(missingCompatibility, installed, 'windows-x64'), /compatibility/i)
+})
+
+test('installed update state preserves the shell fingerprint used by compatibility checks', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-installed-update-state-'))
+  try {
+    const layout = layoutForRoot(root)
+    const shellFingerprint = 'a'.repeat(64)
+    await mkdir(path.join(root, 'licenses'), { recursive: true })
+    await writeFile(path.join(root, 'licenses', 'COMPONENTS.json'), `${JSON.stringify({
+      portableVersion: '0.6.0-rc.3',
+      releaseChannel: 'candidate',
+      dshVersion: '0.1.2-alpha.2',
+      updaterSchema: 1,
+      shellSchema: 24,
+      shellFingerprint,
+      nodeVersion: '24.19.0',
+      runtimeLayout: 'capsule-v1',
+    })}\n`)
+    assert.equal((await readInstalledUpdateState(layout)).shellFingerprint, shellFingerprint)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })
 
 test('an independently published official DSH component updates without changing the Portable version', () => {

--- a/tests/update-core.test.mjs
+++ b/tests/update-core.test.mjs
@@ -115,6 +115,9 @@ test('update evaluation distinguishes current, component update, full package, a
   assert.equal(fullUpdate.product.name, 'DSH-Portable')
   assert.equal(fullUpdate.engine.name, 'DeepSeek Harness')
   assert.equal(evaluateUpdate(updateManifest({ requiredShellSchema: 2 }), installed, 'windows-x64').status, 'full-package-required')
+  assert.equal(evaluateUpdate(updateManifest({ requiredShellFingerprint: 'a'.repeat(64) }), installed, 'windows-x64').status, 'full-package-required')
+  assert.equal(evaluateUpdate(updateManifest({ requiredShellFingerprint: 'a'.repeat(64) }), { ...installed, shellFingerprint: 'a'.repeat(64) }, 'windows-x64').status, 'available')
+  assert.throws(() => evaluateUpdate(updateManifest({ requiredShellFingerprint: 'invalid' }), installed, 'windows-x64'), /fingerprint/i)
   assert.equal(evaluateUpdate(updateManifest({
     component: { ...updateManifest().component, requiredNodeVersion: '25.0.0' },
   }), installed, 'windows-x64').status, 'full-package-required')
@@ -819,11 +822,14 @@ test('compact runtime update swaps only the capsule and preserves portable data'
 test('failed compact runtime health check restores the prior capsule and metadata', async () => {
   const fixture = await makeCapsuleUpdateFixture()
   try {
+    const progress = []
     await assert.rejects(applyStagedCapsuleUpdate({
       layout: fixture.layout,
       stagedRoot: fixture.stagedRoot,
       healthCheck: async () => false,
+      onProgress: (event) => progress.push(event.phase),
     }), /rolled back/i)
+    assert.deepEqual(progress, ['validating', 'rolling-back', 'rollback-complete'])
     assert.deepEqual(await readFile(path.join(fixture.root, 'runtime', 'DSH-App.dshpack')), fixture.oldCapsule)
     assert.equal(JSON.parse(await readFile(path.join(fixture.root, 'licenses', 'COMPONENTS.json'), 'utf8')).portableVersion, '0.5.0-rc.1')
     assert.equal(await readFile(path.join(fixture.layout.dataDir, 'private-session.txt'), 'utf8'), 'keep me')


### PR DESCRIPTION
## Summary
- bind component updates to an exact per-platform shell fingerprint and bump the shell compatibility boundary
- expose validation and rollback phases while keeping detailed failures in bounded redacted support logs
- test the immediate prior same-channel release through its declared component or full-package update path
- prepare the 0.6.0-rc.3 candidate metadata and user-facing notes

## Verification
- 367/367 source tests passed on Windows
- Windows WebView2 host compiled with the pinned SDK
- CI workflow YAML parsed successfully

This repairs the rc.1 to rc.2 failure mode where an older shell accepted a newer token-protected DSH runtime and then spent roughly two minutes failing health checks and recovering.