### PR TITLE
Prepare DSH-Portable 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,11 @@ jobs:
           node scripts/version-policy.mjs "$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
           node -e "const lock=require('./upstream.preview.lock.json'); console.log('commit='+lock.dsh.reviewedCommit); console.log('version='+lock.dsh.version); console.log('packageManager='+lock.dsh.packageManager); for (const [family,count] of Object.entries(lock.dsh.packedFamilies)) console.log(family+'Count='+count)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
-        if: steps.preview.outputs.channel == 'candidate'
         with:
           repository: deepseek-ai/deepseek-harness
           ref: ${{ steps.preview.outputs.commit }}
           path: upstream
       - name: Build and pack the locked official DSH source
-        if: steps.preview.outputs.channel == 'candidate'
         run: |
           test "$(git -C upstream rev-parse HEAD)" = "${{ steps.preview.outputs.commit }}"
           npm install --global "${{ steps.preview.outputs.packageManager }}"
@@ -61,9 +59,6 @@ jobs:
           test "$(find upstream/dist/npm -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.dshCount }}"
           test "$(find upstream/dist/npm-vendor -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.vendorCount }}"
           test "$(find upstream/dist/npm-landlock -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.landlockCount }}"
-      - name: Create a stable-channel marker
-        if: steps.preview.outputs.channel != 'candidate'
-        run: mkdir preview-packed && printf 'stable\n' > preview-packed/STABLE
       - uses: actions/upload-artifact@v7
         with:
           name: preview-packed-runtime
@@ -71,8 +66,7 @@ jobs:
             upstream/dist/npm
             upstream/dist/npm-vendor
             upstream/dist/npm-landlock
-            preview-packed/STABLE
-          if-no-files-found: ignore
+          if-no-files-found: error
           compression-level: 0
 
   contracts:
@@ -107,24 +101,12 @@ jobs:
         with:
           name: preview-packed-runtime
           path: preview-packed
-      - name: Stage the locked official preview runtime when required
+      - name: Stage the locked official source runtime
         shell: powershell
-        run: |
-          $Version = (Get-Content package.json -Raw | ConvertFrom-Json).version
-          $Policy = node scripts/version-policy.mjs $Version | ConvertFrom-StringData
-          if ($Policy.channel -eq 'candidate') {
-            node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
-          }
+        run: node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
       - name: Build Windows portable base
         shell: powershell
-        run: |
-          $Version = (Get-Content package.json -Raw | ConvertFrom-Json).version
-          $Policy = node scripts/version-policy.mjs $Version | ConvertFrom-StringData
-          if ($Policy.channel -eq 'candidate') {
-            ./scripts/build-windows.ps1 -PreviewAppSource preview-app
-          } else {
-            ./scripts/build-windows.ps1
-          }
+        run: ./scripts/build-windows.ps1 -PreviewAppSource preview-app
       - uses: actions/upload-artifact@v7
         with:
           name: windows-x64-build
@@ -487,13 +469,8 @@ jobs:
           path: preview-packed
       - name: Build the product from the matching stable or preview runtime
         run: |
-          CHANNEL="$(node scripts/version-policy.mjs "$(node -p "require('./package.json').version")" | awk -F= '$1 == "channel" { print $2 }')"
-          if [ "$CHANNEL" = candidate ]; then
-            node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
-            PREVIEW_APP_SOURCE="$PWD/preview-app" bash scripts/build-macos.sh "${{ matrix.arch }}"
-          else
-            bash scripts/build-macos.sh "${{ matrix.arch }}"
-          fi
+          node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
+          PREVIEW_APP_SOURCE="$PWD/preview-app" bash scripts/build-macos.sh "${{ matrix.arch }}"
       - uses: actions/upload-artifact@v7
         with:
           name: macos-${{ matrix.arch }}-build
@@ -631,13 +608,8 @@ jobs:
           path: preview-packed
       - name: Build the product from the matching stable or preview runtime
         run: |
-          CHANNEL="$(node scripts/version-policy.mjs "$(node -p "require('./package.json').version")" | awk -F= '$1 == "channel" { print $2 }')"
-          if [ "$CHANNEL" = candidate ]; then
-            node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
-            PREVIEW_APP_SOURCE="$PWD/preview-app" bash scripts/build-linux.sh "${{ matrix.arch }}"
-          else
-            bash scripts/build-linux.sh "${{ matrix.arch }}"
-          fi
+          node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
+          PREVIEW_APP_SOURCE="$PWD/preview-app" bash scripts/build-linux.sh "${{ matrix.arch }}"
       - uses: actions/upload-artifact@v7
         with:
           name: linux-${{ matrix.arch }}-build

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "deepseek-harness-portable-runtime",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-portable-runtime",
-      "version": "0.1.1-rc.2",
+      "version": "0.1.2-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@deepseek-ai/dsh": "0.1.1-rc.2",
+        "@deepseek-ai/dsh": "0.1.2-rc.1",
         "@wsl043/dsh-portable-desktop-bridge": "file:../desktop-bridge",
         "@wsl043/dsh-portable-plugin-market": "file:vendor/dsh-portable-plugin-market",
         "pnpm": "11.7.0"
@@ -17,8 +17,17 @@
     },
     "../desktop-bridge": {
       "name": "@wsl043/dsh-portable-desktop-bridge",
-      "version": "0.6.0-alpha.1",
+      "version": "0.6.0",
       "license": "Apache-2.0"
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.91.1",
@@ -115,17 +124,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
-      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
-        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.31.1",
+        "@smithy/core": "^3.33.3",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -134,15 +143,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
-      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -150,17 +159,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
-      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -168,13 +177,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
-      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -182,23 +191,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
-      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/credential-provider-env": "^3.972.69",
-        "@aws-sdk/credential-provider-http": "^3.972.71",
-        "@aws-sdk/credential-provider-login": "^3.972.76",
-        "@aws-sdk/credential-provider-process": "^3.972.69",
-        "@aws-sdk/credential-provider-sso": "^3.973.13",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -206,16 +215,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
-      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -223,21 +232,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.80",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
-      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.69",
-        "@aws-sdk/credential-provider-http": "^3.972.71",
-        "@aws-sdk/credential-provider-ini": "^3.973.14",
-        "@aws-sdk/credential-provider-process": "^3.972.69",
-        "@aws-sdk/credential-provider-sso": "^3.973.13",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -245,15 +254,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
-      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -261,17 +270,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
-      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/token-providers": "3.1111.0",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -279,16 +288,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1111.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
-      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -296,16 +305,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.75",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
-      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -313,14 +322,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.33.tgz",
-      "integrity": "sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -328,14 +337,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.28.tgz",
-      "integrity": "sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -343,17 +352,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.51.tgz",
-      "integrity": "sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -361,18 +370,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
-      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -380,13 +389,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
-      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -394,14 +403,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
-      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/types": "^3.974.5",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -426,12 +435,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
-      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -451,12 +460,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
-      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -505,20 +514,20 @@
       }
     },
     "node_modules/@deepseek-ai/cordis": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
-      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.2.tgz",
+      "integrity": "sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       },
       "bin": {
         "cordis": "bin.js"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-include": {
@@ -530,57 +539,67 @@
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-group": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.1.tgz",
-      "integrity": "sha512-E1NThkFB3jn3TCqa6Oc++1zQHqLejF3W2wDwv2BlL3UEmgtBXL1K1j1koc+j676RuiOXtJkUJlPcOntRGKLWBQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.2.tgz",
+      "integrity": "sha512-OeGiPD793Mhma9+rGIox95neuufwOFTqQ5jooFgrMK/Mn7Fp7Hkv/d7VKMXZz40iks2fZCbiFE6p9WjTVTQRdg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-hmr": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.16.tgz",
-      "integrity": "sha512-S7VHfylDg1+Y5O6fdYYZu0KFRAj/snHywcFPnX3KmQYa/qv2Q8IXi4zAt9ABq0BJYqhNoqRlbpGMfIjabgXjKA==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.17.tgz",
+      "integrity": "sha512-o1BooaJpwd+C80Tn5+B48MGqrfNZydlfRVQjmCrrULA4nCmlMqBKjDF2FmcZoNP+L2uX9m/6DdGKVtFpQRQVUQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@deepseek-ai/cosmokit": "^1.8.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^4.0.3",
         "picomatch": "^4.0.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-timer": "^1.1.3"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-hmr/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-include": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.6.tgz",
-      "integrity": "sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.7.tgz",
+      "integrity": "sha512-bZ4S1YuOmwOeE97HnslQ6ggVQbaWz4GejJ8OcY4P/DIyc1Qhu/3Szt1XSw6c/pd37kRkxxJXGwt4cmCxWSBBuw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "js-yaml": "^4.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.2.tgz",
-      "integrity": "sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.3.tgz",
+      "integrity": "sha512-YNcHiH7TRFrgnRbQU7qdS1spABUFFHg04QpB9DdboPEjgKLTFfeEAvr6Y7qll3/nGgqywDQdk1tYshqKO0p1WQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2"
+        "@deepseek-ai/cosmokit": "^1.8.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/cordis": "^4.0.2",
         "node-addon-require-builtin": "^0.1.4"
       },
       "peerDependenciesMeta": {
@@ -590,88 +609,96 @@
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-timer": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.3.tgz",
-      "integrity": "sha512-IOkey1VNmJwYa5U8bksyMOnM7mtirqjjbWLr3xA8QybLMK0sMooG3a6iJwtvd8P3MFwo3FQibEg+JPixp37MEw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.4.tgz",
+      "integrity": "sha512-GhxOiU+TF2BbNBKlV2N24zvfv2Kh7RxkFW1hjML6s+DOb+y2zomzbeC5zHIIjsc/rpRwbKpDNucPGSwkH0ChXw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2"
+        "@deepseek-ai/cosmokit": "^1.8.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
-      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
+      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UP1UIh6q3Gme/yXRn/QL2P8IsVlv8Shpg22TRJIZPsCRWLm4CBiA1MUvXmJAfsOEETBMLAl+xWPtFw6ICsN3wg==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.2-rc.1.tgz",
+      "integrity": "sha512-RPq48TzxvwpdT9/7W1tbhZDBMmeK+bxDrX9cqQC27Wx/LqtgJF8PSa3b3xriU8oxtvhwYmk21w2cej3uMQrnVA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-base": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-headless": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-mcp-client": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-persona": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-schedule": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal-bash": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-time-context": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tmux-context": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-ask-user": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-cordis": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web-app": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.2",
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-acp-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-base": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-headless": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hooks-claude-code": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hooks-codex": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-persona": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-schedule": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-minimal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-time-context": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-webhook": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-webhook-github": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "commander": "^15.0.0",
         "js-yaml": "^4.2.0",
         "node-addon-require-builtin": "^0.1.4"
@@ -680,1166 +707,630 @@
         "dsh": "lib/bin.js"
       }
     },
-    "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-cC7lnJe7JgPFcreNXxcxLMxQd78LnpVO9ZXROjZsGRQN1zGH6i/DduI892F1am85IfzzO+XTxMwwUHmfwamb0g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Pv+4p20Eol7Ds/n0OS0vjtChCWfFTJAMThxugXcEcLKEJ9WAtpI4mzWfLgjmeVXnwD2yvp6HlLKDrrQV9PIkww==",
+    "node_modules/@deepseek-ai/dsh-acp-app": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GP3TxD+gWQrF3hLn7gUWIgAZJt1mvHBffQGZ7/dqbn6lcBFXduZXZrkVCEosY8l+iGW4r0Y/gFd3aFOSZo8gtQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-acp": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "commander": "^15.0.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-agent-instructions": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.1-rc.2.tgz",
-      "integrity": "sha512-a3xKsOsqmlWZaGxXfIr97ULJlXSI1clZt0DCSjCaULW4Z1y67DzG8w/kRsb+/Z1pksRMrJE7faLMC/i9S5Y2Ew==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-acp": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NeMdvjOaKUJXViXlaP9stKnrpYKnk07MVqMneznl5nHlQIjF7ddGDCGD+fsMkQ6qT4166UjCQQaoX2kO6E7/KQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@agentclientprotocol/sdk": "1.4.0",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-agent-loop": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.1-rc.2.tgz",
-      "integrity": "sha512-2uJZ6kjJ3IYLRGn6/NhiZgD576ABcbERB/nkReR9TEUMO2zWkz6OuKtVwLyFCFSni2T25Jv+clKQWt7D4MhU3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.1-rc.2.tgz",
-      "integrity": "sha512-88r3jkrbdwTgcP3MZLIUX458Ecu8JcLmZa7PtPszwf33yFoWlZvZmgjyn5ETHV55plNQ8gKMRm9a0RwzGGmzCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.1-rc.2.tgz",
-      "integrity": "sha512-l1C7Z+erWcfj6Ak5EQbcCAPW/0+na4iOXwGknozHgKILLCK2C9CWcrTK0LwozvUPdqh0gFUucSOhi68HQ61srg==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ZQBsDhI0VuFwoDnq75VT2gPJdMPmBYfWM3EBDmUkwHM0E2dmyr+iLGXxp33a7M64r79x7kN+81KOTEL5LS0E8A==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.1-rc.2.tgz",
-      "integrity": "sha512-i/e/Ecg1QCjMePUFHBfjRQU3NbDV0IdORwQbQD6RpiirzyvAIm4vvZgmW/FfgkO2XYJHHIVjo3i1i0YaHPcQag==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.1-rc.2.tgz",
-      "integrity": "sha512-mtmMxA0TZwTjy46E2DF0kmsPCXVq6RBhrwEHWXBaRzc0DLjnYqmJODrZ0X+XwXOkwFZtDxWSv/uheiIsXf8now==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-app-boot": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.1-rc.2.tgz",
-      "integrity": "sha512-eynZWb0oNPKc4OO3HPokqFfz4b5sUEq+EjqhKE2TUWsUsOTgFO43l2Ai3LibqLu6XTpYeHCTbsRLM4Aqg0deBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^4.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-group": "^1.0.1",
-        "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
       },
       "peerDependenciesMeta": {
-        "@deepseek-ai/cordis-plugin-hmr": {
+        "@deepseek-ai/dsh-token-meter": {
           "optional": true
         }
       }
     },
-    "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.1-rc.2.tgz",
-      "integrity": "sha512-QqNSF0+Ddn6qWY480dlilwEy6FLv3JKEWx1UQgoNJrxD4y54SDRzqBQB9yDXWKOoOGyC+05TN6/Px10GNIzMWA==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rCYAt8QsawP1yfDCU7XxNwYT/XWvyFsxYrkwhLLkdfW83QVD0CQHizSkTQE7RFX74nKUD1z3sTLfnLr7xneArw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-attachment-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-bU24CZc2ElJ7JPUUeWLcibRsiuXjsj9dVuUu8yx6t2vensjbqo70kzAIA4eh9q6ai4CeU1/9cRnKLcMQbgNxMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "sharp": "^0.35.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-authorization": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.1-rc.2.tgz",
-      "integrity": "sha512-+ye7d4XzenQ4kpfY2nMIlUhoIbcprotL9fmkTBahafIPDhyyph0JzmUVhz1AGnkIqZc8TltjGzX2ssald+f+3A==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QISKUjEITusLvAkqPLRn70xDUt+GjjY41pISjtPKYcZ4EGmayzhgZ3VJNYEcC+rbaF44hs2o/0VhOwHA7lyxjw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-base": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.1-rc.2.tgz",
-      "integrity": "sha512-DT1kSaseoTZ0b8pwZ5biRkqez2K8AnsLataRiCPsn3uUuxupZOjM1e8x9W+kpkWWFykWy1mbCPhzDRVJ+pLCbg==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
       "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
