### PR TITLE
Use the existing Chat Manager for archive recovery

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -114,7 +114,7 @@ Open **Settings → Plugins → Plugin Market** to search, filter, visit a proje
 
 Optional provider: [Codex Subscription](https://github.com/WSL043/dsh-codex-subscription) connects a ChatGPT/Codex subscription through the existing Plugin Market or standard DSH command; it is not installed by default.
 
-Fresh installs include only two reviewed, removable defaults: [Image Viewer](https://github.com/WSL043/dsh-image-viewer) displays images produced by tasks, while [Session Recovery](https://github.com/WSL043/dsh-session-recovery) only fills the archived-session restore entry point that the official UI does not yet expose. Other community plugins remain opt-in through the Plugin Market or standard DSH commands. Normal upgrades preserve the existing Profile and every installed or removed plugin; removing either default prevents later launches and updates from installing it again.
+Fresh installs include only two reviewed, removable defaults: [Image Viewer](https://github.com/WSL043/dsh-image-viewer) displays images produced by tasks, while the existing [Chat Manager](https://github.com/WSL043/dsh-chat-manager) is now limited to the archived-session restore entry point that the official UI does not yet expose. Other community plugins remain opt-in through the Plugin Market or standard DSH commands. Normal upgrades preserve the existing Profile and every installed or removed plugin; removing either default prevents later launches and updates from installing it again.
 
 On Windows, double-click `dsh.exe` or choose **More → DSH Terminal** from the tray. On macOS, open **DSH Terminal** from the application menu. On Linux, open **DSH Terminal** from the tray. Official commands published by third-party plugins can be pasted unchanged in this terminal:
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ AppImage 的会话、设置、插件和工作区保存在旁边的 `DSH-Portable
 
 可选 Provider：[Codex Subscription](https://github.com/WSL043/dsh-codex-subscription) 可通过现有插件市场或标准 DSH 命令连接 ChatGPT/Codex 订阅；不会默认安装。
 
-全新安装仅预装两个经过审核、可自行卸载的插件：[Image Viewer](https://github.com/WSL043/dsh-image-viewer) 用于查看任务中的图片，[Session Recovery](https://github.com/WSL043/dsh-session-recovery) 只补充官方界面暂未提供的归档会话恢复入口。其他社区插件仍按需从插件市场或通过标准 DSH 命令安装。普通升级会完整保留现有 Profile 及其中已安装或已移除的插件；如果你卸载了任一默认插件，后续启动或升级不会自动装回。
+全新安装仅预装两个经过审核、可自行卸载的插件：[Image Viewer](https://github.com/WSL043/dsh-image-viewer) 用于查看任务中的图片，[Chat Manager](https://github.com/WSL043/dsh-chat-manager) 是已有的会话管理插件，当前只补充官方界面暂未提供的归档会话恢复入口。其他社区插件仍按需从插件市场或通过标准 DSH 命令安装。普通升级会完整保留现有 Profile 及其中已安装或已移除的插件；如果你卸载了任一默认插件，后续启动或升级不会自动装回。
 
 Windows 可双击 `dsh.exe`，或从托盘的 **更多 → DSH 终端** 打开；macOS 可从应用菜单打开 **DSH 终端**；Linux 可从托盘打开 **DSH 终端**。在这个专用终端里，第三方插件提供的官方命令可以原样粘贴：
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../desktop-bridge": {
       "name": "@wsl043/dsh-portable-desktop-bridge",
-      "version": "0.6.0-rc.5",
+      "version": "0.6.0-rc.6",
       "license": "Apache-2.0"
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.6.0-rc.5"
+  #define AppVersion "0.6.0-rc.6"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.6.0.5
+VersionInfoVersion=0.6.0.6
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/launcher/default-plugins.mjs
+++ b/launcher/default-plugins.mjs
@@ -17,15 +17,15 @@ export const DEFAULT_PLUGINS = Object.freeze([Object.freeze({
   license: 'MIT',
   reviewedCommit: '65fecc574f01d635906a0aa049e8522ef8ca3dcb',
 }), Object.freeze({
-  name: 'dsh-session-recovery',
-  version: '0.1.0-beta.1',
-  spec: 'https://github.com/WSL043/dsh-session-recovery/releases/download/v0.1.0-beta.1/dsh-session-recovery-0.1.0-beta.1.tgz',
-  filename: 'dsh-session-recovery.tgz',
-  url: 'https://github.com/WSL043/dsh-session-recovery/releases/download/v0.1.0-beta.1/dsh-session-recovery-0.1.0-beta.1.tgz',
-  sha256: '4d0243b280b1babc0cb2200e8f0d8972fd816be8af4ea3843e80947faf38aa9e',
-  integrity: 'sha512-D02jzm05DAPsat7hQYQA2hxoFPDc+bjoWfBY+VOd8XWrVXUtiVTnn6Z67Hf/EalNLDcJhK4jydTXWkJoULzgYg==',
+  name: 'dsh-chat-manager',
+  version: '1.3.0-beta.0',
+  spec: '1.3.0-beta.0',
+  filename: 'dsh-chat-manager.tgz',
+  url: 'https://registry.npmjs.org/dsh-chat-manager/-/dsh-chat-manager-1.3.0-beta.0.tgz',
+  sha256: 'e7647aacec3f365cb661a312dd4ce66780c29935cbc36ad5f63afc597e4ed00a',
+  integrity: 'sha512-Y7y29ky5AayIZ3F61sOOyAgZ9S0fFozqw72/4wwyIpADs+ohdOXRGOZrx4o026toG0ig+hbCX7Qkw4aazNrjoA==',
   license: 'MIT',
-  reviewedCommit: '6c2879f4809b6797133187602f22160b940c4ed1',
+  reviewedCommit: '126d135dadb0f41747d6c9b6d72d36f76e6500a9',
 })])
 
 function defaultsForProduct(layout, adapters = {}) {

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.6.0-rc.5",
+      "version": "0.6.0-rc.6",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.6.0-rc.5</string>
+	<string>0.6.0-rc.6</string>
   <key>CFBundleVersion</key>
-	<string>6000005</string>
+	<string>6000006</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -24,8 +24,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.6.0.5")]
-[assembly: System.Reflection.AssemblyFileVersion("0.6.0.5")]
+[assembly: System.Reflection.AssemblyVersion("0.6.0.6")]
+[assembly: System.Reflection.AssemblyFileVersion("0.6.0.6")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -8,8 +8,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.6.0.5")]
-[assembly: AssemblyFileVersion("0.6.0.5")]
+[assembly: AssemblyVersion("0.6.0.6")]
+[assembly: AssemblyFileVersion("0.6.0.6")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -26,8 +26,8 @@ using Microsoft.Web.WebView2.WinForms;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.6.0.5")]
-[assembly: AssemblyFileVersion("0.6.0.5")]
+[assembly: AssemblyVersion("0.6.0.6")]
+[assembly: AssemblyFileVersion("0.6.0.6")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/release-notes/v0.6.0-rc.6.json
+++ b/release-notes/v0.6.0-rc.6.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.6.0-rc.6",
+  "zh": {
+    "summary": "将归档恢复能力归回已有的 Chat Manager 插件身份，并保留可回复的任务完成通知。",
+    "highlights": [
+      "全新 Portable 默认包含 Image Viewer 与已有的 Chat Manager；两者都是普通插件，可以删除，升级或再次启动不会擅自装回。",
+      "Chat Manager 当前只补充官方界面尚未提供的归档会话恢复入口，不复制搜索、删除或工作区管理等官方能力。",
+      "开启任务完成通知后，Windows 会可靠提示；鼠标悬浮可展开完整回复，Reply 会回到原任务，任务栏图标会显示未读完成任务数量。",
+      "继续内置官方 DeepSeek Harness 0.1.2-alpha.3；Beta 与稳定更新通道保持分离。"
+    ]
+  },
+  "en": {
+    "summary": "Returns archived-session recovery to the existing Chat Manager plugin identity while retaining actionable task-completion notifications.",
+    "highlights": [
+      "Fresh Portable installs include Image Viewer and the existing Chat Manager as ordinary removable plugins; removing either remains respected across restarts and upgrades.",
+      "Chat Manager now only supplies the archived-session restore entry point missing from the official interface, without duplicating search, deletion, or workspace management.",
+      "When completion notifications are enabled, Windows reliably alerts you; hover expands the complete reply, Reply returns to the originating task, and the taskbar icon shows the unread completion count.",
+      "Continues to bundle official DeepSeek Harness 0.1.2-alpha.3 while keeping Beta and Stable update channels separate."
+    ]
+  }
+}

--- a/scripts/verify-lock.mjs
+++ b/scripts/verify-lock.mjs
@@ -45,9 +45,8 @@ assert.equal(desktopBridgeSource?.name, desktopBridgePackage, 'desktop bridge li
 assert.equal(desktopBridgeSource?.license, 'Apache-2.0', 'desktop bridge license')
 
 const defaultPlugins = upstream.defaultPlugins ?? {}
-assert.deepEqual(Object.keys(defaultPlugins).sort(), ['imageViewer', 'sessionRecovery'], 'Portable must pin only the two reviewed defaults')
-assert.deepEqual(Object.values(defaultPlugins).map(plugin => plugin.package), ['dsh-image-viewer', 'dsh-session-recovery'])
-assert.equal(Object.values(defaultPlugins).some(plugin => plugin.package === 'dsh-chat-manager'), false, 'legacy chat manager must stay removed')
+assert.deepEqual(Object.keys(defaultPlugins).sort(), ['chatManager', 'imageViewer'], 'Portable must pin only the two reviewed defaults')
+assert.deepEqual(Object.values(defaultPlugins).map(plugin => plugin.package), ['dsh-image-viewer', 'dsh-chat-manager'])
 assert.equal(new Set(Object.values(defaultPlugins).map(plugin => plugin.filename)).size, 2, 'default plugin archive names must be unique')
 for (const plugin of Object.values(defaultPlugins)) {
   assert.match(plugin.version, /^\d+\.\d+\.\d+-beta\.\d+$/, `${plugin.package} pinned prerelease version`)

--- a/tests/default-plugins.test.mjs
+++ b/tests/default-plugins.test.mjs
@@ -16,10 +16,9 @@ async function fixture(t) {
   return layoutForRoot(root, process.platform)
 }
 
-test('fresh products declare only the reviewed image viewer and session recovery defaults', () => {
-  assert.deepEqual(Object.keys(lock.defaultPlugins).sort(), ['imageViewer', 'sessionRecovery'])
-  assert.deepEqual(DEFAULT_PLUGINS.map(plugin => plugin.name), ['dsh-image-viewer', 'dsh-session-recovery'])
-  assert.equal(DEFAULT_PLUGINS.some(plugin => plugin.name === 'dsh-chat-manager'), false)
+test('fresh products declare only the reviewed image viewer and existing chat manager defaults', () => {
+  assert.deepEqual(Object.keys(lock.defaultPlugins).sort(), ['chatManager', 'imageViewer'])
+  assert.deepEqual(DEFAULT_PLUGINS.map(plugin => plugin.name), ['dsh-image-viewer', 'dsh-chat-manager'])
 })
 
 test('a fresh product seeds both reviewed archives and promotes their update specs', async (t) => {
@@ -37,12 +36,12 @@ test('a fresh product seeds both reviewed archives and promotes their update spe
     },
   })
 
-  assert.deepEqual(result, { status: 'seeded', profile: 'web', plugins: ['dsh-image-viewer', 'dsh-session-recovery'] })
+  assert.deepEqual(result, { status: 'seeded', profile: 'web', plugins: ['dsh-image-viewer', 'dsh-chat-manager'] })
   assert.equal(invocation.command, layout.nodeExe)
   assert.deepEqual(invocation.args.slice(0, 4), [layout.dshBin, 'plugin', '--profile', 'web'])
   const manifest = JSON.parse(await readFile(path.join(layout.dshHome, 'profiles', 'web', 'package.json'), 'utf8'))
   assert.equal(manifest.dependencies['dsh-image-viewer'], '0.1.0-beta.8')
-  assert.match(manifest.dependencies['dsh-session-recovery'], /^https:\/\/github\.com\/WSL043\/dsh-session-recovery\/releases\/download\//)
+  assert.equal(manifest.dependencies['dsh-chat-manager'], '1.3.0-beta.0')
 })
 
 test('upgrades preserve an existing profile and all user-selected plugins byte-for-byte', async (t) => {

--- a/tests/product-packaging-contract.test.mjs
+++ b/tests/product-packaging-contract.test.mjs
@@ -678,10 +678,9 @@ test('fresh products bundle only reviewed removable defaults and upgrades preser
     read('launcher/portable-cli.mjs'),
     read('launcher/default-plugins.mjs'),
   ])
-  assert.deepEqual(Object.keys(lock.defaultPlugins).sort(), ['imageViewer', 'sessionRecovery'])
+  assert.deepEqual(Object.keys(lock.defaultPlugins).sort(), ['chatManager', 'imageViewer'])
   assert.deepEqual(previewLock.defaultPlugins, lock.defaultPlugins)
-  assert.deepEqual(Object.values(lock.defaultPlugins).map(plugin => plugin.package), ['dsh-image-viewer', 'dsh-session-recovery'])
-  assert.equal(Object.values(lock.defaultPlugins).some(plugin => plugin.package === 'dsh-chat-manager'), false)
+  assert.deepEqual(Object.values(lock.defaultPlugins).map(plugin => plugin.package), ['dsh-image-viewer', 'dsh-chat-manager'])
   assert.equal(new Set(Object.values(lock.defaultPlugins).map(plugin => plugin.filename)).size, 2)
   for (const plugin of Object.values(lock.defaultPlugins)) {
     assert.match(plugin.sha256, /^[0-9a-f]{64}$/)
@@ -704,11 +703,10 @@ test('fresh products bundle only reviewed removable defaults and upgrades preser
   }
   assert.match(cli, /seedDefaultPlugins/)
   assert.match(core, /name:\s*'dsh-image-viewer'/)
-  assert.match(core, /name:\s*'dsh-session-recovery'/)
+  assert.match(core, /name:\s*'dsh-chat-manager'/)
   assert.match(core, /profile-exists/)
   assert.match(core, /no-compatible-defaults/)
   assert.match(core, /\.dsh-portable-archives/)
-  assert.doesNotMatch(core, /dsh-chat-manager/)
   for (const build of [windows, macos, linux]) {
     const updateSection = build.slice(build.indexOf('UPDATE_COMPONENT_ROOT'))
     assert.doesNotMatch(updateSection, /(?:cp|Copy-Item)[^\n]+default-plugins/)

--- a/upstream.lock.json
+++ b/upstream.lock.json
@@ -36,18 +36,18 @@
       "reviewedCommit": "65fecc574f01d635906a0aa049e8522ef8ca3dcb",
       "filename": "dsh-image-viewer.tgz"
     },
-    "sessionRecovery": {
-      "package": "dsh-session-recovery",
-      "repository": "WSL043/dsh-session-recovery",
+    "chatManager": {
+      "package": "dsh-chat-manager",
+      "repository": "WSL043/dsh-chat-manager",
       "releaseChannel": "prerelease",
-      "version": "0.1.0-beta.1",
-      "spec": "https://github.com/WSL043/dsh-session-recovery/releases/download/v0.1.0-beta.1/dsh-session-recovery-0.1.0-beta.1.tgz",
-      "url": "https://github.com/WSL043/dsh-session-recovery/releases/download/v0.1.0-beta.1/dsh-session-recovery-0.1.0-beta.1.tgz",
-      "sha256": "4d0243b280b1babc0cb2200e8f0d8972fd816be8af4ea3843e80947faf38aa9e",
-      "integrity": "sha512-D02jzm05DAPsat7hQYQA2hxoFPDc+bjoWfBY+VOd8XWrVXUtiVTnn6Z67Hf/EalNLDcJhK4jydTXWkJoULzgYg==",
+      "version": "1.3.0-beta.0",
+      "spec": "1.3.0-beta.0",
+      "url": "https://registry.npmjs.org/dsh-chat-manager/-/dsh-chat-manager-1.3.0-beta.0.tgz",
+      "sha256": "e7647aacec3f365cb661a312dd4ce66780c29935cbc36ad5f63afc597e4ed00a",
+      "integrity": "sha512-Y7y29ky5AayIZ3F61sOOyAgZ9S0fFozqw72/4wwyIpADs+ohdOXRGOZrx4o026toG0ig+hbCX7Qkw4aazNrjoA==",
       "license": "MIT",
-      "reviewedCommit": "6c2879f4809b6797133187602f22160b940c4ed1",
-      "filename": "dsh-session-recovery.tgz"
+      "reviewedCommit": "126d135dadb0f41747d6c9b6d72d36f76e6500a9",
+      "filename": "dsh-chat-manager.tgz"
     }
   },
   "webview2": {

--- a/upstream.preview.lock.json
+++ b/upstream.preview.lock.json
@@ -31,18 +31,18 @@
       "reviewedCommit": "65fecc574f01d635906a0aa049e8522ef8ca3dcb",
       "filename": "dsh-image-viewer.tgz"
     },
-    "sessionRecovery": {
-      "package": "dsh-session-recovery",
-      "repository": "WSL043/dsh-session-recovery",
+    "chatManager": {
+      "package": "dsh-chat-manager",
+      "repository": "WSL043/dsh-chat-manager",
       "releaseChannel": "prerelease",
-      "version": "0.1.0-beta.1",
-      "spec": "https://github.com/WSL043/dsh-session-recovery/releases/download/v0.1.0-beta.1/dsh-session-recovery-0.1.0-beta.1.tgz",
-      "url": "https://github.com/WSL043/dsh-session-recovery/releases/download/v0.1.0-beta.1/dsh-session-recovery-0.1.0-beta.1.tgz",
-      "sha256": "4d0243b280b1babc0cb2200e8f0d8972fd816be8af4ea3843e80947faf38aa9e",
-      "integrity": "sha512-D02jzm05DAPsat7hQYQA2hxoFPDc+bjoWfBY+VOd8XWrVXUtiVTnn6Z67Hf/EalNLDcJhK4jydTXWkJoULzgYg==",
+      "version": "1.3.0-beta.0",
+      "spec": "1.3.0-beta.0",
+      "url": "https://registry.npmjs.org/dsh-chat-manager/-/dsh-chat-manager-1.3.0-beta.0.tgz",
+      "sha256": "e7647aacec3f365cb661a312dd4ce66780c29935cbc36ad5f63afc597e4ed00a",
+      "integrity": "sha512-Y7y29ky5AayIZ3F61sOOyAgZ9S0fFozqw72/4wwyIpADs+ohdOXRGOZrx4o026toG0ig+hbCX7Qkw4aazNrjoA==",
       "license": "MIT",
-      "reviewedCommit": "6c2879f4809b6797133187602f22160b940c4ed1",
-      "filename": "dsh-session-recovery.tgz"
+      "reviewedCommit": "126d135dadb0f41747d6c9b6d72d36f76e6500a9",
+      "filename": "dsh-chat-manager.tgz"
     }
   }
 }


### PR DESCRIPTION
## Summary

- keep Image Viewer and the existing dsh-chat-manager as the two removable defaults
- pin dsh-chat-manager@1.3.0-beta.0, whose scope is limited to archived-session restore
- remove the separate dsh-session-recovery identity from current product locks and documentation
- preserve the actionable Windows completion notification behavior in the new candidate

## Verification

- 385 repository tests pass
- focused default-plugin and packaging contracts pass
- stable lock verification passes
- package digest and npm integrity match the published Chat Manager beta