### PR TITLE
chore: prepare v0.6.0-rc.5

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../desktop-bridge": {
       "name": "@wsl043/dsh-portable-desktop-bridge",
-      "version": "0.6.0-rc.4",
+      "version": "0.6.0-rc.5",
       "license": "Apache-2.0"
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.6.0-rc.4"
+  #define AppVersion "0.6.0-rc.5"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.6.0.4
+VersionInfoVersion=0.6.0.5
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.6.0-rc.4",
+      "version": "0.6.0-rc.5",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.6.0-rc.4</string>
+	<string>0.6.0-rc.5</string>
   <key>CFBundleVersion</key>
-	<string>6000004</string>
+	<string>6000005</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -24,8 +24,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.6.0.4")]
-[assembly: System.Reflection.AssemblyFileVersion("0.6.0.4")]
+[assembly: System.Reflection.AssemblyVersion("0.6.0.5")]
+[assembly: System.Reflection.AssemblyFileVersion("0.6.0.5")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -8,8 +8,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.6.0.4")]
-[assembly: AssemblyFileVersion("0.6.0.4")]
+[assembly: AssemblyVersion("0.6.0.5")]
+[assembly: AssemblyFileVersion("0.6.0.5")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -26,8 +26,8 @@ using Microsoft.Web.WebView2.WinForms;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.6.0.4")]
-[assembly: AssemblyFileVersion("0.6.0.4")]
+[assembly: AssemblyVersion("0.6.0.5")]
+[assembly: AssemblyFileVersion("0.6.0.5")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/release-notes/v0.6.0-rc.5.json
+++ b/release-notes/v0.6.0-rc.5.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.6.0-rc.5",
+  "zh": {
+    "summary": "修复工作台已经可用却仍停留在启动界面、随后误报超时的问题。",
+    "highlights": [
+      "持续更新状态文字的工作台不再被误判为尚未稳定；界面满足可见、可交互条件后即可完成启动。",
+      "启动判断仍会拒绝空白页、错误页和只有加载动画的页面，不会用提前显示掩盖真实故障。",
+      "超时支持日志新增工作台尺寸、可见控件、启动层和连续就绪检查结果，便于定位其他电脑上的启动问题。",
+      "继续内置官方 DeepSeek Harness 0.1.2-alpha.3；Beta 与稳定更新通道保持分离。"
+    ]
+  },
+  "en": {
+    "summary": "Fixes a startup timeout that could be reported after the workspace was already usable.",
+    "highlights": [
+      "Workspaces with continuously updating status text can now complete startup once the surface is visible and interactive.",
+      "The readiness gate still rejects blank, error-only, and loading-only pages instead of masking a real startup failure.",
+      "Timeout support logs now include workspace dimensions, visible controls, boot-overlay state, and consecutive readiness results for diagnosis on other computers.",
+      "Continues to bundle official DeepSeek Harness 0.1.2-alpha.3 while keeping Beta and Stable update channels separate."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- prepare v0.6.0-rc.5 for the merged dynamic-workspace startup handoff fix
- keep the candidate on the existing DSH 0.1.2-alpha.3 runtime
- publish concise user-facing release notes and improved startup diagnostics

## Verification

- focused version, packaging, and release-evidence tests: 36/36 passed
- underlying fix qualification: PR #64 Build and smoke test run 33467801838 passed the complete cross-platform matrix
- this PR must pass its own full matrix before merge; publishing will additionally require a successful exact-commit main run