-        "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-loop": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-bash-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-deepseek": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings-file": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill-badge": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-loader": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.2"
-      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-bash-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GAjYTVsJKXkAptjO767xqt0otMufZRtj2qvOAvkx5Bfusd5R6+mMUkSbcx2K2A8WMbltyCbjwhZf4Tu4xyJAdw==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-bash-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-bagZDMZ73C1dVDBjFCn1flNZ8aOEel4dsmDJTfmagqeYPXfIJDFKPhDc3lWjc+o6jMNfmumeUJ62dwhHkjJHKA==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-mcp-client": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.2-rc.1.tgz",
+      "integrity": "sha512-2DTncjbQfEODOpdADJp6HsGVEGIYTHogGNS7VgpLKtHJ0gDa6nc8ebtrJWZhXojNtS0aZz/nmqGNWCf163hpYA==",
       "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-bash-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8vXsAXoUdzKAgvd/E9DgyT6HKmR6ZM4rtJ3fs/XoJ6n2kBk4tWil8Lv+jxCMWJeMOnTJF55gu2+NWQ3ECFPtJw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YX2WLA/aZdDQsien4Zo7IHTEfYVJ+4QhRXbgA6BrRUM23NSP/+V3K00dQYyQVsF3ZwocE5uyvlZvbYeg1Iz4ug==",
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "ws": "^8.21.0"
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-client-hmr": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.1-rc.2.tgz",
-      "integrity": "sha512-q2YqCvIWXfVQBh+AWLQFDF2cMu2ZabgahGKrWXHqQ5q1dY0ae9CvDV+bCMf8+EwQgz1axSOXWQ35+SSKPGwGlw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-locale": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.1-rc.2.tgz",
-      "integrity": "sha512-AMoR4FwMPLmt6WlYd4m0PCoxXj4qqMhpElBQZSc3r3NyGCZIuleU8tCG1xphGtr/w9mA1Y0kUX7Ftdmf7yV4FQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-modules": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.1-rc.2.tgz",
-      "integrity": "sha512-D0vRgJJpMeTB4ExJTGHk9ay01kLxfK5zvp6bgFjYGlk9sBJgCE3qsOGBFNqD369ylJx4W2oyExAH9lOZGNk3Rw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-runtime": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.1-rc.2.tgz",
-      "integrity": "sha512-o1FH7Rlns0Xaxh4SBOWZ1wpa0ViGw6DXWNm5NFpsBTGYD94RGdIrud3QxgrfzmQKLzu33gvS8JL/IjqbzWyYsg==",
-      "license": "MIT",
-      "dependencies": {
-        "immer": "^10.1.1",
-        "zustand": "~4.4.7"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.1-rc.2.tgz",
-      "integrity": "sha512-U8iT0+jQSbIdPPF4rYYEhmFaTyewryOgL/ye3322UhuFXFapjQcPTBkchvZYYWnTJ/SGB2CpKXLQqiVSjsN2tA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.1-rc.2.tgz",
-      "integrity": "sha512-c3tLJL7Qhok4NzVTE/OomBAsNSLbryT0UndqLaxx/9hcS4W7A984SD0iOF9VuZT4dgZ6dQjMse9eIe9M7Kg08Q==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ORrj3w92n5tif0ecKQy/xGd6vlHPkK3XZCxT0+7JUeA1GRo4TW/wc5ljm0/6hM4FcqKf2x7ndW+OdWfZ2Rwfdg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.1-rc.2.tgz",
-      "integrity": "sha512-k7gIeD/+zRF2jtGPi5tG2vZMUkgVnS9HYPA2yzwB0ilB1NhvL/Xbne1Y9vO4aBAakFE1Be1/1RMIKW4PMv0fkA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.1-rc.2.tgz",
-      "integrity": "sha512-5PCyHw2Y7nz9geEUT23et3h2XghJm7/3iWDAKa1/4ldIfCnjfxiZ5ZNRdZ9Xxpj32tBmh2lc6yxIJwrtepIyTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.1-rc.2.tgz",
-      "integrity": "sha512-zUtgUW1N9m+rnyGxVI1uXmXxWA11JxK0/W5sI3ZiwhIzYJNvIMtkMyBjsoNVOVpgd3krwViBxFfbFpP20ew4pA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.1-rc.2.tgz",
-      "integrity": "sha512-VA6tXDGTgHUvudrbPqgvUCnZcuJOc49OTm4k2tGrazm3uUdO7W5uO/VeuAVD8eEA9afS/0IBqqs0WHc3Q8Cojw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.1-rc.2.tgz",
-      "integrity": "sha512-O4fd87GB6Pt0+FgiiygbV/5+DmLI+sPHEBOWouyWqkDKZ19pgRZ541FpYNOmxf6Hjhf8wiG+Zpy3CYi9+n0+vw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ubC7861LSIIKLR8AU/vR/V79tOffQE7bhzaKbGl1A0IPruCZCFZiyYD5J8P0RPvWPSaePXjF/P49or5bF//tdg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-nyoloPDya2sdsTSn4cFJmJBZWpr2EVgJ+oWAkwIrDGWpDTkQXaX2G44bDmMZas8dY6F2uODfLIBp/rYe4ZdPOQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jro0WgcJdi/ClpyKGWg+/0nEq9mmcda1KIoMsB+o9lLqebDUce/enxdEP0UtIEpQVOJ6EMMDY5Bsn+WtrdJNhg==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-G2yJqYpvfEvqSSJ8Rl61gSfoCcX2v3yGEidKzN5InbS0mcewMqLUfn8RihV2fDKu6UG3nggDGN6aahg0csq93Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.1-rc.2.tgz",
-      "integrity": "sha512-y7xSQyQYGuahLyJcSXpB+JbH1F5lGEc3L9K8cjLy5vd/L9N6gLFLWyeGdlGxxM4jxRt1+rAHDDZ/zl7b8GC5zQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ABh9GhtUmwUXtBMQg/rMrTgyEXrCIuv7gK2UGJ2waurhblSrw2br7EYqTcIsZbVdFIec9+sHHVCmowqJf3lGog==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-CEFpGeEL6gtz0jTRWEpHcEH1cBIwzY9023vWmgyjjcFDOcaKv3G324n+IXweHDttbWGSKdtxfpi4FMOu14W3Og==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dR+7VNod6b1OU3NF8eeAC8if1K+Aj8Z80gj/ly5sBcfV2ezRuhWMwiazFrQfFum5k/EDuoKTL5lOt3pciWEu5w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1kMI5AgyX3LPdXNEr75CaLwC40SIpYUCxWkyVO0xcoZ5VIXuB/E9jmBXTkEXS5US6IzSHWvam5Pm9PahPwX/dA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-45Fsle7tGJsIjODdFFESK5PvO0Uk505UgRAy8vKUz36VGUl4v5WpofW562hFSaDBkUztbJQ6/UpCeEQnWs4bjw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.1-rc.2.tgz",
-      "integrity": "sha512-yCpJWKrA4DLd9lwHuUUIdId8H9Vcoq6xtQoNh3UxOYy4KDeoKbcMsRpOOShlnkxdJYGKOoRk3GpRaDw5RPlrwA==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "1.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.1-rc.2.tgz",
-      "integrity": "sha512-WqEQkyjW467leTJoA31BgqM+nALI3JnrvN1IXDhJuKd8E9nXhTLJcRgDrovEUkh2cjbHF8g8gQJ5Qafg9PzJiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0hXnCb+nKBdlNPgblzhckUQNVrUsfhwDWsexYWs2wFoSWcfALfwjwgN9ZMwS5dj9LLvl/rWib8w9a4miuhFENw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LfGTsbJpCNG0nhT9nBzUucVxnJ5tlY78i5JmlUEb3fwEFUM2cq9pmhv5sXWFdn3LOAnGr0QcyTm+08iBubc6zQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.1-rc.2.tgz",
-      "integrity": "sha512-HSxcn/UbifCGsVSYPxd2dHlURTOqRQ0a907rmQ5TMdPCabEauD+yc0m910XcL+3rRlyTsfW/Vy6AjpNK8cAeJQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.1-rc.2.tgz",
-      "integrity": "sha512-NspsecIb4YdvE54jmaGBW/MjFyuu/MwUjQeM/I9iAgMOpLO+jOsoCOT4M8Su1Nfy1bxokgks9XcBJOcNGjN4Vg==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UCilyaNPwMO54JYtpCW5leLL+ecwtoRd4sHNVNG94aPQAqZOrqH+hqrBBsuolDJ9d0cKG9K5Mtew0fPz/hByZA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-skill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LMpSKA/QIqsv6uGawiMUOY0wgdCzoohBm2Dg7+DGvMmbxdHiUkp0N6HM1SbgO35sS/KP3qBmyDmDrvHrye2EDA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YvlWV2GpDVKR/0Ay4rn9whgPx1o0cLBV1TsOzGAp1yQbm2nKjJ3fUJgwcq2Tf6LAZLpJqGxmg8ji0upmkLBjUg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-theme": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gRKI92D+EZtOy7UBkRfNvyL4e/3HikZ7exQSfgGpLEJ278/aXMvStNbL5ZgWVC41+MSZsBUk3dZAfbXNjelz2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-tool": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.1-rc.2.tgz",
-      "integrity": "sha512-JLLkipHwhpjJsUTECuS7jMq8z1YD9CVYS5ZRZvIYvOd0OxgvBB/ga/CJ5MIIBQhCj8/gLvseAOiqV3wm2OF2Hw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8w8klclVCsqqVM6shVWe0vXtfs6pfEfviKHXPLtX70J+yW042wrRkOqcNh61W14QR+OCfq75TIJZbNPDiIf+2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/react-virtual": "^3.14.9",
-        "diff": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rIyokmmWzOvT5W4zBRlPEs84PtcUXKleGW3oABHaAyIidCcWylT868xzXtUiPBh19Wkr734sZT3rYppoC9fqmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.1-rc.2.tgz",
-      "integrity": "sha512-XuAZStSyy834UdX3jcobv4ZleLXcuwGsn9BVk4/SSi6GKOG1wzsVgxJFi7IhaKGURxuCpheUQKe8+TuE1ScePQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.1-rc.2.tgz",
-      "integrity": "sha512-k/jB5ke2e+oNyNKzu4/PBlriwCHKVg5bY3kn7Co3MtWZdqbJ42hfwZkRNMnn+nmziQXCVXWRzuiHZt0xNTAveA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-cmdline": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0/dEVUm7Xy0aBo0DBqC5F3kxC5ahzKcmHOF+Q6E1lBqTwN2xytGYTh0TSfj+6rS31jDqxeIvWxy35bLl83n/Sg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SgFresqH5UABzRQZ7tOfqzOLMHF7089VeH+mfcwNQH5peOavgEKrAGOYz/9RnISH0XmMrj/x177t8gfO8Uvo/w==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.1-rc.2.tgz",
-      "integrity": "sha512-wE+6x4yGsyg4kntVQFOcb5PiAg2Wb3gs1UNY7SHWC7WOcWCAbREZRfqaoAAxO7AZuqlFhBou7wWc6dZqtGENkw==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-command-compact": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rLNBnq5jo9nm4Etw5PrVtcYlFDTM8IQt8w5aL+7CQiEpC6OevP7QzvGrIbJ2VTG2GX9yN6fJosPd0Ky18EQuYQ==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-session-persistence": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8dnQGgqA8yK7SIxyC2utRdkHhM7mxw9iidDlPOx4GRO4fgY8+UpjxFvWPshkKsY2WNYY/nYcZQt5NNoE/Br4Dw==",
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-command-feedback": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0i0EDLFP0h1UpeWq1KrrUXKJFBK7aoCFfzcWnrrD9Lj36I09XfjNDJIm4kcYNTkbOFb4o3MWNw01FKC5rNJjXA==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
       "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-command-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-AfiBUOd2QjM2PW73nwQJtSDUri8RtEB6l3XVlznUrfY3VFu5tF7GcFUXffTxgtroWrvaqETs/vQJc/zsn8tGwQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.1-rc.2.tgz",
-      "integrity": "sha512-BOIe4Sht9rmMv1a6b3GWjWBbeWr7PtHlAy41vgpaymvUUuzOapOIA648ZMGCI/crRIt72Umev2FHtSwCNSbYZg==",
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LV5GAIx7GO8DCRivnN2bmLmuucsYDG+ifG18BaXBqsVKdrzmaIu5o+CBxQAI2bX1N6mfBenLxmvCnROkyumLTg==",
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
+      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-gateway": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9jYky3tan2ZFAyaNP2+wbOvwGiUwJdvqqBVUJ6370+2d7OeZIfPu4PMLLFvPqGXR28a9TwuhWoT7i9gpHxRmmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ws": "^8.21.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-gateway/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-atomic-write": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lwWwdXRZrL/xCluykwh+HSFzNPlSyhLPP3oyXas5Zp0e+bc7blk9u6J7bY2GTNBQBIUC7AN+xwFKd3fnkIXGIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ir6FKWuuO40E5HgB1vsXKUk9oDxrPIlE39TBwazPc8qkgg42NeSM1OmlpCDo4/wdZh50xPxfdI4EVQI7fN8YMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings-file": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-json": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-fetch-http": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-agent-default-model": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.2-rc.1.tgz",
+      "integrity": "sha512-feuTXXl6jIAp71O77l8XzeKcpgahlCXQ7YUjM+Cl/VF0EBpctKkdvwbvTalImRzYYzX5qGK74hblsT2HC4xEwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-agent-instructions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9AHeOBe7+KimM2ystfesEYhqcmCuAnrU5MK9qzaYv6HBvQZrU8zYgRAxoqSxeUB5eJoYPvWMvBTBPIRAyvzpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-agent-loop": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4h16Gn/5oXLTFeorehdlKe5xmDKscR/eRsUu3cs6clKgaTrn6YvnWNB0XkYEg+AXiXbsyfl5MW5Bs4576t7vZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-anonymous-user-id": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8skUsMXiGnyKJi+AiRjGoXIl8inJHgeHgoruW8pjPpWN6g3qJSbO8U9JRZtvwymtjJsQuHmKPI28jc4H6jOCOQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-compaction-basic": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.1-rc.2.tgz",
-      "integrity": "sha512-qNg4JqWlZ5NvlFmaVZtJ+RuvJUtYFgdS7xXlhhBGSHbMZi4sHgB63Mo+9Y0Rl8glLSxLjo2reMMPlECN+duUuw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QISKUjEITusLvAkqPLRn70xDUt+GjjY41pISjtPKYcZ4EGmayzhgZ3VJNYEcC+rbaF44hs2o/0VhOwHA7lyxjw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-attachment-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9G0ytf9s0ONxnRjOjbAhsHj1eeiQtqb6qBeqp9mWT/9/e1Da7GX/YNlwgSnfyi8EUQEG/rh2PM25dC7DNkWK0g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-authorization": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ixmc2KAx27KS0Dx2zpjH9/cJAQi6IEmiN9bokUL7GdTAeAMu8uz6ajO59YDYYLZSUWemj5nEvRn/55B20fekcQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-bash-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-/3+AO2TSC5RUKzP0/UZuWhIdwUUd30fx35/eTn8+KlntD7gPgDRMIv1JfXVTxk2pCU3K1V9JX3XjdJ5dHpEObA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-bash-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dF9PfBWus80Juj3VjUmndbGw1/6cT1BY7BLFuXUi7SDMV1fA4iwA2c7HuvezYFGvpE/8QRZ+c5ZiRfxbWGYktw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-bash-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-command-compact": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.2-rc.1.tgz",
+      "integrity": "sha512-b0E3HxpitGd15csYx97AiQtGb09AARJDQ0/mvrT1DFrPHOHnep+ybayq8VeOrcDhspTz72PwA7OgxZe/I1yvLA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-command-feedback": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.2-rc.1.tgz",
+      "integrity": "sha512-gA9MVB5LW82dvKm1Rxz9fN0smz/7ZJ/H131iz5AWFYhQsJ4OaDFJU6SxudHfLrAEiVN7ZEGyMU5zqqW1DNtC6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-command-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+MwYtJnr9/oZ4WWcz3g7IRoIt+OUR1F+KZ0Xq3IEVSq8z5A8KBenRz7jVVG2LMksQFlEPxB7kas8SI+WEpWNAQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-commands": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uBh4JTX7pOkFhmbWjXjVLnOQOawyccC7+DazbHrLRN6/wy4OgTRH+DaW0+ibLq+XRAO19OvBTtuoh3x/KkJx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-compaction": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.2-rc.1.tgz",
+      "integrity": "sha512-omzrM2EQdoUvQ41PbbXiFERC7I4FYiLNmHIYrlCZfCAdxo0G4u3kt7eahhVaSSi2YsinL7sW79C7cTVaUWlZVg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-compaction-basic": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.2-rc.1.tgz",
+      "integrity": "sha512-x4HEQ4hiPwHE5nljFXsVzG8nOVnEQIwmIxVB9csnWyKcika6yoAGPujeFcGdZKoMPiADt2JglO8fLuAj3ROCXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-compaction-tool-result-pruner": {
@@ -1847,630 +1338,294 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.1-rc.2.tgz",
-      "integrity": "sha512-HUS95EsuveR8fuzaZW0qSv90mVWbv6aj7W9zfWPbr5BmLJsmomQlw6jFX3GodN1Iv8qWtrzFkMuxDHk4ZTHcAA==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4QcB5CY5+ubrIoNLJBZwNV+2mnagwn4JwDW9qunr7UL29cS8AeWAksqMbpDZOMmyDuLpg4Alcnb5kqKtfZFNug==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.1-rc.2.tgz",
-      "integrity": "sha512-4/DNA4fCSa1nIb52mbRT3TV8wpsnDzjMRJfPbffk8+Fv/bj50jaeQY5yMgUXsUYWX98/RlekXTK4u4LdjtyHKQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-credentials": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e7DGpuYQqiD4dOWGQeY/XAWPTjbax/MkrXBwsB8wBtNpoPiAKiLYgd+iFiQc66BGOlutSRFz31IKdbduqPbTxA==",
       "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.1-rc.2.tgz",
-      "integrity": "sha512-+AQGegPy+gdtcjTTPxDDYwAFUn6BB1J/MFFbmpPr+WIqJoDyVsuCDe8Rr8mCJmxs12CmTZXXSOE03LW203W8fA==",
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.1-rc.2.tgz",
-      "integrity": "sha512-aeVBaH07rox7NuSNbSqbz8g0eNb2IIhNbrZngj/VxUsr/TR9TXOq7lm1CL6SBUDlstGw3vNWeXyhim/DmA5iSQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-credentials-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-xlDyX9BrfT579qv6ilh4EsqtMs4A4oYsuCYHvK8UWQ6YRflxC4GiXDU44iNfosQo5BQwzJzUlBmwHy9id3e71g==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-credentials-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-CuIREkLNPytX0Cl/TSVehdVXz6+QBkY8wjhkSMpOIrtK8hC18c3Hs/kUBwlCk68bbWDvUk+pSrc/l3D4NPwHhA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^4.0.3",
         "yaml": "^2.9.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-file-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8Pd4SNHhV6OlbwfV5K4qmFb709I0Z68qgaUQJ7zM4BTjClNe1/dktQnETtWPfqbPTx/2sNKXM1rz4WXuROrIfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-file-reference-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-aFOn9vsRfjWJYJyBLLD/kItD/KxAzxLNpKTUlxy8mSBMPUM5HEpUkAopgOg265OsjfvKdAVSt+eY1snrURXNgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-fs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8j+6MffvCHATLQrhAVfc9rKyunKu/O7mjjJzmdsUSdID7V4iUYMwqPamhlAyI+tfohZu/vcforKzCRIZGmCYug==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BSIB2j8WvATQ1mf7wUIpHPftDwbzz246qp6aUpLGSzBWGmLBdX3O1oDhyNV1YhgPmDQlwovac2odcAb62tuDdw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-fs-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jvn1MsAMqCmt5SjRNkPjmpc+RIWrZQrBVtf/OpmKr2PaBEGqSbCkPApWDE9iSMhcuQg6k5evScOXwAsduzKOLA==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-fs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tFHHKtD11tIk3FpkWF0vBKdX05zKbwqXQW9LhreA5hErCKEsulUsQLamf+kF1D8fuKqa8Yb+yWQIfYS93cy39w==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rlq7yu4xavkKK1Oa1/aNCOeUW7t/3OXJJOfOcZXuUgJn5f8G0AbpTDpp2CeuL1cHlKpbunGhEkKQ2N/dv7ZR9w==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-fs-observation-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Uw3ErcPwQZUvXylLSf+CDjzfAza5ZVNOMkG4hIJjvgG4WBg3tqoCOY2OQk4O1DGTie4EzL4mHpAe5auwoV4JTw==",
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-fs-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-PI65uLZ3ARkfVV/PXvACS1HEXggoOaXgYQzXQFdLOfm7AiHOdZWZccUAXBetpZhcNYIOKsVoLnfZkXcHByqecQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-fs-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nnZnsOYLWrN2AnoB0qvQBLhh2VdU4A39AqOgWwsxnT3JrScGpvBcBMCt4fpLP9l5VjOY1qhIbLf6xd5p93C/6Q==",
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lSHTh4vfS6eRb9to/y+bjRf2+0QkNpY3tHJ29HMTewR9fJYZsEVVu4Hc+GPhPEjF7RpiD35/sKx+akijtDasyg==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-djzY1oNZV5RwnOFXmDeWFbyswInV9RVWAD0qryxMznQtEDF31PUJ8BQfqs9tVrTV36V3a0neYrZP0DDvRP8ZCA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-goal-round-driver": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.1-rc.2.tgz",
-      "integrity": "sha512-pWipAFKx0l+ai/gJvNQNNk+ukHkb5Rb85llAhJVwyk7YfXLC2G8lIfnG7ln58M3vfUKuLxQLE/GL1Qbr7FQuyQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-goal-round-driver": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.2-rc.1.tgz",
+      "integrity": "sha512-TNlX5K7EL+hNGqegaEs3ODGKhEGtUll368Gtmw+uRmgVzJIUIBiyH4JIDQSIwO8PcYQ2wIpXuipRTgQCp/9K+w==",
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-headless": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Pk50xwmUUehOxNe8DJ2/tThj7Aw1MmJQeUkfAQh9miF7Tm+WOOxiOOei/H4wjH9cf+FuqtbLDw6jrHmGotfhjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "commander": "^15.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lGsP7sbnu20AiRAb+gxYiKx9oa9r1D/8Fr6BwWHXpaPx6ZE4Qg0+ybh5SZVfGQ+XhLcQisu3nwWemEjtTJGiig==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dplRnGGXXsQYFQ1KMHymAM0iaxuE9Z153JHYcGEgOwXNkS3HA20gSi3yMt6fz+zi/cMHYXvY1JQhS54BTc761A==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "fflate": "^0.8.2",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.1-rc.2.tgz",
-      "integrity": "sha512-m3puwS+bvJQ1eASdpEEwlQqKa9znhBSgtoSSI0GZN5VMynZVl7E31HMltENz3QC2Nd+C3bh7vNjrJFtumUDsLQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YW79cegRtVJ3zeVEvYPCpyfIGZV8l5iXUfdm2DI2lwUZsbQ0ZH09AeeLyy6fREmbtuy99l9MExKG1KYWl9No4Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.1-rc.2.tgz",
-      "integrity": "sha512-iLIXqO2fWDsItbtiNPE2Yv2KK0u5A4W5xDbNgd9jpLvzB9vg0NLv4wG9zI4azQ0zf0XgmfPt7BK7UpMM8iStKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.1-rc.2.tgz",
-      "integrity": "sha512-EvCe+NWYCMvJM1FCZCqrT9ggwcQjCGfnI+9t9F1ZIXbjmnhTD1X9K9xt0Ber61lO7ZN20h98Hls8gkzWbHt42A==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.2",
-        "koffi": "^3.1.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-frontend-static": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.1-rc.2.tgz",
-      "integrity": "sha512-KmdcBiprbRPuCK2d5e6VmXbXmT6fwd6nwGtqU6iOxh/Tl3/1V3c/lg7dvJu1LeOmyw8epXFbzgEQNw5ATJtaBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Hud9ezW0bexWfhX7C+c5rdUDX1xzbEGDzj1lGQyj/QxdrxHYHjGrJq3tLRyvN6K4FSmEdG2IBKdQGCOLVrIthA==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.1-rc.2.tgz",
-      "integrity": "sha512-t9MrjC65QHiiWhG9V8UZxgfE/aWYhJHHrIM0kbTvtXxg4tLGIKo/upHp7iiag65F3HTkVLrH/DUyPMi4v2ZA7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.1-rc.2.tgz",
-      "integrity": "sha512-l+1Om/EDFyMjhgSuEx2WDLLA2fia/+ga9mBTCoT/MMslsnWaK5G0/lWwbwlTBSaJ6OfmYc3DuBgox8DbgIGHRQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SXvDJMvcUrGrlzIyE7j8/lI4Pj1nDe/UOR8C05Zagp+/0R8p46n6KylySvZdPAFENV5t8WX3Fw3eOaS4No0+wQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-VuNPXosjgRbEg0tp+GXsdAqkicwSk5Ynl2AezUQheJgpmw5cvWy3rLEg79B686xGc72tIA6pCW6eBbZGnKOmIg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-jobs-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-26lg7mi9RKnu8IP8SWLbY+uZenbqF2AkAZvgZaLDlw1z58NtBsbgKgh6FNC8JXEyknAwYc6auQQKF+nLTlEjCw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-jobs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bfNV6IJRG7vPWg+Rp3siRCA0BVK8rB1aqn0BG2nPKzCIA2coKqeJ8uPbEm+GuyW/naMR4uCOrrCVLyrwBuMwzg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-launch-environment": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LIjPUPwaZ2cIiz98Oqxn9TDKXhWlp+0EGmUhk4RerBAkqRVtDl0B/leK1pSZLLIR+qcr+VAwLGJagY8Xm9XWvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ASJfjIdZbIXvLwi3rGo+eZb/GxMVV/WO5/XVD3B96mT8EIzrlw3+nMR6/CvmJVzcycKQ2XN0wj7jD6TasPRySA==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-llm-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FWt7UZ6l0XN2IFIBYVPJUQkFI0knmA3kZiNIhsdQCjJT5zGe1ZzH1EqqpO5Rzc6THIox58VkvLIllU6Mns4dIQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-llm-deepseek": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GH9AukC2kozv6Q8/9DDhACHSe7fpTG7o0iWGUEN/m7/qajCJ8abySOFi3N7otdVmolR6Mvz2GZDTn2HdHqkWWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "eventsource-parser": "^3.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.1-rc.2.tgz",
-      "integrity": "sha512-/02zlUjTHlJkme5+eM6VFtuiK6TacI5rxwIWMaxItp/s8rz91grzWir+qxRsPrz6XIrmKXagyvi3m/tuRCtk5A==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-llm-pi-ai": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.2-rc.1.tgz",
+      "integrity": "sha512-aT+21AUbZ1JYco9bBcmCgLYG85LLeWTCWUysBqcAkZADb7Vfn5F77LEpztE6BvRHKCtzVvsgp/HKKESwkK0zNA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "@earendil-works/pi-ai": "^0.82.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@earendil-works/pi-ai": "^0.84.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-authorization": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-authorization": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-llm-retry": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.1-rc.2.tgz",
-      "integrity": "sha512-a13Fpmn8HFy8LCjl6gljaNPxcVjO/R+/uMPDl0QLjwQcHWVyGW38ZA8jP5iRuFgdyNNXpyxLWuZXi/0VOH00tA==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-llm-retry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WRpanzi4u2Z2X2uv/rwRZh5HTYUtd5smFTBMT4jYd1UpFOmjoMY/grDboZG9KI1OsgaS1vadiBJT4vvixFDEAA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-mcp-client": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.1-rc.2.tgz",
-      "integrity": "sha512-oxNes59UTkXuTmOqQr6+GhZW7u2JtqSYiI5eZyBQ6K+yjPEQESa3/rYnRI+gHGAtx8EFgn6hsdOS5uoEwtFuXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GzxDiNvyUVs/bbbm+Hr3MfuU3wM8ErRF5z9XadnSGPYZvipZDAMrvrS5v6JgOUaZt6ApBpEMJ4xVgIel1VnGYQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-permission-presets": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.2-rc.1.tgz",
+      "integrity": "sha512-CYGxMvAlePbMMHoIBdmrpdbDtea+mcr9/L4i50CoMGafeihwrkrCOowdYutOUbKWgdVeetME/UCkcdTEDRU+vQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GIknPrwU7vZOUQ2o/ES7Z0uUhUrZGp/yigKP+RXEu41VI9tcybiXQAA8CEdDFmNQ11R2wfYQhr3WO5vy35akWg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.1-rc.2.tgz",
-      "integrity": "sha512-tCni+bTEp/FWokfz3fqn4p6SzHn6pkY6H3HkS9UY5PHrztUE1ESUQUp41kIVtwUhRmJU7yissqjxe6kLDB6t2Q==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-permission-presets": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.1-rc.2.tgz",
-      "integrity": "sha512-k9hdF0lXV6dmVNBeWTmJpk0okaaH3hnvpQVRfUja8mlpJgPr482QMReuQsGJkY8ztzSE+JtzZndPSXjRrvLzSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-persona": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.1-rc.2.tgz",
-      "integrity": "sha512-3pQjr8qSCVmGtExX9WzGNF9tNHKAFjtDyX6g/2HY3Br/hzANfQY13F/HqdjxufB3K0Rsu4CNkq78TyweXVUZew==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-plan-mode": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jIQ71skseprYkwcIkZfS5jtClF6Z5oDC8JIwMN5ukGRDkkoKTT+uLWnw3AgArAOBi0CIy8j5Khy7GP7v+02F5g==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-plan-mode": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dYdmByVI0C94nY+dVO3a2uLofVc+p87Ld04CFtqXLabcsneKp9Oj1sK3qlIaFfSHgrTFCBeTrs8znHxNAb/xqw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.2-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-commands": {
@@ -2478,258 +1633,285 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/dsh-pwsh-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-MtX+IN0dN60n9F8A07ugz4+GptSaoj2Jyub1vkUFkgpdiph9lDAh+PVVG4EKrusu5YG8eXDCDDnb3S1UNtrNiw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9pZh7d2/vGXgGbu6USy6/f14wxbydnnBJItOnoGWWXEwXL9D5zL51u564r6RFxcMuJVWFWFExEd9a2oPRodq3g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-hBUTg5p8TTQifZrfstbimVlBFyUOb7JhNkWKc+n6UpTzoFRSkPAvrjGeXKDmFI6jXpL4nXzLJoaIssfYnRg7bw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.1-rc.2.tgz",
-      "integrity": "sha512-alDGjPdN1o7BVnBy2h4WZa+Zgb6yT76fyAQ7T7wN6K9jbnenSuvCjQyhoehhSFZUEl8ldRqaafFhS9ErGpVmDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@deepseek-ai/dsh-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rnO2RqZ+ycpwrXrXlMcrhWAICdui3ZVTjNQ8eZrOPE18hAbX3tw0nLFq26sBjMSnBfDQHNZ4VaFpt0p8qhkPWQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-pwsh-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jFJQOWkQ3qHWj4xg5he0pjJtzktZYnrjMmDTJmxI4vyMK8UxpEoR0tD4p6eNAJoxZusot9o1/SUqe+HJcjoSrw==",
       "license": "MIT",
       "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-sandbox-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Sn1RTGRFLA3fB+thcBwyyfDRdpgXJ7/6qBz/piFh+emJ4IfGFlBEUz7H2QfuwOGAmzlOmncxf2brcM5SfAgJ2A==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QjJzrM/tJDkgvtVzYz2bmCxBzdSUo/YwI/rPBJeTwLbWBuehyhX6BueCwU6Ja1Bsdm9crz2D7rVc/DU/xrFttw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.2-rc.1.tgz",
+      "integrity": "sha512-p2KQ+EHEUNS9rx4oxJpmLTdB6bdwfmfHA7viUr+2LIiUaUB2nxsOPat33CS/4oOpbgw6DzRWIUGJ1BLW9+ZM1g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.1-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nTO350NlVo9cvKzbeILcPIRIk9ijidrv29snRjTOx7kP5aO/BI2b4KxsRCYoXg8WGAMbIkGbsmZKUD4qz7hyXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-sandbox-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-RLmSPqNivNg+Q+kmKbMuwwH13QTcT5TlJT8rRja/sDxaePS8btya7wWDRsjNDbSs1NjRRi3Plulvw9/BEs8ARw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
         "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-sandbox-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-cpoIUxCzpZJDTMXVt9gS+qgWEDAWf6rIe715uY1NF0ROoiEXPlmToLsHLF+4pXTW3wWWzpGVswO0bPYEKrQr3g==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-sandbox-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nLARL84X6K4DCUJsqRWINg3+1EVxsw70hbP+Yl92W/PsquQVs/UJQc55gnhYGmIMf6eJ0vQv39fziNSnAxdx5A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.1-rc.2.tgz",
-      "integrity": "sha512-DJ5jI8uzJA2VJiIgkUrqNDo1oKMJMaQ1Z8F7kFpxEkI3IMRSfMyqTur740ERBkX3pVc5uDLx6HNeEBx/JR43SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "koffi": "^3.1.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-schedule": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I/uuXlZv6gc71SdXoV5sGQhh95nNjhy0zJWfhttfapNvuQYxZEzQU0vTAOsQB5FtdZ/xvDZm86z01/E8+usLAA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Xy3ejL6dwVSluZL7XOWy76ya4pCw1uHwxodDK4O9XiQUiUV4FBXnt0aNJUtMeAFN0c1YujxxCmRniMvuuNn1Nw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.1-rc.2.tgz",
-      "integrity": "sha512-4/cv6X9HPhm47eyRhCu/WZwzrtJKegk5J+0xaxcZ9i8S0smdxP57tqy8a0jkSshLQn7BzMFxneQrlYExrLrDhQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-VmnQBKuWEHD78CtK1W5Auhz9VayTiNQTpbsNFex4uD/9h0XglFxVN7G3/XVUDOp8VHxReV/Mh8F1RS9s/2yoxg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-log-export": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.1-rc.2.tgz",
-      "integrity": "sha512-IQ0itJ5VsmvTkBZYNnwNIj7h2qaw7dlHrnKt7toUiAc5gC12tFwKouMFdBS5VtOSsxTuQLdnVNPa81XOy24opg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dxdYxRfmK5jWtiFFabqRNb/jGGjkXyF2djI7O8IIKmDVjhQiv170zpvhbAhRUuqClEdseCtbQpLBrRm2blzt3g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1H+boST8tlc8fu5VVClcCRFGI18dH1EOAzfC+HsQZ+GiC7jhPN112oJWyzxKot1P07bmKdKev3un4VR2Chr/aw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-wccstcC9NdeXnqq1Uqgf5P5U5YRgSqVqudvgWLS6ldj0wIRKAmv4fQsi9E+dRlxtxfLdSsHGh9o0SnIPb0syIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-log-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+nSHnhXgIlGg1iE2EWJSCTiGW+DZNFqzCU120RNLoIUkkPzTTtB9p7lwG8fcmddSM/tgBVF9SQzcvSriRwcumQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-persistence": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8dnQGgqA8yK7SIxyC2utRdkHhM7mxw9iidDlPOx4GRO4fgY8+UpjxFvWPshkKsY2WNYY/nYcZQt5NNoE/Br4Dw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.2-rc.1.tgz",
+      "integrity": "sha512-YR5PFDFsM7CLp0zWcLbldfmnPA0T9kROiP7+g1uflBGvhK2JoaH+UM06JGWe7EvnplCGNTnAzcXhAQp7dwz/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SNaOrjRS4RMXocna6uL33TeS/uhcQ7jDJtJZ1HyDPL06mXUdAgje2MVt8OZCh6dH95xIiqpQQm+KjzeiQnhYSQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UvCRpIb+LoQI/nCLof17xc2P2KuZoucU3VuzfAukfsF3dYZAy5OP7jrCRdVZIvjRfvFUd7G+awdS9sWbnjcolg==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-projection-cache": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FfdT3Jtv4+wlBp5B3F7zBKrUlkbQc/xmdKAtAK+paoH45xjDu3nrW2vhXD8mYDSa3TYsxYaji5gk96Bn0UipOA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.1-rc.2.tgz",
-      "integrity": "sha512-QxQFRg/KnrZnYiO7fNtTJVTakuGs9ZFRkGGgYuNPzSz1pRqiohGNE/JZzBtq+HMv38RRTRZrM4aIOUV8OgqoXQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-query": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.2-rc.1.tgz",
+      "integrity": "sha512-cubi3flRd66ebzJ/My5t9YIB7ymLdmQonjb07oU5btMHO/ln+gpKnqq2DcnfsdKkktSR+f5VpLMbfTNtoBuRCw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-query-sqlite": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FwHIJe5/HtRnyl3NjHB+r+PmzuADmjwpfgJIDsurar05/YyeiVqmyIIThUw1g+X2YBezAm4s+gUk32GE26/Nfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -2737,84 +1919,25 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gZ9q3v+NdQC5jaArBMQfpX36wLXXvhtEfKK3zu3jOd9HopYxgNKnm/mUX8Ma9P42gR3Q+m5SGU42pow5vy34Cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2"
-      },
-      "peerDependenciesMeta": {
-        "@deepseek-ai/dsh-session-persistence": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-c9mz19ndxjVxSnXEhmJwGDjyKG4oNmu4Sfneix8OUJ+mAr3jIgb/QZZ8rYEc8Bi+Dd1z7Wr90IeWOBF0nolU3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-stats": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SKGUZicnHHU8+zCswoluBCHSbTkA5ARQjl7YNxN6qY01ud/azpPdbcVaKO2MUy60Q1myx3W0Xk93VzF7sMt6cA==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-telemetry": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.1-rc.2.tgz",
-      "integrity": "sha512-yYNUtpxykp10m6YVCcfmxtfiRZeNr9g+Mg5/37oO6W5Fs9A6L3vfCM4Ppn47lwLbQetejsR1QClV4P4I//c01g==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-telemetry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bchNYxgXzsBZylG5QBQinlq3jsUboMDXSG1BgoQlJ8KHvYxbNP2dINEZ1Z5aEnAiZv+FeuXzSRU4capDpaUhbA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.1-rc.2.tgz",
-      "integrity": "sha512-a+kmjEWvRZTMW/oGzoF0LwlsEOdtr4zCv0PeFPG5+wA3XGqn+uukgh5LnXJt4htApxPfWVj1qBz5GFRgg6MkNQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WF9VMDX8yNqZ2fI7lvt4Rpzr867M+QkEzRRpEQQluwJa2ynz8hSe/tB9GM2wQvcNRp8voB3k8v9eNSBC/fziWw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.220.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
@@ -2823,174 +1946,175 @@
         "@opentelemetry/sdk-logs": "^0.220.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.1-rc.2.tgz",
-      "integrity": "sha512-qHv+9nE6J/piHsWwckmbJBS1sJjunCWsv00arhsgjW1XMLCHxG6QOB+U48P4EBZjve798Tz8AQIlWZy+9T8XmA==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-title": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hCffH0uZWEM9p3MPkOQOFUxpPwfV48N8KDc3hYX7zVOFgHBY93ylwkEEVVkWN+sNp2zJmFrZSya23jFVshDtQg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.1-rc.2.tgz",
-      "integrity": "sha512-HWgRO5C+xFOq8dEKwotJ+jNj9SLo222EIlZuTCV3kdEjblLkSJES8jmXsahzLsIEqXfwdplHfgpG+365XE8NWQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lM6DozrWjxXGGIrMmtAfp3cN8jKt4Xy8e34odR/B6tzUKIJZtQFHaGD7FTsl3GGG7+LRQD7QCvo5dXNHQbjbHA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title-llm": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-title-llm": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UTdH4h5zuMsNDSEAa3xp6YsfVbLRCCkm/0uBt8wKhu7+rWh7OCgvAgvvwaIKEGST8/8NWC6ogdT2GFNCX4WizQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-session-title-llm": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.2-rc.1.tgz",
+      "integrity": "sha512-LVKZQHGbafRkbz9XT25lquZNd15oStlktGqQ6oxv6utdCzqwlAhFy5K7sAUlVPkqLDqGh9JnTm75hs+GX6OlUw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.1-rc.2.tgz",
-      "integrity": "sha512-iGdKEt91Im3gE7xA9CzRfTJsPcFcxDeDOCLhAjzbpjEv7TAjx/EoYP7lPtiy+QmOjKSKy206SEtAKol9PXWbOw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-settings": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.2-rc.1.tgz",
+      "integrity": "sha512-wMmJ2w5S6I7hgmgPppuAVemltEcTmAa8gvii7fk4T2KGVCuBYgig8xPwQ8Lp2ukLZSzzE6ZVCQxhdYZyJX/USA==",
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-settings-file": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.1-rc.2.tgz",
-      "integrity": "sha512-6EKER/KLEOwmTkB0AMb/Or/UVkeaqxisZ4WKo+tgsYyJYDTBTDOZjVRz+nedK7vLj1AH8JiEKvmAf6FMxkZvrw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-settings-file": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.2-rc.1.tgz",
+      "integrity": "sha512-UdNAyQBL2cVKrxKc3lifwhldvMjfoKuwcnnDOrKrscDSIO6zTfr6otfTsO5ChPSZPVLNwnH6kj6vgRr9td7L7g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^4.0.3",
         "yaml": "^2.9.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-shell": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gEqPUxKOpOV66wvM4o8Z5FEuWmsEvYzD9OQy3cyo/kjzlx+2+KUWi22cl/YWtBs/zUtRJbdG5UqMnh8GUeO8Hg==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-shell": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uFrSY0nNKzh5orGl2B0B4RfK7wTdIlwhPQc7aLA44jyjioLlqhF7PUek/NWtye2scwp3YHOw158XeOQUD8qTFg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-shell-env": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dDKKqsxsbklUpxX5ornd/SKJ2yfr/SOHOWDgeJkYvx3SMSXq8EvhCK/VEvHswXQ25rRLFWM4/Mr3htk1hn/GPA==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-shell-env": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.2-rc.1.tgz",
+      "integrity": "sha512-o1VqxyHp1OrMB8aHnzYAPwuU4giUErCxBg0yr035r6f3Le36viS0sUHsnjcAsMdbaQJf/XvzbaokYDVrdVHE4A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-FACjlOqdsWX+0RtSs3RWrdY0QQEpPJrBfvxUbWSh7E8UyCM8dKdIbsQnuXIjsAgC7GgYp7lyFDSCMovQ3ARp8g==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oaHunkTZ9gtlxp66GcqZ3tQmPXEgbu/KNCnc9JipaIwfLHFYiU3CKuFjVAiu82qtSr9w7umRMFKAstkr1R30jw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-skill-badge": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1JL4KdWk8pApJAVGlX7SS7p/MIhFKSq7GgA32qHIKWZBnL0qkwtaDdGbk2mam00NVcfGnpTPBXjwL1kOboPn8Q==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-skill-badge": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bhPQBAWpKhVlPURULy1ZqhVxJZ2+Jq8Yj1wtV0+nY5StTq3UqaIMELtdpklILHqqwExFMk65RYabBtS6qApOEw==",
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-skill-filesystem": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.1-rc.2.tgz",
-      "integrity": "sha512-eyQGv4046c392kIvOCom+gvJpiFbkWsf/VqB7dCQXTZrdXEx99P8oOm3jsagnllcLKYyZVVETs75pPgznye/iw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-skill-filesystem": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.2-rc.1.tgz",
+      "integrity": "sha512-kDciORrnBhA3KuSOcqG5cOPO6QYu0TyYHRQBO+v4Vc7sLyry/2mdWRR8OI9hDEkkjqMiupYRVrgNlj2hfSMKWw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^5.0.0",
         "yaml": "^2.4.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
@@ -3005,129 +2129,95 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/readdirp": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
-      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-spill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-iayBN51zRj0+ER6KKJM6UlN1dfKXe5eDJeSwYmH+j3wLbCBQTD7Axnhmo9t68JBRrg+eczg2epFMR5RrXrisUQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-spill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tt5DfoVmLHWwGPumYSBXWNzf43Kmp8xiWwGb19w+UuiCgDo/zWzTIKyBHI2fUyuwoc9Itk7zDu2WOp/o21XDWw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-spill-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I2t9BRjFw33Ya7c/nSZEwZeDSOCk06fDnGvTmXZoaP+Y4mWRBKStfRk4DvBsUQJW+/ov/E5OEvhNhzhZcUnXgw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-spill-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BIm26ncQXCih4LBK9+Xh7ffBrW98wVHTzCtlZ7KXXxVvsuJe0nITrUxcTeBmc9x1qh8ndBil2Y8Dk8apvCeLJA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-spill": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-spill-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ulkAuhjIm9sOzNdZ7TDqXyvk601Wn3mN/d1QkBBNmCnxt8yQY/nS4ixGtqCVWCu/tdzQOlVw55qKrcNvsQAJ0A==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-spill-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uRQ698e9YV/s605KzVODcKxOIw2t1/tzVDtUoEd47Gh5SeawD51qBTxlGuFWdu9VoYD4tmlaAtjUDEBQFZqt7A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ptJ1ss8spF+Y2VXjsMV37Qh1+hviYWZylDvXtfEBXjLbPi/BP3dktT4B6OMIAD1rRN+0A4HdTqJBgLk7Gp1rig==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.1-rc.2.tgz",
-      "integrity": "sha512-9/3OuaZpxf9NZWhrARpgZ7UBa03pPaTIiDBw+SfESfwVk42NNLVCQgvnEbrWoNwdtzmv0aYCEV23sKwwlQ0LBA==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-storage-domain": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Ee+fI/46ZXgKV4bfLeiNJMhlo9Mx0jT9GXzuJ0DcdGGOsNSZrY/EQAzVXHJJu6EVwIJqBkv1bxEKijVSF2YhZQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-storage-json": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UNq6yn/iCh6T1TJ+4XN1Gofam3oqqNgENxAcnajRaD8KIsryVstS7Nke+j3vLdu6MDiGjCsilxyZYtqduE+Dog==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GhRsymKb1uYbc7OwHh8WTdSXqAcx/KHFJwYX4BYJk90dsOkVx9ccBq6QoJfDYja34s1KCyv2UO/8MUtrzBsITw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-CNa0WuFCR69TMnBKYQInz49/olDSaVHiYkDTyTuDh7YW7Y80/f/HjQe5G0fQaqZMLla3IUSXCIPl5EssWmjcQw==",
-      "license": "MIT",
-      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.2-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-agent-presets": {
@@ -3151,74 +2241,2457 @@
         "@deepseek-ai/dsh-session-projection-cache": {
           "optional": true
         },
+        "@deepseek-ai/dsh-session-query": {
+          "optional": true
+        },
         "@deepseek-ai/dsh-user-approval": {
           "optional": true
         }
       }
     },
-    "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.1-rc.2.tgz",
-      "integrity": "sha512-m5qWHamlJqpwJEUZIZHfKEERhCmsR74B93jGo9ues2pMB7yYjk297oRLQXmaJrQi9FD6zmFntgpwXStK20mbWQ==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zXlwMkp6Bps70s5asN6XtHGjETlKzfbAYOkBEc9sVzBu7Do6vmfNg4NZQMzE3cSm2O7wx28Mmjpiy3/bh+RFVg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.1-rc.2.tgz",
-      "integrity": "sha512-+GCNjPnRJOB4fv6pc4b9qQZvzoluH9neOLCrKEpJsoNn1c2XCQMaylc8G+WEziIbvzDvHcpKJJWm50XlKuDfMg==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.2-rc.1.tgz",
+      "integrity": "sha512-z7+cVtkC5TlseV61ZsMlU89+3WF3WHyPfyLNrvas6R2De+nfUigRedVX3TfEpOmQBwfuuVmtHjNDiua5QJiSYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7R3pcxOS0S2yZrkJ8smbvkX9kZH2Xj3LJ9HYp12UHeNj4tB/vk9kUZK9lW0wk03WSxUdgefOhsVjeKsrWjGOwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-token-meter": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.2-rc.1.tgz",
+      "integrity": "sha512-6mlC89JNGudPvR9LekEo2mnEo/DXf60ZjekIKXxZqpf66AOQ2/pa2HJuFikEd9WWRvu2D96Qvx3rILxi1vXVww==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-bash": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.2-rc.1.tgz",
+      "integrity": "sha512-xKc4oXVDBwM/PaicpjGdWEaJ1N14B7KPmOzdpQ7ynE4gKUnvGU/eTg18EHamdyDOidh5ox0fNUnxk0rQjVo2+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-mKKoboZVhMjJ/SIgtd/xR54KRrG4s5+YYBtkqvxKdQn3tjFxJZ4HkJ41DauwfZqTOXz2r0rWJ4neNqc5ZNaOdw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9a1lcPGD4Z3p7OLTMkkCdwN0w7Gl96Jlypq6qopUA0WMkKai83VfeLZvramPnTJo6ezpuPXcLFWGm/2UDSlbcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "diff": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-fs-search": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.2-rc.1.tgz",
+      "integrity": "sha512-F6j7OhMCowlOwIYmB4hA6sqenw2V7Eez90BjLww87iM9YarR6D/CQcHJN4OIViepuyE4sLtk5gkXM8oT/PeTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@vscode/ripgrep": "^1.18.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ooHKN6Eqy3owNS/oCDO7mR+UalEE4AxJMXou29waahIdSQsFAlk4pPApvhrwg1lpchF5CKwBPOtsVmjq2HfBKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ya7E6zToAdJ+GvNeZFPx8jNx0CfI52tlp0NCGzXHeB0S74haGWCV0iFe1nyoDJg7SDiN1xc1d2nV9klOqWtd5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-pwsh": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.2-rc.1.tgz",
+      "integrity": "sha512-LaImOCdizIGkQnxzzkoaqzRWGZLsuDuqqF2adgJ3zeG0nDwan4Sz+1wYz4YSp0Gg6mJ79CYacsbYmGhYYyKY/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-ralph": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.2-rc.1.tgz",
+      "integrity": "sha512-HRgdfKxuEaFZNyDahTsDrA22EU3UfG70j5kDMtE3aImM8DSvfFIZ0yvjfFG39WBI+uxDy1b7j5HcAImaa87Htg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-H4dORZoB2wuTcHjE1uMvos7D850mE9X1ETjXdzr6+1JTTw8uOeDsHhmNfpOMjhA4/ztFEW7QAQlymI25Er6yAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vD4GEYQ9iOkGaPCLbY4rziAxxAnNwrPS8rgrMkf1R0kfrSSPkAqVaepvuskgxV6M6lyduIKFu5yEHQZwVZbMFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7rQfZsMWYv5oPMvVvQTv+rEDd6CFz4YimJHlSH56fsEwxW/A6Eg3jDBHLpiZpuk03gP6WIzcyExaC9adPq1ohg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-subagent-control": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ogSTUIs3z20weu4dHIHUHL5kzJ+wnjQETGfsrU3qb2ChAbx6LpJvNN788YMI2RP6udVbEJV/0HjkMhIuZsazZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-todo": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NFDdJNwryfwrNDsy9XeYYB9NaI/GAfgNMKvMlMxgXXuvmVoeLD71o5r2/S5Cl0unXLRfV+dP91hkj4Z+aVYTzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-web": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hpBy6VhE12fDeZ1a6bSOOg3msvJCMS4nwD1R2Nm7sjkBCiXR/BYAHmpkHXhNEMvTY2KhnH6qRhx7SFGSstfwwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@joplin/turndown-plugin-gfm": "^1.0.67",
+        "turndown": "^7.2.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tool-workflow": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tqZJcQO7wOgLgT0XLyRjSkMpri0//6WmOVjcoY7+BeybtqJg9OTL31dXBIYpR7QkhQXmeEhHAZl0Lz/7kR+Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
+      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-user-questions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ZXSliLrhEx92TUsjXeNzr3fKLIexnGV+KPcgs+HRUESlsCGs9wuZH6ep4rfrRLc4dYBbw4bbgNKQct7RftJ4eA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-web-search-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-EjnDmaiQdNmD3dAZKWssMgLWm0b+AidB7j5B0YoOMIzrLhajI1Uggnf2Er8L+869P99GJjB1nUm1otzoQ8yL9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-workflow": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JjadkNhYAeU8bD8immmpJyX9zbqke5Y9rWCf9m+vzvE+GUqPwSILTTVzESUxl7rEJtI99UAL6dYy0qbkYIq6HQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Xxe9GzhOK4gIfNUG/Wgx3vsCx7aGZTt268943aRO0wlKQ7Jcku5rH84KfJ+IP2ZY0954KRm4+GQLOKJc/1SSjw==",
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.2-rc.1.tgz",
+      "integrity": "sha512-33fzDRvZSa46l7MPD44ti8lNeGGMI8dTHsoAF/h+puzfEjOBJ4g75sh6oxs7sgszcTUSr5UQAZ2XGU1LC/9DoQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base/node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-connection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-30g7JG+Z8bDj+ux+KsDfMSXPI6zXotMAFNCxI8O8mJiutJNlZxIL5LXQeDrJpVOW9MWWQkoMp+R+Dxzp5DNDSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-connection/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-connection/node_modules/@deepseek-ai/dsh-credentials": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e7DGpuYQqiD4dOWGQeY/XAWPTjbax/MkrXBwsB8wBtNpoPiAKiLYgd+iFiQc66BGOlutSRFz31IKdbduqPbTxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-connection/node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-connection/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-hmr": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.2-rc.1.tgz",
+      "integrity": "sha512-gMw6iSn8va2Nt11Tp8zl7q8riaPp3/3wANqZCExLarKCZUs+6fw5MRbbpV7egX3RbsD/Wiihuw0Mhqxsa3Lwqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-hmr/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-locale": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.2-rc.1.tgz",
+      "integrity": "sha512-p34i5WcZ0+b77RKEatGLc6Rh4OgJJmc15kWbBqtCtSI1BxpwZxjDzoNIMTTS3jDGUQqfEd9X7Js9D4uNJDUewg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-locale/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-modules": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.2-rc.1.tgz",
+      "integrity": "sha512-neStnvWlar+qmADi32QBIJ3m0gmWEk1U0YT9WrTKEfkwQiooPU8lJQjXNfv93x6dgtqieCUhMtUR2a4925R38Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.2-rc.1.tgz",
+      "integrity": "sha512-MOlqFzA/TXyvMq9/hAs6C7J1VzZAU9JwJmHqk+RXr1lTYkez0ciXP3hxURyddyRUKt9+C4vSWirJfrSv6woOCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-5mi8xwZd9AiiYtii5PamrU8VogxvBENViTyxMuJIWogR3RnzuItPvyNoD5+H32d0yIWrKr25V+9xFZo17QXKqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JKescxUlp1I4RBb5uhIaeEF23qYAdkSCMOmQ8lreVXOnerSisSaEhTThocmvmIksi5uUjqH0uxlM8IAtiKsuLg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BX07g202Uo6PtSvE3unzEl9KcbCbuX/3ORbTktjuc2scnjLLrAjBiWm5pirX8m8hYaOVdobcB8xkvLRlR4X1Mw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-chat": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uqP142/EzvlJmqgl6gwCT8dTk9ZM8HusaXLrlircOmVxxrwydeHPb2VvRlcbdW1dzJdrlP7hzGVQJegJBa3AIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-chat/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.2-rc.1.tgz",
+      "integrity": "sha512-icfc+d0IAFj8Yd8l8Bq00AsOKAlUTDQfYDICiCIwkqhRzqJgjZGpLIe+M7idr2iZUmM0xstr+r+H+nzi/336OA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.2-rc.1.tgz",
+      "integrity": "sha512-PDrV7twPfmZE5TjdvdVVZMHOla36wCojRC8GJBUp1cdXsWUP+Omk10gxYbH1g5TQPdAWgSL+GktdjondSXMSNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@lexical/history": "^0.49.0",
+        "@lexical/plain-text": "^0.49.0",
+        "@lexical/text": "^0.49.0",
+        "@lexical/utils": "^0.49.0",
+        "clsx": "^2.0.0",
+        "lexical": "^0.49.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-conversation/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.2-rc.1.tgz",
+      "integrity": "sha512-2ZtuMYvUOoZraYeXZKh+RkPq0RJFJxPCZIyBdrU6o7k8+WJEflGX0eq3GZ7uy/p97v2V9blqCdIRPz8AAm5UXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.2-rc.1.tgz",
+      "integrity": "sha512-1w8SNnxXA+9xuHqPRb9Z8lesQbik9zYN43+NwzNQT4uoqIcxNpZkiUFa7qG1qRD8Du02D7J0gObVbRJMPnBSkg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.2-rc.1.tgz",
+      "integrity": "sha512-11BYh3EOZWbTMjMeskE0Np244b4YYcMkKe5JSSqISL8FT8De3SpOQdKjijt9bX498a6kNlhKWQ27nEzJ7yat6A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jiUaBBc3XGgS073YhoODC3xFBkG57yznkegbh2V6CFp9c7GLXnIs/7yK1JYA5zxSiOMeEBqynphXMGyAABZdfA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vdB8TZyHM8xLUKmKsZtBQa0gQV0YR0uM2HjkpqAgOhVFeykGWhLtdhi+7kagEAAlthCQAFh4aYmdhWLfr8l/oQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.2-rc.1.tgz",
+      "integrity": "sha512-TqdW8VLfNUQYg4g+hVKn22lzpUFMWYbziSBNvi8KVg+aK+SiX+q2UHSGbUQzfYy6TGz+d9HHG9gts7Um/5cHLw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-yMvMk1yPinci0U2nqTyaxu+/IXI5DlFmTac3QBoaQGwu31SoreuPjThjPcxnTyJCR9MAwyWcgkpGoXpK0Z/DyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hV/FMsJ/JjaCDxfaRH4+V2t7RauiQqo0vr5Ql0wi32dC4EYT/thhslu9TNCaHpm92SkOkgGFrlwmjYB+slq3FA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JBjZtx5IyrYuYgGnZBuMWKWrH9BDX5uDcEM7dxoUWGwhTca1sDw4I3eKGnIRng6pFoG9SdlXR5lkz18cZd7JCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-eJaZkGhFSS9Wr7rKEoGtei8LoHfsDyHiLpamaZ8eyHS4FN7auqgSUD32MymOqsrrh9+BWNJ8iltncpt8vCFGCA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8SwRFa37w52JO5N7XzsHNQwVLgwqE2avnQpsqrRq40x45i2IKDbA2KFmqBAwIB+2yO/jVGyrtU6SZHelN2T+JQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.2-rc.1.tgz",
+      "integrity": "sha512-eu7bRtNkXCmaKc1CR/TEVhdB+ZzT8iPI9/YOm9ao2yteey5uNVxelSWoO/eENs60twVQ8w25MibDRfGNshuZ4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-reference": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.2-rc.1.tgz",
+      "integrity": "sha512-apaG3DlG6bPlwyfSezu71MiFdJJp18gQS4zlNNrAAaZf8sEn+n6eNfoaBsMCzdchwQNTp1dLDkLK88q4RMG9Bw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.2-rc.1.tgz",
+      "integrity": "sha512-mG4aNL7dL57i6I6FLol3AWWp3g2C+EV3jYt2MZHzbfMcS0gQnEd/BSGH3T5DfNCQcOEIGqu0TQ0B3bxnJatmTA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-schedule": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.2-rc.1.tgz",
+      "integrity": "sha512-yZK6iQrePXHNUmlqzPH7jhrv8Kd00tw5/R5kuFfYlXzC7D01TPirYhviJu+fx3TNp5/pI8wP0QHg4Z5Fd+/VuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-A54OtGqniFgT/FHnuUXRLsmR8bJwM3pJrHkgQCvblrDSVdzfjqqglRLcdE0y0W6v2w9V4KpdLuqMW56VoqL42Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.2-rc.1.tgz",
+      "integrity": "sha512-/S16tlS84fggURMqO94HjYbE0xIH82aRJ2E4UupgM9acD3yJ6SCVam17tMcWKnqA6UWJK9llEHhl+KN9JyI/0Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qJfUARsCQ6uqwk2dPrspw30JKUrzTXwPtFcoSCra9ZNTweNcS60FxqwtoCA64//PZ2DMxD/OeuOYQQh3HnniFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-general/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.2-rc.1.tgz",
+      "integrity": "sha512-r4ErsBy1NE9QWqZmFyxoBFQhCc+pymmc62PFN7PBxFAX85JRJ3asWwjZPpgXW+y7AkqNWy1JVJqlLdf7W5pCIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FIZptwP3ZvoxsebwqnXyKWvxv2lPte7W2dJwmU8cb/BPJ6MqpQpHKWEaidVErwNDzgvGH02P3wP2lUkvGL1nAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.2-rc.1.tgz",
+      "integrity": "sha512-duv2kU94U2Kz3czBABCCz5yCm22gH3zUoPRyjhD9aykxbXUw7CaJuuv7PqedMdWB9JJT2MKpc/K2t7CkYqCeDg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+KSFQIsoRK/L2vgExSWQqApeDcE3gJB0l8F+f2wa3t1j4yU1i8GhoIrtjDj+tC7rNVX3oWDOpGE5Hui/GubU/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ec5WDXW8VYnL7IW/FAC4LhnCWEoS1khDdv6McYOk/BUrOhkjymEwIE8GZdBgRW3Lp/uPXE5dHfPsr6B4p8SqSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-LG5XDUoNBMDgNrXyyYbxKZN/0hJ4oPjzAoIrg8NPfZea7HAfHGQ8L7Vdc4e5xhJs69TFWy99glhi0L7VU5bfig==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-theme": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JqSxsN510rmJl14IKpcZcDmO7qOrr0ftY/anRhgzJ2gDsamUXlLraaUGpcLgGBnNRvWO7X5N22R8HKPUo4uLQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-theme/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-tool": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.2-rc.1.tgz",
+      "integrity": "sha512-rr3ENrcaRZ8Vb1RkfLaFWUZTGoSfr01GZmwtXi0NHc3HFrRlZwPy0aGeKeMNF/TBoOsV57gxGdWMAPMKWHlTlA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Q+O0cvpr2fzqPAWUEG+CbUVXu0nS1Fnt8a4tJBk0qeWSBfserCTCs3/pGhx7h+lIm/uwjfPsVp8G9M0RQCR+RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.14.9",
+        "diff": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WNy9euPx0U6HI0SxzujRFG2hVI8MYtLZdVrzMUxzUfrelWdXMRUvneiYcabm0Ss14u47E0tZAetuJaKlwTyK3g==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.2-rc.1.tgz",
+      "integrity": "sha512-UXST3yp9tMuRIP5RqXkmShJqtnYcRJE7J0Ujcj1uVcac3JWaoEI8Ijka+Pb3DJlwCHN8bpLpynmgwyqu/A5gdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9zp9ZRfC1nmGEvtF6g5aP9gSgIhA6wAv1LPldxCs5Iicv+5oXr32JqhUzC0X7uCEnh2cFLEcYtEmEllcXsislQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cmdline": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.2-rc.1.tgz",
+      "integrity": "sha512-5lSAhyFiJkJFsNzAu3oAgK5Bur9syR/Iq7XVgkC4zA5BmPb+0OAxZ8V/Ihj3JnhrtC4Q3+J6jsZyZRnk3M8x+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-code-runtime": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dv5UszPJb/AFcarZc2c6h5z/X80bsrSd3bfIOugwNVclSI6P+L3ixseoZKgyks7T0Ap0h6ngXGk2WeoUkmYxnQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.2-rc.1.tgz",
+      "integrity": "sha512-CjJ1x8Ub/GTbMsAXBpdGK10ZMoLRLQxnJDM7hUb/HhCOSwjfRiUYXw4KyPl3Ez7ariW/qIlI+HZBLiaDb8AUWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7UTnGeKWpxfJRewQ8uADe2CoSCaJesI6W8YXJ/SzHA9hvHx8KM3hZl0fD6OxlQszUFoSeWdkCFZocAd97Dw5Eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deque": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.2-rc.1.tgz",
+      "integrity": "sha512-v2HL9e6NER5Yv8p3+8zls9YvhG3NeRRMVg0GZ/4VgOJcVDgZp14EYVVbheX9HzYlyiic41ciAf1T8Y2pkV41OQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-home-paths": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.2-rc.1.tgz",
+      "integrity": "sha512-DeDXxvrhAlkS+hxNLSFvWp8LDFhn26pO8gcutptOgSkrObM0yYW5119kyduwD1ExW0v1geToX+uDjBxO/SS/pQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.2-rc.1.tgz",
+      "integrity": "sha512-OQUMJFzqz+AD2ONXxC6pxSxEW20Nbq8xENhRkAMRi9eGfdUxt+4ANB2JN8LPXYs0Kzd+/azNTghsearQnVU7xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.2-rc.1.tgz",
+      "integrity": "sha512-krm27o84Gpy20QaeiUaGJH0EMhw0ajt9riJ+3A+KDklwYcZ/x0H5T+PNnejUI0x2mELIQDrFg/95dlzET1wJ1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.2-rc.1.tgz",
+      "integrity": "sha512-YNQgkWBT3f3aImtb7rUGkVy/0uJy2x/T3G+v7SWIMkOO+7XWvqxJ3Y9alU0GcaFbnTMepfnZzv5S8s/IJy1mGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-browse/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ThdAccRwHx1UwKeIuySCR2msDOEk4q12bqFOTbpa9TaZtbMQDIIyvNeXrXXNAxkTo7WKi6Nz6KNYEorOUnizSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.2-rc.1",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-frontend-static": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.2-rc.1.tgz",
+      "integrity": "sha512-MYBkvRe62S1Gkt1YMTXUF55CbOB7RMVulTdzfABwCK1LgKvYur6cILkHLP4jUM3Hi0XJp7IdITmvTjjeFHFYrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-frontend-static/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-webserver": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QVcaf4qnIa1t215Y8TRiRhqkEz4Lu5/F+KqvWT+4sHOiyWmZr8g1JndqlwP6MBnMQEPmp0I/EKYJ7PWMV32gkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "compression": "^1.8.1",
+        "negotiator": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-webserver/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-launch-environment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-f9yDccTKrbClo71pIiAGqBxPsYf+vvcYA5zxkfgmjphpxI3HMwdDl+LNyqTHBe9UxpbgBzQNYQGtfWO0kDTefg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7VYsha5AXsVLnsAwYJffWXz9bwUbElw8i5N8tlTSdai9Bupk3sMbsotzPf8ZbsuGAxQYErahMwQwgGEu4qZO6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-native-command": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dBVql+9hXcdnWcfwBiFAfzz9CmAnx6iWYsBFQNdPgVu9m7VcOyiIT8ZQ47BVm7GHmpDXmqiI7pL1iwnI56hrzg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-output-retention": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QkLhJVGmausQ3kYORlp1aP1XjloG2J0mJZvnplNJt6iWPmzkE8ObAWOBpQGMVNrNAsucrXr/haeGU1gXLUSXsg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BPaOnN86YDNzLywOCUHNFW9KbUXFZpVUbuU2Djmnnsi+tl/g3qyhOR0ROJDV1Jb5NMYDcw3c5E72Hi0fgCrIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-win32-process": "^0.1.2-rc.1",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.2-rc.1.tgz",
+      "integrity": "sha512-aewk23zvjr4QMVTnAGaBBRlWEtdKyDuuG3BAfUeAfoOwmM+5LtK71VrVODFDybT+stn/FQfdL/vFeQ4GSs1y+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-anonymous-user-id": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8skUsMXiGnyKJi+AiRjGoXIl8inJHgeHgoruW8pjPpWN6g3qJSbO8U9JRZtvwymtjJsQuHmKPI28jc4H6jOCOQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QISKUjEITusLvAkqPLRn70xDUt+GjjY41pISjtPKYcZ4EGmayzhgZ3VJNYEcC+rbaF44hs2o/0VhOwHA7lyxjw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-credentials": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e7DGpuYQqiD4dOWGQeY/XAWPTjbax/MkrXBwsB8wBtNpoPiAKiLYgd+iFiQc66BGOlutSRFz31IKdbduqPbTxA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BSIB2j8WvATQ1mf7wUIpHPftDwbzz246qp6aUpLGSzBWGmLBdX3O1oDhyNV1YhgPmDQlwovac2odcAb62tuDdw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-llm-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FWt7UZ6l0XN2IFIBYVPJUQkFI0knmA3kZiNIhsdQCjJT5zGe1ZzH1EqqpO5Rzc6THIox58VkvLIllU6Mns4dIQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "eventsource-parser": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nTO350NlVo9cvKzbeILcPIRIk9ijidrv29snRjTOx7kP5aO/BI2b4KxsRCYoXg8WGAMbIkGbsmZKUD4qz7hyXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.2-rc.1.tgz",
+      "integrity": "sha512-eoZSnH2kReDvAHihFnWmbqryTMO+mV1nrhoCGJ4mzhLAguFWxJB2CRJ1ZO9hqTukoKYhqp2BpvSvtZIjKIzTQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-sdk-protocol": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tt0kRuk6Wqwiytx3XVz8gitFqMn097INtDdCnWofRjgJqwUv+n+vsXAzCYNucATp7lxhYzsayzLR0FfacYoZtA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-settings": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.2-rc.1.tgz",
+      "integrity": "sha512-wMmJ2w5S6I7hgmgPppuAVemltEcTmAa8gvii7fk4T2KGVCuBYgig8xPwQ8Lp2ukLZSzzE6ZVCQxhdYZyJX/USA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GhRsymKb1uYbc7OwHh8WTdSXqAcx/KHFJwYX4BYJk90dsOkVx9ccBq6QoJfDYja34s1KCyv2UO/8MUtrzBsITw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox-policy": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-query": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-user-approval": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
+      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dzpZgq72dGZ0pt4GCSWRL4p+tnGjB8qATxQ9h1LvYvppT39MFImN1SI6mqLf0xS6Ur7UJGxW8UoILyfJLocpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-agent-loop": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4h16Gn/5oXLTFeorehdlKe5xmDKscR/eRsUu3cs6clKgaTrn6YvnWNB0XkYEg+AXiXbsyfl5MW5Bs4576t7vZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-anonymous-user-id": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8skUsMXiGnyKJi+AiRjGoXIl8inJHgeHgoruW8pjPpWN6g3qJSbO8U9JRZtvwymtjJsQuHmKPI28jc4H6jOCOQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QISKUjEITusLvAkqPLRn70xDUt+GjjY41pISjtPKYcZ4EGmayzhgZ3VJNYEcC+rbaF44hs2o/0VhOwHA7lyxjw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-credentials": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e7DGpuYQqiD4dOWGQeY/XAWPTjbax/MkrXBwsB8wBtNpoPiAKiLYgd+iFiQc66BGOlutSRFz31IKdbduqPbTxA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BSIB2j8WvATQ1mf7wUIpHPftDwbzz246qp6aUpLGSzBWGmLBdX3O1oDhyNV1YhgPmDQlwovac2odcAb62tuDdw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-fs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tFHHKtD11tIk3FpkWF0vBKdX05zKbwqXQW9LhreA5hErCKEsulUsQLamf+kF1D8fuKqa8Yb+yWQIfYS93cy39w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-VuNPXosjgRbEg0tp+GXsdAqkicwSk5Ynl2AezUQheJgpmw5cvWy3rLEg79B686xGc72tIA6pCW6eBbZGnKOmIg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-jobs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bfNV6IJRG7vPWg+Rp3siRCA0BVK8rB1aqn0BG2nPKzCIA2coKqeJ8uPbEm+GuyW/naMR4uCOrrCVLyrwBuMwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-llm-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FWt7UZ6l0XN2IFIBYVPJUQkFI0knmA3kZiNIhsdQCjJT5zGe1ZzH1EqqpO5Rzc6THIox58VkvLIllU6Mns4dIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "eventsource-parser": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-llm-retry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WRpanzi4u2Z2X2uv/rwRZh5HTYUtd5smFTBMT4jYd1UpFOmjoMY/grDboZG9KI1OsgaS1vadiBJT4vvixFDEAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9pZh7d2/vGXgGbu6USy6/f14wxbydnnBJItOnoGWWXEwXL9D5zL51u564r6RFxcMuJVWFWFExEd9a2oPRodq3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-pwsh-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jFJQOWkQ3qHWj4xg5he0pjJtzktZYnrjMmDTJmxI4vyMK8UxpEoR0tD4p6eNAJoxZusot9o1/SUqe+HJcjoSrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nTO350NlVo9cvKzbeILcPIRIk9ijidrv29snRjTOx7kP5aO/BI2b4KxsRCYoXg8WGAMbIkGbsmZKUD4qz7hyXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-sandbox-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-RLmSPqNivNg+Q+kmKbMuwwH13QTcT5TlJT8rRja/sDxaePS8btya7wWDRsjNDbSs1NjRRi3Plulvw9/BEs8ARw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-sandbox-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nLARL84X6K4DCUJsqRWINg3+1EVxsw70hbP+Yl92W/PsquQVs/UJQc55gnhYGmIMf6eJ0vQv39fziNSnAxdx5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.2-rc.1.tgz",
+      "integrity": "sha512-eoZSnH2kReDvAHihFnWmbqryTMO+mV1nrhoCGJ4mzhLAguFWxJB2CRJ1ZO9hqTukoKYhqp2BpvSvtZIjKIzTQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sdk-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-sdk-protocol": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tt0kRuk6Wqwiytx3XVz8gitFqMn097INtDdCnWofRjgJqwUv+n+vsXAzCYNucATp7lxhYzsayzLR0FfacYoZtA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-session-log-deepseek": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+nSHnhXgIlGg1iE2EWJSCTiGW+DZNFqzCU120RNLoIUkkPzTTtB9p7lwG8fcmddSM/tgBVF9SQzcvSriRwcumQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-session-persistence": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8dnQGgqA8yK7SIxyC2utRdkHhM7mxw9iidDlPOx4GRO4fgY8+UpjxFvWPshkKsY2WNYY/nYcZQt5NNoE/Br4Dw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.2-rc.1.tgz",
+      "integrity": "sha512-YR5PFDFsM7CLp0zWcLbldfmnPA0T9kROiP7+g1uflBGvhK2JoaH+UM06JGWe7EvnplCGNTnAzcXhAQp7dwz/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-session-title": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hCffH0uZWEM9p3MPkOQOFUxpPwfV48N8KDc3hYX7zVOFgHBY93ylwkEEVVkWN+sNp2zJmFrZSya23jFVshDtQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-settings": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.2-rc.1.tgz",
+      "integrity": "sha512-wMmJ2w5S6I7hgmgPppuAVemltEcTmAa8gvii7fk4T2KGVCuBYgig8xPwQ8Lp2ukLZSzzE6ZVCQxhdYZyJX/USA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-shell": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uFrSY0nNKzh5orGl2B0B4RfK7wTdIlwhPQc7aLA44jyjioLlqhF7PUek/NWtye2scwp3YHOw158XeOQUD8qTFg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GhRsymKb1uYbc7OwHh8WTdSXqAcx/KHFJwYX4BYJk90dsOkVx9ccBq6QoJfDYja34s1KCyv2UO/8MUtrzBsITw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox-policy": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-query": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-user-approval": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-terminal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-O9MJdEpZBvoYzjWXycmgh/nMmXTgXoArZOXwld9q34cSgkXSUOVOPSiPuN5HjPZYZcT4aeT7Q4Wdr4LxezbshA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-terminal-bash": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tDEjaycT+2ZRmy8yVZb/1p/ZvulfPtfiRVfYqOENNSitlWIUgZWq5JH32JuGsXZpYJTUhwrDLHXSR1Lwls29ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@xterm/headless": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-AcWq9UHKmLyNTh67Aa5UapmuLYdDVUJy4aJ9NvrI1DJLHCZQCs9NCUDx3UecyCwfa7qHtOEz205LY5HRACMqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Y8hRn41iRaRY88qH2zvR9sk3VSPnfqkLybqoOSepezfM6LXtrY24hNS0GTmRd88hlSre0DtB92c0WAJ+QLixmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vD4GEYQ9iOkGaPCLbY4rziAxxAnNwrPS8rgrMkf1R0kfrSSPkAqVaepvuskgxV6M6lyduIKFu5yEHQZwVZbMFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
+      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-export": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.2-rc.1.tgz",
+      "integrity": "sha512-S3r4GSNP0LPI1qf7psVNByeEf3p96JoP7jtBOLgWa4tdgbqtYvGADQmMGcR624EwVlf7APPqcFePxpGqGnoXbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "fflate": "^0.8.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-export/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-export/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tMtOe7GkHKZ71QpOzp2Mfisg37aAYjPCRS2MYfDrgM0pmj29Gn7HOxAPCk6gEqxs6rZbPbG1/SB9esWuQNfITg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage-json": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vYQ/0Eh2Uzjdxi6vf3Y3WZg2ux4pG0ubgtC6VHGngtQekgIdtk4aRTvRAtBdFgfmyewM9XjLgvKxTUtkh000Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage-json/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YXEBaUfdkCJm4Wj/w08imS+1TMd3K4Rjr/xD5tuJR1I4/EnBCseP6AOlwjcrDP5PPWfOZghrK8H01sk6cqiK8Q==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.2-rc.1.tgz",
+      "integrity": "sha512-roTna1QHNpR5NsOLBWRai+GxW1hQAUyIyXOg5tsAIPXt7dug/kZJXeryiR9e92Fc/yoXzHMgrBQCThuXuo97LA==",
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I4pyzpohZEVRQQbuEpMP0t8oKsf+XIlRo64aJVKGXI2eMcg9f9gbfhKQNYNqRGbegQL1HYpSLU6Rzyibldgwaw==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Spc/IXWvjEteGysifGr6JvCokcH8T88z0mdxIGcu9SFdgDyY8HKR+h5yq73+rbo4RYzT7+TBE43TIZy5LfmzgQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3226,748 +4699,2050 @@
         "node-pty": "1.2.0-beta.15"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.1-rc.2.tgz",
-      "integrity": "sha512-on4hjAlYI5uX9q7Sf95YkMMBVe6heywtA/H50ksrIMUub8U2B98hO9iQpHhjwIO1F1vu+5pLcPvRr6yUGGmtXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-terminal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-NOsajXg4cX09coiLtCMgSqXAw90uptqyA9Njv6MVAOLgh6ctpjsolL3VIIWapSJ6AngsCTqVXW7sxexwpl0yUw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-terminal-bash": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ltR4K6OBe/7I04w4gCGgbxIv8/qVYHO13vAvwfwmrDM5jePbrEPMu5/xpwPbR28C0kOb7dQy2Z1+FwtVGxviqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-time-context": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.1-rc.2.tgz",
-      "integrity": "sha512-4Q1sCr06SfJ7jkhrvfdg8ZSFp5Ohtl4E9nH19nUbIjcGK8F5yA2h68HPEglztDo54vxI5HZSblLIjdGKZkY+FQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.1-rc.2.tgz",
-      "integrity": "sha512-RrouVgU3G5gXr9zHhpThkMG6YKdcRJzXXdPm1dq3ioBxbvxlfMSfNY4tN8lWMJxLyGtvWkPra0HQX+YWxvdOOA==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.2-rc.1.tgz",
+      "integrity": "sha512-llz11yxWeJB8suKCa6hRLjNBWVaPn3Fbd0XoBS0bkZLhPFzO1mDorx/XMca2GhI7XF9A86CURQcDt+aGjjvqJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-loader": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Zbwvblrb+6exFu5Atb0ShONAUsdoA6kcAZGi436JAB2SWfYbh62KdcahHDrQh/2GQaJgc+WjvKT9qoHTx0U5NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-loader/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-protocol": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vBWD0NpriPd96ltbWaAw+iKeWFIEjiAcCWYtmqEcV1Ms+FaV02usjjm7LCmhSQhMZpBSBc7EZUX0spGlpjI1bA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-registry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Y6eWVTp3GBDt9DYjYqsLIHG3SJelBZvhDpBipz0Cam1Al85MQyecqdMrmOmvCZZ7nDwelC6xkZfg7vikrtpB/w==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-crypto": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-rc.1.tgz",
+      "integrity": "sha512-gE8FznQ1hkknw9QMrHNSlm3UEyRYuj3MLVvlJ6NyH1kmOsdjnbrVbSs+Pn72k2oIV4Fiyu3Umg0sLznUEcsiXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-time": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.2-rc.1.tgz",
+      "integrity": "sha512-OoudDLoYothbZKDbjO6kFu3NLgAnglIS8NFkg5fjnBtz8LGwplN8w7kRURLIrZtH38HknYhpDsdJh8LZai3U6A==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tmux-context": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gsOY/pbm9gdO2sKlqWymv4UxGocm3/4hU+84eTD/Wi6Vnt0QOPDSHEO/SjZ/sdIxiTxoKQLz4mqy0LYmc7DNDA==",
+    "node_modules/@deepseek-ai/dsh-util-values": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FQdgoK+KYVR0pBQb9fTsajvGb3gzUxEzJQEYnFOt+Qdwc4nkxJOPwJJdIvXuqvZaQ33DaOoqpnpcr2p5HpLu4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-workspace-path": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.2-rc.1.tgz",
+      "integrity": "sha512-cT9mxw5dS7YTbUoMDLmX4HeMKnqovCMnSsAVDU1fr3zKv7YAdT76rW6fjOkV/NGJBQRxUsbYdXKjqeYFosAmUw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+umPNfJ+1Gshq38jR3tjgf4j0QaJZT5PretdHi1J+RU61Ou9Sc5w9n8haxa69os7g6FjBNxvGv8fnMeFDgcLKg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-token-meter": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.1-rc.2.tgz",
-      "integrity": "sha512-XHSgvMga4h73LHzuG8gztocs74+6NYg7ciHdu2aM2PYC59/rPfxq4Kz9Hq6TTvYa4a/sDgCij/T0tZBNvQixDQ==",
+    "node_modules/@deepseek-ai/dsh-web-fetch-http": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.2-rc.1.tgz",
+      "integrity": "sha512-yA2oxrCnRxSVYVOFr94ChB/m6TtOgPc7GZT78Ps2EtBPbAP5MnVSHM6JoVeqlHkFwtQ+qw/Hri9KBnOQtpgg1Q==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ipaddr.js": "^2.5.0",
+        "undici": "^8.10.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-fetch-http/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-fetch-http/node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-frontend": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4f82gSDByk+h9nGfsmoDdRcoEXtsE4W7w5n9aJRRHIzNwHFe8Z1rtl3PafdVBZcSrZ/0bouxDMknA+F3FZAG4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh-web/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-win32-process": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.2-rc.1.tgz",
+      "integrity": "sha512-egG88t1NDajO8YfjYQpHxBx0xR8CB/K+GTU9c0W1Tn8YX6GiFXqOZLiaCNj2mVIv7WnMShzZIX6bVkFrg5oTag==",
+      "license": "MIT",
+      "dependencies": {
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-agent-default-model": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.2-rc.1.tgz",
+      "integrity": "sha512-feuTXXl6jIAp71O77l8XzeKcpgahlCXQ7YUjM+Cl/VF0EBpctKkdvwbvTalImRzYYzX5qGK74hblsT2HC4xEwQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-agent-instructions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9AHeOBe7+KimM2ystfesEYhqcmCuAnrU5MK9qzaYv6HBvQZrU8zYgRAxoqSxeUB5eJoYPvWMvBTBPIRAyvzpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-agent-presets": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vNvDw8DYtZ8ySublYY6gFPPruNIST3Xq9bf7RlgoAY4xJxc4w3+/+HOhoYrxQRDWk+FQgYkBnSfnT0OTSOY3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "js-yaml": "^4.1.0",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-ask-user": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.1-rc.2.tgz",
-      "integrity": "sha512-6zSUxSducAdrSJ9J172rzJrqv0I/LbZQZa2ri3k0shYzM2reOi1tf+xWDxVFafUscxeyBpnpmNfXXBuZPt0HZw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-bash": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YNmrKmBanj5EQn1zejjbo4UUFtg2/h3s9y0lY3vBu+dezNz4HdUlSkSZACbNUAZywyLomdhlt4rJdtdnrqyS7Q==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.2-rc.1.tgz",
+      "integrity": "sha512-flBhNmq0KfIlyy2/8TqmjH1aE9kgaz4S25RhAhOOpHiE7HCcbXePd/+nEPpi9MBlCit8lgHcueznwHpHQLTz+g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-pPI2ln6OdlCW6Kks5VWsFm7sC5NEkZetKOJ8TUrsXkbCM32wWLEaMPVsN9p5XcG/ao99p+Nh0Rdx7PYn4lfg0g==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-api-remotes": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.2-rc.1.tgz",
+      "integrity": "sha512-brMHiYcOVt5nXeuiDz1jw6dTJbyZSl/sA4KeZ00vGmYDaIseO6Ujz33zRUjuLMqgvQU4xBFBYXKCU5TLgqlfrQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-vPYSRvYV9mDSNRl3BU4M76cIA4oigBD16eS/TxFjAj6fpkdc4JgLA9nsvl515/1DJLEIYnp3HQF3iCsptEdurw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-cordis": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.1-rc.2.tgz",
-      "integrity": "sha512-cBgfa+0Al94/ur+jaWk2uHZ2ChFw3Mf9nmgaFcToFxkBDAcSCpeKjXK27aw/g2EIz3MvPMzOJo9MLDF3WkUEZg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-fs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-llX8AWbaI3CGme/a2eeTSfy5atk8u3iJeOFzmZV/KZ0v0hMhKZIK1xQInWwC9OmSDJ/StStJe0hDPVLWbB7hVg==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-api-session-controller": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zmhpkf6ydnYKYw+dmSeGube5py1gUfpIKW3pRMQpX+LOO3xCsAhlRgVnaTTnDveNcZugBEljcVeefOqbJiiadQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-workspace-path": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-api-settings-controller": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.2-rc.1.tgz",
+      "integrity": "sha512-xcLcONiPWHOcFcmseYH0suKITI8sAQv4APPD+MdYPUn2fetPKCB6Lh3AJtAOors4ESabGq6lZ56hrsYzcYYcDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-api-workspace-controller": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tfBLMGhU+otJudklD5e9JAK2jq3bSbsAM0LahLZyDpivUYMh56YbLFOLM0yG1qdvgfq2K1MVzssaw3vkq1P1zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-app-boot": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.2-rc.1.tgz",
+      "integrity": "sha512-1vltL0FvLjn1Cx1WqAzqGrEJY/gFx7ec8/ZPi2Dxon3Et1IOupJiuze2nZ3Wi7sfgGl5CxytktSkGmJtfTD3mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-atomic-write": "^0.1.2-rc.1",
+        "js-yaml": "^4.2.0",
+        "resolve.exports": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-group": "^1.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-hmr": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QISKUjEITusLvAkqPLRn70xDUt+GjjY41pISjtPKYcZ4EGmayzhgZ3VJNYEcC+rbaF44hs2o/0VhOwHA7lyxjw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.2-rc.1.tgz",
+      "integrity": "sha512-0Y/Uiq9iK2Z8/ODL+KOsjbPzZ+n3D+j52CcBpblzysKw2GOF/zAoQtEZHhtgy3oK2R8HRxrQo4zJI20v7fC43A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-command-compact": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.2-rc.1.tgz",
+      "integrity": "sha512-b0E3HxpitGd15csYx97AiQtGb09AARJDQ0/mvrT1DFrPHOHnep+ybayq8VeOrcDhspTz72PwA7OgxZe/I1yvLA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-command-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-+MwYtJnr9/oZ4WWcz3g7IRoIt+OUR1F+KZ0Xq3IEVSq8z5A8KBenRz7jVVG2LMksQFlEPxB7kas8SI+WEpWNAQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-commands": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uBh4JTX7pOkFhmbWjXjVLnOQOawyccC7+DazbHrLRN6/wy4OgTRH+DaW0+ibLq+XRAO19OvBTtuoh3x/KkJx1Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-compaction": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.2-rc.1.tgz",
+      "integrity": "sha512-omzrM2EQdoUvQ41PbbXiFERC7I4FYiLNmHIYrlCZfCAdxo0G4u3kt7eahhVaSSi2YsinL7sW79C7cTVaUWlZVg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-compaction-basic": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.2-rc.1.tgz",
+      "integrity": "sha512-x4HEQ4hiPwHE5nljFXsVzG8nOVnEQIwmIxVB9csnWyKcika6yoAGPujeFcGdZKoMPiADt2JglO8fLuAj3ROCXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4QcB5CY5+ubrIoNLJBZwNV+2mnagwn4JwDW9qunr7UL29cS8AeWAksqMbpDZOMmyDuLpg4Alcnb5kqKtfZFNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-cordis-host-runner": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.2-rc.1.tgz",
+      "integrity": "sha512-fI2eavQhDiEXdwpnGc484/05xFMBwgu71Yw4pNyCYVfdH5y54i2vJ91EqOAiVjLx0SYwdrcnNo+ON7+zqayjnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-credentials": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e7DGpuYQqiD4dOWGQeY/XAWPTjbax/MkrXBwsB8wBtNpoPiAKiLYgd+iFiQc66BGOlutSRFz31IKdbduqPbTxA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-file-reference": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.2-rc.1.tgz",
+      "integrity": "sha512-m4Rvk7tpOep62Q1UCceeqFKSM0K4Y6igZopuKn+AZkL2FAM2JISojMefXq5SKtjPiZP0Vg4BpDey3M63Bnl4xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-file-reference-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-TFqBWigbO/yQDHgmGjY+gcSs3VjEXDqw+uWxMDvpgLvGArhUR03/cXrxF2pnKOjSZGx79tTLWo2YbaYKuKJSuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-BSIB2j8WvATQ1mf7wUIpHPftDwbzz246qp6aUpLGSzBWGmLBdX3O1oDhyNV1YhgPmDQlwovac2odcAb62tuDdw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-fs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tFHHKtD11tIk3FpkWF0vBKdX05zKbwqXQW9LhreA5hErCKEsulUsQLamf+kF1D8fuKqa8Yb+yWQIfYS93cy39w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-djzY1oNZV5RwnOFXmDeWFbyswInV9RVWAD0qryxMznQtEDF31PUJ8BQfqs9tVrTV36V3a0neYrZP0DDvRP8ZCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-goal-round-driver": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.2-rc.1.tgz",
+      "integrity": "sha512-TNlX5K7EL+hNGqegaEs3ODGKhEGtUll368Gtmw+uRmgVzJIUIBiyH4JIDQSIwO8PcYQ2wIpXuipRTgQCp/9K+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-headless": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tKJ1/7wHAwDY2mBz5DJnEq2JvkusN3srbyH5kCXUW8131bwvJkkMLMyUfGnf5ASlFe9vmBapF8sYU9KPWUgh0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-hook-protocol": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-D/HfjuhFN+wGnXRgim4jESDcOoR/FiyL4TIjkKAurJgYYUrvWyCpRR0U+eGt+/xTVqGKwGCYqcmOyxr236CkHw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-hooks-claude-code": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NyM09zrzBhYlLDT2/9NepRWt9MEANFsxzptEVMTdVNjY6kiMFSkdzDh51bcGzdMpacCdj5LzxR5tQhKqK5otPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-hooks-codex": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.2-rc.1.tgz",
+      "integrity": "sha512-l/IFUr7c85Rz21ZuoFH/+XufTf2FMr6Nyqr71qUaWW4XCu3SkpOnr04oh5TFGHJF4iS6u7ZdP+Nupe1mH6/Dbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.2-rc.1.tgz",
+      "integrity": "sha512-MyLA5XncFdfk9btv29FZSg+ojFOOsHEiPkGWAQiRw+EG/2HlVUEm/9KqPxh2jxB5eFge9GahTg2e7x3Veziadw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-VuNPXosjgRbEg0tp+GXsdAqkicwSk5Ynl2AezUQheJgpmw5cvWy3rLEg79B686xGc72tIA6pCW6eBbZGnKOmIg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-jobs-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-bfNV6IJRG7vPWg+Rp3siRCA0BVK8rB1aqn0BG2nPKzCIA2coKqeJ8uPbEm+GuyW/naMR4uCOrrCVLyrwBuMwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-llm-retry": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WRpanzi4u2Z2X2uv/rwRZh5HTYUtd5smFTBMT4jYd1UpFOmjoMY/grDboZG9KI1OsgaS1vadiBJT4vvixFDEAA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-mcp-client": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.2-rc.1.tgz",
+      "integrity": "sha512-2DTncjbQfEODOpdADJp6HsGVEGIYTHogGNS7VgpLKtHJ0gDa6nc8ebtrJWZhXojNtS0aZz/nmqGNWCf163hpYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-message-feedback": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uqgPGGES05+CME5A+/Asm0eWAXHVaTR2/DBqaAH0o0zW+9IQr9DP77DC6zb7jFbUuqQ4a1Ntvu9wWmuYrlUudA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-permission-presets": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.2-rc.1.tgz",
+      "integrity": "sha512-CYGxMvAlePbMMHoIBdmrpdbDtea+mcr9/L4i50CoMGafeihwrkrCOowdYutOUbKWgdVeetME/UCkcdTEDRU+vQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-persona": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.2-rc.1.tgz",
+      "integrity": "sha512-OBlNDneeoIjXRJY8miV5rKMv4gnVLj+WAbs2tN9U0JO/p8Nd1gCFI+YCN0tt9Jd11ifBAD7q+IXK/WQldAsXcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-plan-mode": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dYdmByVI0C94nY+dVO3a2uLofVc+p87Ld04CFtqXLabcsneKp9Oj1sK3qlIaFfSHgrTFCBeTrs8znHxNAb/xqw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-commands": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-pwsh-local": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jFJQOWkQ3qHWj4xg5he0pjJtzktZYnrjMmDTJmxI4vyMK8UxpEoR0tD4p6eNAJoxZusot9o1/SUqe+HJcjoSrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QjJzrM/tJDkgvtVzYz2bmCxBzdSUo/YwI/rPBJeTwLbWBuehyhX6BueCwU6Ja1Bsdm9crz2D7rVc/DU/xrFttw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-sandbox": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nTO350NlVo9cvKzbeILcPIRIk9ijidrv29snRjTOx7kP5aO/BI2b4KxsRCYoXg8WGAMbIkGbsmZKUD4qz7hyXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-sandbox-policy": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.2-rc.1.tgz",
+      "integrity": "sha512-nLARL84X6K4DCUJsqRWINg3+1EVxsw70hbP+Yl92W/PsquQVs/UJQc55gnhYGmIMf6eJ0vQv39fziNSnAxdx5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-schedule": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.2-rc.1.tgz",
+      "integrity": "sha512-16HNYSyG6rZjTRUL/3ZMYWSim9TpBx8vo9E0eRcEyeDkUafPig9fxqF8iSYiOElPXWr/CniepkwBwLc5av6LwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session-persistence": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8dnQGgqA8yK7SIxyC2utRdkHhM7mxw9iidDlPOx4GRO4fgY8+UpjxFvWPshkKsY2WNYY/nYcZQt5NNoE/Br4Dw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session-query": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.2-rc.1.tgz",
+      "integrity": "sha512-cubi3flRd66ebzJ/My5t9YIB7ymLdmQonjb07oU5btMHO/ln+gpKnqq2DcnfsdKkktSR+f5VpLMbfTNtoBuRCw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session-reference": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.2-rc.1.tgz",
+      "integrity": "sha512-pVMQYFFejT53nJOcaqNRaUq9VInAFovkwe7TmeeNSgbUZUVY4W7nyNYGKxzo9u7eqs+8ASqCgsIEM8WRVUymGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session-stats": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NCxXJPPeWwtbkF+bnzVXdknbafgmQi5vxPsY89ABEs40jJa81OeY95sFnqdedjtKXH2nPycX99P49i28gX2PPg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session-title": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hCffH0uZWEM9p3MPkOQOFUxpPwfV48N8KDc3hYX7zVOFgHBY93ylwkEEVVkWN+sNp2zJmFrZSya23jFVshDtQg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-session-turn-outline": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.2-rc.1.tgz",
+      "integrity": "sha512-cJrQOI6T5W8mDv17wUngS1/ogAtoC9dmPy2nl+8V0X1u1xyLzD1SceBgapUZ6NBBX8cX5gutI+Ub7802MVgAdA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-settings": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.2-rc.1.tgz",
+      "integrity": "sha512-wMmJ2w5S6I7hgmgPppuAVemltEcTmAa8gvii7fk4T2KGVCuBYgig8xPwQ8Lp2ukLZSzzE6ZVCQxhdYZyJX/USA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-shell": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uFrSY0nNKzh5orGl2B0B4RfK7wTdIlwhPQc7aLA44jyjioLlqhF7PUek/NWtye2scwp3YHOw158XeOQUD8qTFg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-shell-env": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.2-rc.1.tgz",
+      "integrity": "sha512-o1VqxyHp1OrMB8aHnzYAPwuU4giUErCxBg0yr035r6f3Le36viS0sUHsnjcAsMdbaQJf/XvzbaokYDVrdVHE4A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oaHunkTZ9gtlxp66GcqZ3tQmPXEgbu/KNCnc9JipaIwfLHFYiU3CKuFjVAiu82qtSr9w7umRMFKAstkr1R30jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-skill-filesystem": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.2-rc.1.tgz",
+      "integrity": "sha512-kDciORrnBhA3KuSOcqG5cOPO6QYu0TyYHRQBO+v4Vc7sLyry/2mdWRR8OI9hDEkkjqMiupYRVrgNlj2hfSMKWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^5.0.0",
+        "yaml": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-spill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tt5DfoVmLHWwGPumYSBXWNzf43Kmp8xiWwGb19w+UuiCgDo/zWzTIKyBHI2fUyuwoc9Itk7zDu2WOp/o21XDWw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-storage-domain": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Ee+fI/46ZXgKV4bfLeiNJMhlo9Mx0jT9GXzuJ0DcdGGOsNSZrY/EQAzVXHJJu6EVwIJqBkv1bxEKijVSF2YhZQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GhRsymKb1uYbc7OwHh8WTdSXqAcx/KHFJwYX4BYJk90dsOkVx9ccBq6QoJfDYja34s1KCyv2UO/8MUtrzBsITw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.2-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox-policy": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-query": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-user-approval": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-terminal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-O9MJdEpZBvoYzjWXycmgh/nMmXTgXoArZOXwld9q34cSgkXSUOVOPSiPuN5HjPZYZcT4aeT7Q4Wdr4LxezbshA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-terminal-bash": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tDEjaycT+2ZRmy8yVZb/1p/ZvulfPtfiRVfYqOENNSitlWIUgZWq5JH32JuGsXZpYJTUhwrDLHXSR1Lwls29ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@xterm/headless": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-time-context": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.2-rc.1.tgz",
+      "integrity": "sha512-e5sjsgEJNT6cF8dFCernoXazypALlJOrwb1bOfJvPwrdcYbztNifGR8jDoFj88i6hor7twpf4LSU2dqzGc0QJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tmux-context": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.2-rc.1.tgz",
+      "integrity": "sha512-WOSrPXbAqegbEKJfATRB0F214aQzE9zMlJ4k65Urf+xjcY1t4OcDtjuk6QV6CNGeG2U6V6dvEol4lQF9Aj47qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-token-meter": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.2-rc.1.tgz",
+      "integrity": "sha512-6mlC89JNGudPvR9LekEo2mnEo/DXf60ZjekIKXxZqpf66AOQ2/pa2HJuFikEd9WWRvu2D96Qvx3rILxi1vXVww==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-ask-user": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.2-rc.1.tgz",
+      "integrity": "sha512-4x7Y6DxaUClUllZ2jOusuukz8LPBotUinfRhf615sDm5JMk8JVD8tHjpFZ6eUX505wIyWgjDWLePb5s99j69/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-bash": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.2-rc.1.tgz",
+      "integrity": "sha512-xKc4oXVDBwM/PaicpjGdWEaJ1N14B7KPmOzdpQ7ynE4gKUnvGU/eTg18EHamdyDOidh5ox0fNUnxk0rQjVo2+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-AcWq9UHKmLyNTh67Aa5UapmuLYdDVUJy4aJ9NvrI1DJLHCZQCs9NCUDx3UecyCwfa7qHtOEz205LY5HRACMqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-cordis": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.2-rc.1.tgz",
+      "integrity": "sha512-EJKVeKgAR+J3Bz/HeXU+Xeh0KTEp04JYuOf3tdiiOsEr0Aed8OL5Wr4YUJb8uvU8xLZPBWYjGlUJG7bx0rg/dA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-fs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-9a1lcPGD4Z3p7OLTMkkCdwN0w7Gl96Jlypq6qopUA0WMkKai83VfeLZvramPnTJo6ezpuPXcLFWGm/2UDSlbcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
         "diff": "^9.0.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-fs-search": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gHu+6Cs9zs1EYd5KSEJxAsw29sz8pGaj+wJb1cwbK39gzK0AUQ10RlBYuxee6SXgMMnD/vFJZFjxRtCAdo1CCA==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-fs-search": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.2-rc.1.tgz",
+      "integrity": "sha512-F6j7OhMCowlOwIYmB4hA6sqenw2V7Eez90BjLww87iM9YarR6D/CQcHJN4OIViepuyE4sLtk5gkXM8oT/PeTNg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "@vscode/ripgrep": "^1.18.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-kTECpE732uwlxRJr/jBZb1BqaxZzrA7Rv4KuM3eolvhoTJ5zjyiR2YHmDmCSfuI6zmA/BEfWss7D0mLbVtJEZA==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-goal": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ooHKN6Eqy3owNS/oCDO7mR+UalEE4AxJMXou29waahIdSQsFAlk4pPApvhrwg1lpchF5CKwBPOtsVmjq2HfBKQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-jobs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-wCU7mo2uoQcAtz7de4ZXP2es9lALsmz6XzC+KAlS2e7/yTBi9a5LL2vdSr6XhExVAuhu/6f9eM/w4EQBOxtKlw==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-jobs": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ya7E6zToAdJ+GvNeZFPx8jNx0CfI52tlp0NCGzXHeB0S74haGWCV0iFe1nyoDJg7SDiN1xc1d2nV9klOqWtd5g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-pwsh": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Gr0F4VWCIIR25qWVv4mMEJnewXILHLCkZwrLfbHA2OOI7DNvvdB5wjJxhuo+ZQa8/3KJ/byQGtEBqCY9mb10Zg==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-pwsh": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.2-rc.1.tgz",
+      "integrity": "sha512-LaImOCdizIGkQnxzzkoaqzRWGZLsuDuqqF2adgJ3zeG0nDwan4Sz+1wYz4YSp0Gg6mJ79CYacsbYmGhYYyKY/g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-h/CgOw+pZQDl+upWeFdUF1wzgZQ4NgTSMAmlOe60QRObEP8rEYggELP3QQiJbgXs34N5E6Ovf4W/ADtnFJVsEw==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-Y8hRn41iRaRY88qH2zvR9sk3VSPnfqkLybqoOSepezfM6LXtrY24hNS0GTmRd88hlSre0DtB92c0WAJ+QLixmw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-ralph": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SGOMIJPufjz+eia6p8lRIZ9ybflk/6m1E+MAm6zg4QeCnXcGr2z3fkA8+/CTViosj9wh8NfXJYMFweRpbigkDA==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-ralph": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.2-rc.1.tgz",
+      "integrity": "sha512-HRgdfKxuEaFZNyDahTsDrA22EU3UfG70j5kDMtE3aImM8DSvfFIZ0yvjfFG39WBI+uxDy1b7j5HcAImaa87Htg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-skill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ADOjLELlf6QgrJDFdieNDN42pInPHL39ZU/+v+MXxkhE6poM+kcZmn/eCxbfSvMBFQm9E58Zvg60c0hrsi5BCg==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-skill": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.2-rc.1.tgz",
+      "integrity": "sha512-H4dORZoB2wuTcHjE1uMvos7D850mE9X1ETjXdzr6+1JTTw8uOeDsHhmNfpOMjhA4/ztFEW7QAQlymI25Er6yAg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Pzyjfr3T9VSUKyAmxoejp4GVvwup9gmj2Kx6WmoUEMK17NPZrhRXgMXbzFu2JnRjxRp2p1FSs4JDb2734xMQzA==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vD4GEYQ9iOkGaPCLbY4rziAxxAnNwrPS8rgrMkf1R0kfrSSPkAqVaepvuskgxV6M6lyduIKFu5yEHQZwVZbMFg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-subagent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-26TuzAuxy8x/jDuWJdvCSRQ/ojm7++5FQ6CRLCdZcgU/3Iw2ZY9TKqAIz48cFHOv/wS3+ru0rX3fF1etv6a11Q==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-subagent": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7rQfZsMWYv5oPMvVvQTv+rEDd6CFz4YimJHlSH56fsEwxW/A6Eg3jDBHLpiZpuk03gP6WIzcyExaC9adPq1ohg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I1enWV1Pm045l5usFwpJtbzJEpic/XdPdWOg+l0it4ia1jUq9l5jPZeQ85Z2x4UbyxtXFOMDGvSL+9kMi0LzLQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-subagent-report": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.1-rc.2.tgz",
-      "integrity": "sha512-nxy8Y4PhhaasMewLb/Cj+gU/CthtXgtrPuR2NZmYr49xWYXBu8A2IoWFwf6Y7HkbZRSPg6LPsQJEpftjnIYc2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-todo": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YKP77X/fiKxva/ZzcqkDy6WhNUWYA9oTrAPLAVf3GP+ubIu+r4/cPxu6f2+/8rXLYSi47HXAHajeqQbw2UNXnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-web": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.1-rc.2.tgz",
-      "integrity": "sha512-oV54OJFYYseJCT77F8lr9ZU/f/x8ZbPTmgQpYPC/O24Hw5uqUHEADkukC2ajrltZSTd0+OVqxHFwpWH4gjDoHQ==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-subagent-control": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ogSTUIs3z20weu4dHIHUHL5kzJ+wnjQETGfsrU3qb2ChAbx6LpJvNN788YMI2RP6udVbEJV/0HjkMhIuZsazZA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-todo": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.2-rc.1.tgz",
+      "integrity": "sha512-NFDdJNwryfwrNDsy9XeYYB9NaI/GAfgNMKvMlMxgXXuvmVoeLD71o5r2/S5Cl0unXLRfV+dP91hkj4Z+aVYTzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-web": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.2-rc.1.tgz",
+      "integrity": "sha512-hpBy6VhE12fDeZ1a6bSOOg3msvJCMS4nwD1R2Nm7sjkBCiXR/BYAHmpkHXhNEMvTY2KhnH6qRhx7SFGSstfwwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "@joplin/turndown-plugin-gfm": "^1.0.67",
         "turndown": "^7.2.4"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-workflow": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.1-rc.2.tgz",
-      "integrity": "sha512-tOLaym8/eyHOATADljSbUYBizaYZTqMKp8p+r2SwiWqIjnRral67BwoO5boX+3t+m2Z45+mvrEnHCu1deYLuaA==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tool-workflow": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tqZJcQO7wOgLgT0XLyRjSkMpri0//6WmOVjcoY7+BeybtqJg9OTL31dXBIYpR7QkhQXmeEhHAZl0Lz/7kR+Qdg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0GGL4D55MwYDepzZMOI3L0ycu5b2qr96GL0Y7snwhAnpK2Di61rbX3fJE+PB3ZrovGX0csIRdt9n3iJZDVtDrw==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
+      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-typert-loader": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YTShO0kcBBwXDx8J1Xgn0z4l9nNBqBbpHh2wFAN+PXPORXn0p0F4RY5z2YUVLKLJaL8XRjNKdl43hHK/ttomqw==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lxBssDc5Pz1qBE5kuIyaArA7AvIPq9rpaVclylodiSzVJe95e2xruBg73tflyjtd8y00toet+DLgQ6tSSsq6Kw==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-user-questions": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.2-rc.1.tgz",
+      "integrity": "sha512-ZXSliLrhEx92TUsjXeNzr3fKLIexnGV+KPcgs+HRUESlsCGs9wuZH6ep4rfrRLc4dYBbw4bbgNKQct7RftJ4eA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ATZu3i7UId+ktsWW3pUFm5Hi1fVsRXFmByATVPp2RlxH1zjxXnauVW6k70ZwU/4FOsphRzo65SXOlAXA+natYg==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-web-app": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QGh+XWRgrsVktKD3YHw+cY/knwBESq+2TtyOGNc+V7GU3LG9qL6EPB0M8pIDjxF1jLls+M71LIVbevuFx3oZ6Q==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SdsO4Rs+NeJFoertkVilXBACREOLfkKPJJznYKqDhJxeRo38RJ56dtj0Xd0/6rERmsQiMck4Bwdrzg1ubUqPNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.1-rc.2.tgz",
-      "integrity": "sha512-9lYoB7qCFE+Vvgwjny3MnRfS7QUefOspj4KpE3b30DAAJfxwrU4hRtLCHOKxyurF01qrkoEBBpXn4H5ilXYTKg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-web": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Rtikc8RUlfx6m9+hYvKB3JlAD34PrI2UFHEu1h8UMb7pM/ulIRpjBF7TPlg537WRK4ufCysqCJm0RheNMoYCcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-web-app": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1zGHY7qwBVlVJrzIWu+86SuBZXaVUxe2JRfffsuRvKXq2QcR/K4CoJJfZ43cDoWKu9xPvvxz7w2ezV+EdXgg1A==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-hmr": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-plan": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-frontend-static": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-log-export": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-json": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web-frontend": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-session-controller": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-settings-controller": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-api-workspace-controller": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-modules": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-approval": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-chat": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-schedule": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-file-reference-local": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-stats": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-turn-outline": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "commander": "^15.0.0",
         "open": "^11.0.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-shell-env": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-web-frontend": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1cjf39g6RW7cgtvwhIF6MSnp5sk3KYRkmRhZM4GETWLXCrTfMD0WCJr3yME1uvJsYPTk28XmKXwwMUPrO3kksQ==",
-      "license": "MIT"
-    },
-    "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.1-rc.2.tgz",
-      "integrity": "sha512-g8wl7k0Htd0MI5CCh0XHK768P5u05ge0JRThMSgNYQvuKJ+gY4uVwzPXJb7eZ7xNWgXt8ERLXIOMVRylaJX1XQ==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-webhook": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zpOB9obPJgsLEF8uVzG61v7MPgyhMJbiI4EzV6iK0rkFulV0Tm6G+iQhRYB8tUHEaLCgOzUBCo32lrx+YnhypQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-workflow": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YHUGOBfHGXVr9RRAdCvKZ/1SeeKx4jRumSBMNJo1ETbVqEK+ov2kV61pHFfLu1h+heCsEbOsEJeVXvgYC8EBhw==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-webhook-github": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.2-rc.1.tgz",
+      "integrity": "sha512-RGwuVtaHDTtXaKtHDZ59uErpzIjrO0K6U7arKCi0HDNuDvBHiU70bpn431Cax+6ynLfH5VZqtSDb0qmHnRTdOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@octokit/webhooks": "^14.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-webhook": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-workflow": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.2-rc.1.tgz",
+      "integrity": "sha512-JjadkNhYAeU8bD8immmpJyX9zbqke5Y9rWCf9m+vzvE+GUqPwSILTTVzESUxl7rEJtI99UAL6dYy0qbkYIq6HQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.1-rc.2.tgz",
-      "integrity": "sha512-DdMO6gn56wakPTetkLKwuuj7cI3y3ji6c0oR3ksFQLhkYwaYV1hZSxVU6HEiW3hl2so8C163ms8QBgDyIWZsXg==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.2-rc.1.tgz",
+      "integrity": "sha512-33fzDRvZSa46l7MPD44ti8lNeGGMI8dTHsoAF/h+puzfEjOBJ4g75sh6oxs7sgszcTUSr5UQAZ2XGU1LC/9DoQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.2-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jBUob4H5TZAiExq9YNVCglKAFmAKMtd1UbyqFfnZZ1Owm+3c3NbAXY947MHiD6NwCwFEW1y7FjrFj66UQvG90A==",
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-workspace": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.2-rc.1.tgz",
+      "integrity": "sha512-8q1e4a9K8ON4VabR6VfachNnuOHKvfBlQlv07mFT6CwoaCZXB1WwZxjJFOnIcF7R05uRAPJSVAgUMedgWMxVEQ==",
       "license": "MIT",
       "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@deepseek-ai/node-addon-landlock-run": {
@@ -4019,6 +6794,7 @@
       "version": "3.18.1",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
       "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.2",
@@ -4026,22 +6802,21 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
-      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
+      "integrity": "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -4050,13 +6825,13 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-ai/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
+      "integrity": "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -4115,9 +6890,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -4133,13 +6908,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -4155,20 +6930,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4178,9 +6953,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -4194,9 +6969,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -4210,9 +6985,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -4229,9 +7004,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -4248,9 +7023,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -4267,9 +7042,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4286,9 +7061,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -4305,9 +7080,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -4324,9 +7099,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -4343,9 +7118,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -4362,9 +7137,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -4383,13 +7158,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -4408,13 +7183,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4433,13 +7208,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -4458,13 +7233,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -4483,13 +7258,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -4508,13 +7283,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -4533,13 +7308,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -4558,17 +7333,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4578,16 +7353,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4597,9 +7372,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -4616,9 +7391,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -4635,9 +7410,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -4659,10 +7434,42 @@
       "integrity": "sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==",
       "license": "MIT"
     },
+    "node_modules/@koromix/koffi-android-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-arm64/-/koffi-android-arm64-3.2.1.tgz",
+      "integrity": "sha512-1pJQ4jnZlUJduK9u9DC5CGy3aOgDUPvIXpNb6syV3+Dh5Q/ugezAIGCqvY+w+1mgXsve0pd0NVvJRjdZNHQ6MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-android-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-x64/-/koffi-android-x64-3.2.1.tgz",
+      "integrity": "sha512-HH40xGh3gVQifjOBnhwT2tECC0lL1lYe+nxHvWNSzxDIyQNcVPXg38ta7vuONRFpD+uIrw7fqGYLzbZIagkVcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
     "node_modules/@koromix/koffi-darwin-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.6.tgz",
-      "integrity": "sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.2.1.tgz",
+      "integrity": "sha512-Vj4h+xcjc5+Cn0DhPHjgRX4omKAv96Kehtcd+1YgYuY2W7FvQn9vS+3SmzVwhC5Qmg9bIwUZObYQ8T/4hBqQqA==",
       "cpu": [
         "arm64"
       ],
@@ -4676,9 +7483,9 @@
       }
     },
     "node_modules/@koromix/koffi-darwin-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.6.tgz",
-      "integrity": "sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.2.1.tgz",
+      "integrity": "sha512-gFCWxNBTZIvxo1p+PURWfsy2Ctj5FGnVVs1f03lTLhBvmxEto70pdIiFztdFLDFkAJ1pmtQmruRKapeK+E8YPA==",
       "cpu": [
         "x64"
       ],
@@ -4692,9 +7499,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.6.tgz",
-      "integrity": "sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.2.1.tgz",
+      "integrity": "sha512-qj+f1s2e6vULaUG1cdlTcCXmunCq2t+rjxku1+esaMIqVnHpOwj0QzPuInG0AFdXjwBNQhyVR/HpDj8daEwwsQ==",
       "cpu": [
         "arm64"
       ],
@@ -4708,9 +7515,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-6olHb1Qfgai0jjs6ddlDDD0ZfsCxy7SPi8rMRpuYQWH0qhgtyQu82hw5b1p7z+TJ0zZP3ZeQQ6l+U/MlM1ICHQ==",
       "cpu": [
         "ia32"
       ],
@@ -4724,9 +7531,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.6.tgz",
-      "integrity": "sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.2.1.tgz",
+      "integrity": "sha512-Dikhw1ySYNVMkmeFvFVjnU5Wdk6mffNoOjJxm9bTG96vg7OlemylxqdEven47R1YJ3yzNVJn/MlQ207ORWfi2w==",
       "cpu": [
         "x64"
       ],
@@ -4739,10 +7546,26 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
+    "node_modules/@koromix/koffi-linux-arm": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm/-/koffi-linux-arm-3.2.1.tgz",
+      "integrity": "sha512-OfwUwZylidq95wQKp6ClInULrfB2giu7dqM6Rhe0zAe6lES5I2SXNw15T9+GnRHk3/9hKT2XZ37OZLaKSyWNLA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
     "node_modules/@koromix/koffi-linux-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.6.tgz",
-      "integrity": "sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.2.1.tgz",
+      "integrity": "sha512-K+cGUL5iBcDqxmsocrjmlASqDf24gc7artbVW3PewG2c9AqwC63lezgwvB85Nx4lZAQjB6zIFHh9A7t1yGbwhw==",
       "cpu": [
         "arm64"
       ],
@@ -4756,9 +7579,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.6.tgz",
-      "integrity": "sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.2.1.tgz",
+      "integrity": "sha512-rxj6UYjU1qd98gxNQOSCdLpc5cPRi5Giq9rNd3jnGuSNIyMkwa6Dxw4cUjmhIBCYESMJtmNt5NWnJp5u9wTfYQ==",
       "cpu": [
         "ia32"
       ],
@@ -4772,9 +7595,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-loong64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.6.tgz",
-      "integrity": "sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.2.1.tgz",
+      "integrity": "sha512-aHhnHzkPRmT/IHDlGvESJ/Bs32m8N6UE6Ab6kMeJzgk74IN8af2m/81/wZJtybR1M2UxCV4NmlVNUYQQvSAO3Q==",
       "cpu": [
         "loong64"
       ],
@@ -4788,9 +7611,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-riscv64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.6.tgz",
-      "integrity": "sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.2.1.tgz",
+      "integrity": "sha512-qtQBsjbm3LiirLJvajWmKkNb7ARk7fvJVXdftJ7NtAnF3Xw8EbDvrtvmvtNI1yLPlYcBmlzCCD71hwhWYk0SIA==",
       "cpu": [
         "riscv64"
       ],
@@ -4804,9 +7627,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.6.tgz",
-      "integrity": "sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.2.1.tgz",
+      "integrity": "sha512-c7hw7Qs/r5gnFRTQLcbifBwRU7wiocj+2pVuDQ5Ahb3r36SZmupmgYbTWcLvTW+hul1jd7SKRV0d14ZJq/tvSw==",
       "cpu": [
         "x64"
       ],
@@ -4820,9 +7643,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-mmY8fY8LQ/CB52+h3yrMYmVyoxzW3x08S0yI6VNfHWdfU6yJtZkKCbhjmQCYMrWbYKC4gMvwZwCywIGPAkLyeA==",
       "cpu": [
         "ia32"
       ],
@@ -4836,9 +7659,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.6.tgz",
-      "integrity": "sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.2.1.tgz",
+      "integrity": "sha512-k4ig6aAPbFSRATOIIOfdf/KtlOGH4SVls6L9fy0QnTxRJYvY2oSltTsQtBDANgEQldlq8Kl5WnpRa1VSibP4Lw==",
       "cpu": [
         "x64"
       ],
@@ -4852,9 +7675,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.6.tgz",
-      "integrity": "sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.2.1.tgz",
+      "integrity": "sha512-cTWBJGK//pDMeKQJE/79Aq9MiOAF4H8QyLZHSQ9IWm8czOfwjG4J1AhsQ9DjI9KFOykH77hhnpmQTGVMIubGig==",
       "cpu": [
         "arm64"
       ],
@@ -4868,9 +7691,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.6.tgz",
-      "integrity": "sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.2.1.tgz",
+      "integrity": "sha512-Z50EM6TAZ7CFyMmyX6thv8eNpJchqe9eenhibSIy2Eq/FQYF76gU2VK/LEoaF46L8hfC7TpTp9b10MvReHEyFA==",
       "cpu": [
         "ia32"
       ],
@@ -4884,9 +7707,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.6.tgz",
-      "integrity": "sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.2.1.tgz",
+      "integrity": "sha512-ZmZNiBO6bkOSh3QNzgfvb1cMY0yMobn6ZQrSMqbAce21qyYL8niIbyipz9N/PIRDciGhsV0wUxnZsxIO+yWsHQ==",
       "cpu": [
         "x64"
       ],
@@ -4899,22 +7722,216 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
+    "node_modules/@lexical/clipboard": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.49.0.tgz",
+      "integrity": "sha512-AVKj21xH1qU7JAFA/v0hCoafa+Yti1I7cHG+JQIgc/EqCtP8ePeJyIfTPNN/tXskoCdq++HewQoiSXRwwlocVg==",
+      "license": "MIT",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
+        "@lexical/extension": "0.49.0",
+        "@lexical/html": "0.49.0",
+        "@lexical/internal": "0.49.0",
+        "@lexical/list": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.49.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
+        "typescript": ">=5.2"
       },
       "peerDependenciesMeta": {
-        "@opentelemetry/api": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.49.0.tgz",
+      "integrity": "sha512-62/4DP5qyX/l4Yf5qRyyQrs9BV725eRU3OmLUW6g7T5xrcHXxAo7tia/NvqjqvXdpvQzyHjWgsy7dMitGITUsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/extension": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.49.0.tgz",
+      "integrity": "sha512-Wv0VsuqxorbxHCK4ms1PwAu6cXIGNLtflq66auF+zwxOtBprkSFV8VzzzdKLOYD2admP0VK6EqVCeGXFK1GggA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.49.0.tgz",
+      "integrity": "sha512-uQdtEd34gIJklXNSdHS2Wko1zxx1xUMVXbiodcLO6a3GeFTE5bKnx6af1zGX78KpYhUQYnHWorKuUvtdZlJPaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.49.0.tgz",
+      "integrity": "sha512-NQqAydKzRjQl7Jx+bTTyC2iuz5uhuDaQX0SSPrdfgaFDCPjqQEejcBkCt1QXnu1CkbVHutZKVGVzljx40Y6y+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "@lexical/internal": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/internal": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/internal/-/internal-0.49.0.tgz",
+      "integrity": "sha512-s+XjPC7Qb39A/Xx9ahcz1s69CPix4ultaqyW+MDG0AXYW2quDr7m0USqReKIAiuoLIWtGN5HW8BwV2Y6t4qr6Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.49.0.tgz",
+      "integrity": "sha512-zs6wYkxakDRcJO0KmwrPPHgeLLIxzjD+P2CRu+scJCHRuA5e2iSw2iFjH5n/LlWBrlnPMSjeQse4QqsRy9nnqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.49.0",
+        "@lexical/html": "0.49.0",
+        "@lexical/internal": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.49.0.tgz",
+      "integrity": "sha512-l7IuUj9n9CtFfz4Fz6zU6mmO+VkcnvyyebABx+lHevvTa7B6YI5PPVgABFfzdyPanyW/FGs7qpKBf59inAqbkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.49.0",
+        "@lexical/dragon": "0.49.0",
+        "@lexical/extension": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "@lexical/utils": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.49.0.tgz",
+      "integrity": "sha512-08Vd1+VoC6YnztWOFWVsqF/Hxw5EP8qeL1c7t3+rVCV8revLzXxdQw+vbPX3tgM4fmjOBDUXk6Ws1+rTtsqjcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.49.0.tgz",
+      "integrity": "sha512-mowedvbvx0HDaW+ymVdYmWVhueqgauhhqIWaCtbJj33tPk8pOu1BB0pZuJQbOB+1bDnFiZhkJV8W/CvR2M9lEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.49.0.tgz",
+      "integrity": "sha512-Jaa6DERBqxiFOFa49VPRV1WOb7mzRbMZ5U+v+RFagjzTmBhfxDmEkbQQ9nYTU3n3DPfdT8Hkyffextmw04etXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0",
+        "@lexical/selection": "0.49.0",
+        "lexical": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -4963,6 +7980,71 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
+      "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
+      "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.2.tgz",
+      "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^18.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-18.0.0.tgz",
+      "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^29.0.1"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
+      "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.1.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -5073,12 +8155,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
-      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/core": "2.11.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -5089,9 +8171,9 @@
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -5219,6 +8301,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5599,13 +8691,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
-      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
-        "@smithy/types": "^4.17.2",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5653,9 +8745,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
-      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5731,9 +8823,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -5745,6 +8837,12 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
@@ -5752,7 +8850,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5769,7 +8866,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5786,7 +8882,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5803,7 +8898,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5820,7 +8914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5837,7 +8930,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5854,7 +8946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5871,7 +8962,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5888,7 +8978,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5905,7 +8994,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5922,7 +9010,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5939,7 +9026,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5956,7 +9042,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5973,7 +9058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5990,7 +9074,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6007,7 +9090,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6024,7 +9106,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6041,7 +9122,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6058,7 +9138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6075,7 +9154,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6268,6 +9346,15 @@
     "node_modules/@wsl043/dsh-portable-plugin-market": {
       "resolved": "vendor/dsh-portable-plugin-market",
       "link": true
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/@yuku-codegen/binding-android-arm64": {
       "version": "0.8.7",
@@ -6772,18 +9859,28 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "ms": "^2.1.3"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -6893,6 +9990,45 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -6907,12 +10043,16 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie": {
@@ -6974,20 +10114,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "ms": "2.0.0"
       }
     },
     "node_modules/default-browser": {
@@ -7243,9 +10375,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -7261,6 +10393,61 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/express/node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -7274,9 +10461,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -7356,6 +10543,29 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -7540,9 +10750,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7588,6 +10798,29 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7600,6 +10833,29 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
@@ -7615,16 +10871,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-without-cache": {
@@ -7647,21 +10893,21 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-docker": {
@@ -7737,9 +10983,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
-      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.11.tgz",
+      "integrity": "sha512-A5NPn7g8EAzGU3IzRs+Yiq8K5n3ypYS75M5+KKiVHdUexfpWK1kP4ZMq7QnTGDoMj6TJ1dtcEJjW60yZDXS4hg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -7829,30 +11075,50 @@
       }
     },
     "node_modules/koffi": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.6.tgz",
-      "integrity": "sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.2.1.tgz",
+      "integrity": "sha512-0qE3lZ8jllRqPN4Ob6Ajl7c2bJSJDhQWuKLGP5hIEpHLllJWv1ydHFMhHmHc5p/W9GticKVDbYzZd7TBoQ4CZg==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
         "url": "https://liberapay.com/Koromix"
       },
       "optionalDependencies": {
-        "@koromix/koffi-darwin-arm64": "3.1.6",
-        "@koromix/koffi-darwin-x64": "3.1.6",
-        "@koromix/koffi-freebsd-arm64": "3.1.6",
-        "@koromix/koffi-freebsd-ia32": "3.1.6",
-        "@koromix/koffi-freebsd-x64": "3.1.6",
-        "@koromix/koffi-linux-arm64": "3.1.6",
-        "@koromix/koffi-linux-ia32": "3.1.6",
-        "@koromix/koffi-linux-loong64": "3.1.6",
-        "@koromix/koffi-linux-riscv64": "3.1.6",
-        "@koromix/koffi-linux-x64": "3.1.6",
-        "@koromix/koffi-openbsd-ia32": "3.1.6",
-        "@koromix/koffi-openbsd-x64": "3.1.6",
-        "@koromix/koffi-win32-arm64": "3.1.6",
-        "@koromix/koffi-win32-ia32": "3.1.6",
-        "@koromix/koffi-win32-x64": "3.1.6"
+        "@koromix/koffi-android-arm64": "3.2.1",
+        "@koromix/koffi-android-x64": "3.2.1",
+        "@koromix/koffi-darwin-arm64": "3.2.1",
+        "@koromix/koffi-darwin-x64": "3.2.1",
+        "@koromix/koffi-freebsd-arm64": "3.2.1",
+        "@koromix/koffi-freebsd-ia32": "3.2.1",
+        "@koromix/koffi-freebsd-x64": "3.2.1",
+        "@koromix/koffi-linux-arm": "3.2.1",
+        "@koromix/koffi-linux-arm64": "3.2.1",
+        "@koromix/koffi-linux-ia32": "3.2.1",
+        "@koromix/koffi-linux-loong64": "3.2.1",
+        "@koromix/koffi-linux-riscv64": "3.2.1",
+        "@koromix/koffi-linux-x64": "3.2.1",
+        "@koromix/koffi-openbsd-ia32": "3.2.1",
+        "@koromix/koffi-openbsd-x64": "3.2.1",
+        "@koromix/koffi-win32-arm64": "3.2.1",
+        "@koromix/koffi-win32-ia32": "3.2.1",
+        "@koromix/koffi-win32-x64": "3.2.1"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.49.0.tgz",
+      "integrity": "sha512-9V1ZIzGpJEd8rIN+nN7veL4fW4fFWbS66Un4JNqSZB4D5t9euzN9+3+jEXy83FjNjNy0MiiUI3+DQaGCLYko0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.49.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -8206,9 +11472,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -8219,19 +11485,6 @@
       "dependencies": {
         "content-type": "^2.1.0"
       },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/negotiator/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -8504,6 +11757,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8514,16 +11776,16 @@
       }
     },
     "node_modules/open": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.1.tgz",
-      "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+      "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.4.0",
+        "default-browser": "^5.5.1",
         "define-lazy-prop": "^3.0.0",
         "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.2.0",
+        "powershell-utils": "^0.2.1",
         "wsl-utils": "^1.0.0"
       },
       "engines": {
@@ -8534,13 +11796,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -8647,9 +11906,9 @@
       }
     },
     "node_modules/powershell-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
-      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+      "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -8659,9 +11918,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8694,10 +11953,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -8821,6 +12089,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8922,6 +12199,29 @@
         "node": ">= 18"
       }
     },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -8998,6 +12298,29 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/send/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -9024,9 +12347,9 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
@@ -9040,31 +12363,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -9336,30 +12659,17 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc"
@@ -9613,9 +12923,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -9628,34 +12938,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.7.tgz",
-      "integrity": "sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "1.2.0"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     },
     "vendor/dsh-portable-plugin-market": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,20 +1,20 @@
 {
   "name": "deepseek-harness-portable-runtime",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.2-rc.1",
   "private": true,
   "description": "Pinned official DeepSeek Harness runtime for DSH-Portable.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@deepseek-ai/dsh": "0.1.1-rc.2",
+    "@deepseek-ai/dsh": "0.1.2-rc.1",
     "@wsl043/dsh-portable-desktop-bridge": "file:../desktop-bridge",
     "@wsl043/dsh-portable-plugin-market": "file:vendor/dsh-portable-plugin-market",
     "pnpm": "11.7.0"
   },
   "allowScripts": {
-    "@deepseek-ai/dsh-subprocess-local@0.1.1-rc.2": true,
+    "@deepseek-ai/dsh-subprocess-local@0.1.2-rc.1": true,
     "@google/genai@1.52.0": true,
-    "koffi@3.1.6": true,
+    "koffi@3.2.1": true,
     "node-pty@1.2.0-beta.15": true,
-    "protobufjs@7.6.5": true
+    "protobufjs@7.6.6": true
   }
 }

--- a/config/footprint-budgets.json
+++ b/config/footprint-budgets.json
@@ -3,16 +3,16 @@
   "platforms": {
     "windows-x64": {
       "archiveBytes": 71500000,
-      "extractedBytes": 202000000,
+      "extractedBytes": 215000000,
       "files": 9600,
       "directories": 2850,
       "items": 12400,
-      "appBytes": 107000000,
+      "appBytes": 120000000,
       "appFiles": 9550,
       "appDirectories": 2800,
       "appItems": 12350,
-      "marketBytes": 350000,
-      "marketFiles": 8
+      "marketBytes": 400000,
+      "marketFiles": 12
     },
     "macos-x64": {
       "archiveBytes": 77000000,
@@ -20,8 +20,8 @@
       "files": 9500,
       "directories": 2800,
       "items": 12300,
-      "marketBytes": 350000,
-      "marketFiles": 8
+      "marketBytes": 400000,
+      "marketFiles": 12
     },
     "macos-arm64": {
       "archiveBytes": 75000000,
@@ -29,8 +29,8 @@
       "files": 9500,
       "directories": 2800,
       "items": 12300,
-      "marketBytes": 350000,
-      "marketFiles": 8
+      "marketBytes": 400000,
+      "marketFiles": 12
     },
     "linux-x64": {
       "archiveBytes": 90000000,
@@ -38,8 +38,8 @@
       "files": 14250,
       "directories": 3875,
       "items": 18150,
-      "marketBytes": 350000,
-      "marketFiles": 8
+      "marketBytes": 400000,
+      "marketFiles": 12
     },
     "linux-arm64": {
       "archiveBytes": 89500000,
@@ -47,8 +47,8 @@
       "files": 14250,
       "directories": 3875,
       "items": 18150,
-      "marketBytes": 350000,
-      "marketFiles": 8
+      "marketBytes": 400000,
+      "marketFiles": 12
     }
   }
 }

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.6.0-alpha.1"
+  #define AppVersion "0.6.0"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.6.0.10001
+VersionInfoVersion=0.6.0.65534
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.6.0-alpha.1",
+      "version": "0.6.0",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.6.0-alpha.1</string>
+	<string>0.6.0</string>
   <key>CFBundleVersion</key>
-	<string>6000101</string>
+	<string>6000999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -24,8 +24,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.6.0.10001")]
-[assembly: System.Reflection.AssemblyFileVersion("0.6.0.10001")]
+[assembly: System.Reflection.AssemblyVersion("0.6.0.65534")]
+[assembly: System.Reflection.AssemblyFileVersion("0.6.0.65534")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -8,8 +8,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.6.0.10001")]
-[assembly: AssemblyFileVersion("0.6.0.10001")]
+[assembly: AssemblyVersion("0.6.0.65534")]
+[assembly: AssemblyFileVersion("0.6.0.65534")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -27,8 +27,8 @@ using Microsoft.Toolkit.Uwp.Notifications;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.6.0.10001")]
-[assembly: AssemblyFileVersion("0.6.0.10001")]
+[assembly: AssemblyVersion("0.6.0.65534")]
+[assembly: AssemblyFileVersion("0.6.0.65534")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/release-notes/v0.6.0.json
+++ b/release-notes/v0.6.0.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.6.0",
+  "zh": {
+    "summary": "0.6.0 完成桌面集成与更新体验，正式提供可靠的任务通知、内核版本选择和默认插件维护。",
+    "highlights": [
+      "Windows 任务完成后会进入系统通知中心，并支持查看完整结果、回复原任务和任务栏未读提示。",
+      "选择工作区使用置顶的原生目录窗口；桌面窗口与任务栏稳定显示 DSH-Portable 自有图标。",
+      "设置中可以从经过验证且与当前 Portable 兼容的版本目录选择 DeepSeek Harness 内核，并保留独立的产品更新入口。",
+      "已安装的默认插件会随 Portable 自动升级到本版本已审查的基线；主动删除的插件不会重装，较新版本不会降级。",
+      "主界面会显示可用更新和当前隔离环境；插件市场同步了 dsh-market 1.41 中适合 Portable 的代理、搜索和分页兼容修复。",
+      "本版本默认采用已完成 Alpha 成品验收的 DeepSeek Harness 0.1.2-rc.1。"
+    ]
+  },
+  "en": {
+    "summary": "0.6.0 completes the desktop integration and update experience with dependable task alerts, engine selection, and maintained default plugins.",
+    "highlights": [
+      "Windows task completion now reaches Action Center with the full result, originating-task Reply, and an unread taskbar indicator.",
+      "Workspace selection uses a topmost native folder dialog, while the desktop window and taskbar retain the DSH-Portable application icon.",
+      "Settings can select DeepSeek Harness from a verified, Portable-compatible version catalog while keeping product updates separate.",
+      "Installed default plugins automatically advance to this release's reviewed baseline; removed defaults stay removed and newer versions are never downgraded.",
+      "The main shell shows available updates and the active isolated environment, and the market includes the applicable proxy, search, and pager compatibility fixes from dsh-market 1.41.",
+      "This release defaults to DeepSeek Harness 0.1.2-rc.1 after finished-product Alpha acceptance."
+    ]
+  }
+}

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -25,9 +25,6 @@ UPDATE_CHANNEL_TAG="$(printf '%s\n' "$VERSION_POLICY" | awk -F= '$1 == "updateCh
 if [[ "$RELEASE_CHANNEL" == "candidate" ]]; then
   [[ -n "$PREVIEW_APP_SOURCE" ]] || { echo "Candidate builds require PREVIEW_APP_SOURCE" >&2; exit 1; }
   COMPONENT_LOCK_FILE="$PROJECT_ROOT/upstream.preview.lock.json"
-elif [[ -n "$PREVIEW_APP_SOURCE" ]]; then
-  echo "Stable builds must not consume PREVIEW_APP_SOURCE" >&2
-  exit 1
 fi
 
 lock_value() {
@@ -126,7 +123,7 @@ if [[ -n "$PREVIEW_APP_SOURCE" ]]; then
   [[ -f "$PREVIEW_APP_SOURCE/preview-runtime.json" && -f "$PREVIEW_APP_SOURCE/node_modules/@deepseek-ai/dsh/package.json" ]] || {
     echo "Preview app source is incomplete: $PREVIEW_APP_SOURCE" >&2; exit 1;
   }
-  "$BUILD_NODE" -e 'const fs=require("fs"); const receipt=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const lock=JSON.parse(fs.readFileSync(process.argv[2],"utf8")); if(receipt.dshVersion!==lock.dsh.version||receipt.dshCommit!==lock.dsh.reviewedCommit) throw new Error("Preview app receipt does not match upstream.preview.lock.json")' "$PREVIEW_APP_SOURCE/preview-runtime.json" "$COMPONENT_LOCK_FILE"
+  "$BUILD_NODE" -e 'const fs=require("fs"); const receipt=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const lock=JSON.parse(fs.readFileSync(process.argv[2],"utf8")); if(receipt.dshVersion!==lock.dsh.version||receipt.dshCommit!==lock.dsh.reviewedCommit) throw new Error("Source-pack receipt does not match selected upstream lock")' "$PREVIEW_APP_SOURCE/preview-runtime.json" "$COMPONENT_LOCK_FILE"
   rm -rf "$STAGE/app"
   cp -R "$PREVIEW_APP_SOURCE" "$STAGE/app"
   rm -rf "$STAGE/app/node_modules/@wsl043/dsh-portable-desktop-bridge" "$STAGE/app/node_modules/@wsl043/dsh-portable-plugin-market"
@@ -158,7 +155,7 @@ fi
 printf '%s  %s\n' "$DSH_NOTICES_SHA256" "$NOTICES" | sha256sum --check
 cp "$NOTICES" "$STAGE/licenses/DeepSeek-Harness-THIRD_PARTY_NOTICES.md"
 
-DSH_CHANNEL="$(if [[ -n "$PREVIEW_APP_SOURCE" ]]; then printf preview; else printf stable; fi)"
+DSH_CHANNEL="$(if [[ "$RELEASE_CHANNEL" == candidate ]]; then printf preview; else printf stable; fi)"
 DSH_PACKAGE_SET_SHA256="$(if [[ -n "$PREVIEW_APP_SOURCE" ]]; then "$BUILD_NODE" -p 'require(process.argv[1]).packageSetSha256' "$PREVIEW_APP_SOURCE/preview-runtime.json"; else printf ''; fi)"
 DEFAULT_PLUGINS_JSON="$("$BUILD_NODE" -e 'const fs=require("fs"); const lock=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(JSON.stringify(Object.values(lock.defaultPlugins||{}).map(({package:p,version,sha256,integrity})=>({package:p,version,sha256,integrity}))))' "$COMPONENT_LOCK_FILE")"
 cat > "$STAGE/licenses/COMPONENTS.json" <<EOF
@@ -287,7 +284,7 @@ TAR_HASH="$(sha256sum "$TAR" | awk '{print $1}')"
 printf '%s  %s\n' "$TAR_HASH" "$(basename "$TAR")" > "$TAR.sha256"
 FOOTPRINT="$OUTPUT_DIR/footprint-linux-$ARCH.json"
 FOOTPRINT_BUDGET="$PROJECT_ROOT/config/footprint-budgets.json"
-[[ -z "$PREVIEW_APP_SOURCE" ]] || FOOTPRINT_BUDGET="$PROJECT_ROOT/config/footprint-budgets-preview.json"
+[[ "$RELEASE_CHANNEL" != candidate ]] || FOOTPRINT_BUDGET="$PROJECT_ROOT/config/footprint-budgets-preview.json"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/report-footprint.mjs" "$STAGE" \
   --platform "linux-$ARCH" --archive "$TAR" \
   --budget "$FOOTPRINT_BUDGET" --output "$FOOTPRINT"

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -25,9 +25,6 @@ UPDATE_CHANNEL_TAG="$(printf '%s\n' "$VERSION_POLICY" | awk -F= '$1 == "updateCh
 if [[ "$RELEASE_CHANNEL" == "candidate" ]]; then
   [[ -n "$PREVIEW_APP_SOURCE" ]] || { echo "Candidate builds require PREVIEW_APP_SOURCE" >&2; exit 1; }
   COMPONENT_LOCK_FILE="$PROJECT_ROOT/upstream.preview.lock.json"
-elif [[ -n "$PREVIEW_APP_SOURCE" ]]; then
-  echo "Stable builds must not consume PREVIEW_APP_SOURCE" >&2
-  exit 1
 fi
 
 lock_value() {
@@ -131,7 +128,7 @@ if [[ -n "$PREVIEW_APP_SOURCE" ]]; then
   [[ -f "$PREVIEW_APP_SOURCE/preview-runtime.json" && -f "$PREVIEW_APP_SOURCE/node_modules/@deepseek-ai/dsh/package.json" ]] || {
     echo "Preview app source is incomplete: $PREVIEW_APP_SOURCE" >&2; exit 1;
   }
-  "$BUILD_NODE" -e 'const fs=require("fs"); const receipt=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const lock=JSON.parse(fs.readFileSync(process.argv[2],"utf8")); if(receipt.dshVersion!==lock.dsh.version||receipt.dshCommit!==lock.dsh.reviewedCommit) throw new Error("Preview app receipt does not match upstream.preview.lock.json")' "$PREVIEW_APP_SOURCE/preview-runtime.json" "$COMPONENT_LOCK_FILE"
+  "$BUILD_NODE" -e 'const fs=require("fs"); const receipt=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const lock=JSON.parse(fs.readFileSync(process.argv[2],"utf8")); if(receipt.dshVersion!==lock.dsh.version||receipt.dshCommit!==lock.dsh.reviewedCommit) throw new Error("Source-pack receipt does not match selected upstream lock")' "$PREVIEW_APP_SOURCE/preview-runtime.json" "$COMPONENT_LOCK_FILE"
   rm -rf "$STAGE/app"
   cp -R "$PREVIEW_APP_SOURCE" "$STAGE/app"
   rm -rf "$STAGE/app/node_modules/@wsl043/dsh-portable-desktop-bridge" "$STAGE/app/node_modules/@wsl043/dsh-portable-plugin-market"
@@ -163,7 +160,7 @@ fi
 printf '%s  %s\n' "$DSH_NOTICES_SHA256" "$NOTICES" | shasum -a 256 -c -
 cp "$NOTICES" "$STAGE/licenses/DeepSeek-Harness-THIRD_PARTY_NOTICES.md"
 
-DSH_CHANNEL="$(if [[ -n "$PREVIEW_APP_SOURCE" ]]; then printf preview; else printf stable; fi)"
+DSH_CHANNEL="$(if [[ "$RELEASE_CHANNEL" == candidate ]]; then printf preview; else printf stable; fi)"
 DSH_PACKAGE_SET_SHA256="$(if [[ -n "$PREVIEW_APP_SOURCE" ]]; then "$BUILD_NODE" -p 'require(process.argv[1]).packageSetSha256' "$PREVIEW_APP_SOURCE/preview-runtime.json"; else printf ''; fi)"
 DEFAULT_PLUGINS_JSON="$("$BUILD_NODE" -e 'const fs=require("fs"); const lock=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(JSON.stringify(Object.values(lock.defaultPlugins||{}).map(({package:p,version,sha256,integrity})=>({package:p,version,sha256,integrity}))))' "$COMPONENT_LOCK_FILE")"
 cat > "$STAGE/licenses/COMPONENTS.json" <<EOF
@@ -293,7 +290,7 @@ HASH="$(shasum -a 256 "$ZIP" | awk '{print $1}')"
 printf '%s  %s\n' "$HASH" "$(basename "$ZIP")" > "$ZIP.sha256"
 FOOTPRINT="$OUTPUT_DIR/footprint-macos-$ARCH.json"
 FOOTPRINT_BUDGET="$PROJECT_ROOT/config/footprint-budgets.json"
-[[ -z "$PREVIEW_APP_SOURCE" ]] || FOOTPRINT_BUDGET="$PROJECT_ROOT/config/footprint-budgets-preview.json"
+[[ "$RELEASE_CHANNEL" != candidate ]] || FOOTPRINT_BUDGET="$PROJECT_ROOT/config/footprint-budgets-preview.json"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/report-footprint.mjs" "$STAGE" \
   --platform "macos-$ARCH" --archive "$ZIP" \
   --budget "$FOOTPRINT_BUDGET" --output "$FOOTPRINT"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -183,7 +183,11 @@ try {
         throw 'Candidate builds require -PreviewAppSource; refusing to publish a stable DSH runtime behind a beta shell version.'
     }
     if ($ReleaseChannel -eq 'stable' -and $PreviewAppSource) {
-        throw 'Stable builds must not consume -PreviewAppSource.'
+        if ($PreviewReceipt.dshVersion -ne $Lock.dsh.version -or $PreviewReceipt.dshCommit -ne $Lock.dsh.reviewedCommit) {
+            throw 'Stable source-pack receipt does not match upstream.lock.json.'
+        }
+        $DshLock = $Lock.dsh
+        $DefaultPluginsLock = $Lock.defaultPlugins
     }
     $ShellFingerprint = (& $NodeExe (Join-Path $ProjectRoot 'scripts\shell-fingerprint.mjs') windows).Trim()
     if ($LASTEXITCODE -ne 0 -or $ShellFingerprint -notmatch '^[a-f0-9]{64}$') { throw 'Windows shell fingerprint generation failed.' }
@@ -281,7 +285,7 @@ try {
         dshPackage = $DshLock.package
         dshVersion = $DshLock.version
         dshCommit = $DshLock.reviewedCommit
-        dshChannel = if ($PreviewAppSource) { 'preview' } else { 'stable' }
+        dshChannel = if ($ReleaseChannel -eq 'candidate') { 'preview' } else { 'stable' }
         dshPackageSetSha256 = if ($PreviewReceipt) { $PreviewReceipt.packageSetSha256 } else { $null }
         pluginMarketPackage = '@wsl043/dsh-portable-plugin-market'
         pluginMarketVersion = $Lock.pluginMarket.version
@@ -465,7 +469,7 @@ try {
     if (Test-Path -LiteralPath $ShaBackup) { Remove-Item -LiteralPath $ShaBackup -Force }
 
     $FootprintReport = Join-Path $OutputDir 'footprint-windows-x64.json'
-    $FootprintBudget = if ($PreviewAppSource) {
+    $FootprintBudget = if ($ReleaseChannel -eq 'candidate') {
         Join-Path $ProjectRoot 'config\footprint-budgets-preview.json'
     } else {
         Join-Path $ProjectRoot 'config\footprint-budgets.json'

--- a/tests/preview-upstream.test.mjs
+++ b/tests/preview-upstream.test.mjs
@@ -7,14 +7,17 @@ import { npmCliCandidates, productionPackageClosure } from '../scripts/stage-pre
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-test('stable and candidate upstream locks are separate and immutable', async () => {
+test('the stable release explicitly promotes the reviewed candidate without mutating its lock format', async () => {
   const [stable, preview] = await Promise.all([
     readFile(path.join(root, 'upstream.lock.json'), 'utf8').then(JSON.parse),
     readFile(path.join(root, 'upstream.preview.lock.json'), 'utf8').then(JSON.parse),
   ])
-  assert.equal(stable.dsh.version, '0.1.1-rc.2')
+  assert.equal(stable.dsh.version, '0.1.2-rc.1')
+  assert.equal(stable.dsh.version, preview.dsh.version)
+  assert.equal(stable.dsh.integrity, preview.dsh.npmIntegrity)
+  assert.equal(stable.dsh.reviewedCommit, preview.dsh.reviewedCommit)
   assert.equal(preview.channel, 'beta')
-  assert.match(preview.dsh.version, /^\d+\.\d+\.\d+-(?:alpha|rc)\.[1-9]\d*$/)
+  assert.match(preview.dsh.version, /^\d+\.\d+\.\d+-(?:alpha|beta|rc)\.[1-9]\d*$/)
   assert.equal(preview.dsh.tag, `dsh-v${preview.dsh.version}`)
   assert.match(preview.dsh.npmIntegrity, /^sha512-[A-Za-z0-9+/]+={0,2}$/)
   assert.match(preview.dsh.reviewedCommit, /^[0-9a-f]{40}$/)
@@ -60,26 +63,27 @@ test('Windows packaging consumes preview runtime only through an explicit receip
   assert.match(build, /upstream\.preview\.lock\.json/)
   assert.match(build, /Preview app receipt does not match/)
   assert.match(build, /if \(-not \$PreviewAppSource\) \{[\s\S]+verify-lock\.mjs[\s\S]+npm ci failed/)
-  assert.match(build, /dshChannel = if \(\$PreviewAppSource\) \{ 'preview' \} else \{ 'stable' \}/)
+  assert.match(build, /dshChannel = if \(\$ReleaseChannel -eq 'candidate'\) \{ 'preview' \} else \{ 'stable' \}/)
   assert.match(build, /footprint-budgets-preview\.json/)
   assert.match(build, /Candidate builds require -PreviewAppSource/)
+  assert.match(build, /Stable source-pack receipt does not match upstream\.lock\.json/)
+  assert.match(build, /\$ReleaseChannel -eq 'candidate'[\s\S]+footprint-budgets-preview\.json/)
 })
 
-test('macOS and Linux candidate packaging fail closed without the staged official preview runtime', async () => {
+test('macOS and Linux packaging fail closed unless the staged official source pack matches the selected lock', async () => {
   for (const filename of ['build-macos.sh', 'build-linux.sh']) {
     const build = await readFile(path.join(root, 'scripts', filename), 'utf8')
     assert.match(build, /PREVIEW_APP_SOURCE/)
     assert.match(build, /Candidate builds require PREVIEW_APP_SOURCE/)
-    assert.match(build, /Stable builds must not consume PREVIEW_APP_SOURCE/)
     assert.match(build, /preview-runtime\.json/)
     assert.match(build, /upstream\.preview\.lock\.json/)
-    assert.match(build, /Preview app receipt does not match upstream\.preview\.lock\.json/)
+    assert.match(build, /source-pack receipt does not match selected upstream lock/i)
     assert.match(build, /dshPackageSetSha256/)
     assert.match(build, /footprint-budgets-preview\.json/)
   }
 })
 
-test('CI builds one immutable official preview package set and stages it natively on every platform', async () => {
+test('CI builds one immutable official source package set and stages it natively on every platform', async () => {
   const workflow = await readFile(path.join(root, '.github', 'workflows', 'ci.yml'), 'utf8')
   assert.match(workflow, /preview-packed-runtime:/)
   assert.match(workflow, /repository: deepseek-ai\/deepseek-harness/)
@@ -90,6 +94,7 @@ test('CI builds one immutable official preview package set and stages it nativel
   assert.match(workflow, /pnpm --dir upstream\/native\/landlock-run\/packages\/entry pack --pack-destination/)
   assert.equal((workflow.match(/stage-preview-runtime\.mjs/g) ?? []).length, 3)
   assert.equal((workflow.match(/--packed-root preview-packed\/upstream\/dist/g) ?? []).length, 3)
+  assert.doesNotMatch(workflow, /if: steps\.preview\.outputs\.channel == 'candidate'/)
   assert.match(workflow, /build-windows\.ps1 -PreviewAppSource preview-app/)
   assert.match(workflow, /PREVIEW_APP_SOURCE="\$PWD\/preview-app" bash scripts\/build-macos\.sh/)
   assert.match(workflow, /PREVIEW_APP_SOURCE="\$PWD\/preview-app" bash scripts\/build-linux\.sh/)

--- a/upstream.lock.json
+++ b/upstream.lock.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "dsh": {
     "package": "@deepseek-ai/dsh",
-    "version": "0.1.1-rc.2",
-    "integrity": "sha512-UP1UIh6q3Gme/yXRn/QL2P8IsVlv8Shpg22TRJIZPsCRWLm4CBiA1MUvXmJAfsOEETBMLAl+xWPtFw6ICsN3wg==",
+    "version": "0.1.2-rc.1",
+    "integrity": "sha512-RPq48TzxvwpdT9/7W1tbhZDBMmeK+bxDrX9cqQC27Wx/LqtgJF8PSa3b3xriU8oxtvhwYmk21w2cej3uMQrnVA==",
     "sourceRepository": "https://github.com/deepseek-ai/deepseek-harness",
-    "reviewedCommit": "b150a551b8d465e31e418e1b2eaf5e79bbb7d28e",
-    "noticesSha256": "50c0b03d591244cdceb61c3bcb0db224e998388af6cbad8fa9d1e980440e25b3"
+    "reviewedCommit": "a66e4702047846cdaa10c66c9d3df3951f5ea70d",
+    "noticesSha256": "45c3d5ad23ea58fe6aaa2703488f74f03ea53cc0fa80c1024c24d63670570779"
   },
   "pnpm": {
     "package": "pnpm",


### PR DESCRIPTION
## Summary
- promote the reviewed DeepSeek Harness 0.1.2-rc.1 runtime into the stable 0.6.0 product
- build stable packages from the same receipt-verified official source pack used for candidate acceptance, avoiding duplicated npm dependency trees
- update bounded footprint budgets only for the measured RC1 runtime and dsh-market 1.41 payload
- add bilingual 0.6.0 release notes and synchronize all platform versions

## Verification
- 412/412 source contracts pass
- Windows 0.6.0 offline package builds successfully from the reviewed source receipt
- footprint passes: 59,031,099-byte archive; 210,946,517 bytes extracted; 8,672 files
- native workspace picker smoke passes with the topmost workspace dialog
- native tray/Action Center notification smoke passes
- live candidate engine catalog returns the compatible 0.1.2-rc.1 target