### PR TITLE
Fix stable source artifact staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           path: preview-packed
       - name: Stage the locked official source runtime
         shell: powershell
-        run: node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
+        run: node scripts/stage-preview-runtime.mjs --packed-root preview-packed --output preview-app
       - name: Build Windows portable base
         shell: powershell
         run: ./scripts/build-windows.ps1 -PreviewAppSource preview-app
@@ -469,7 +469,7 @@ jobs:
           path: preview-packed
       - name: Build the product from the matching stable or preview runtime
         run: |
-          node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
+          node scripts/stage-preview-runtime.mjs --packed-root preview-packed --output preview-app
           PREVIEW_APP_SOURCE="$PWD/preview-app" bash scripts/build-macos.sh "${{ matrix.arch }}"
       - uses: actions/upload-artifact@v7
         with:
@@ -608,7 +608,7 @@ jobs:
           path: preview-packed
       - name: Build the product from the matching stable or preview runtime
         run: |
-          node scripts/stage-preview-runtime.mjs --packed-root preview-packed/upstream/dist --output preview-app
+          node scripts/stage-preview-runtime.mjs --packed-root preview-packed --output preview-app
           PREVIEW_APP_SOURCE="$PWD/preview-app" bash scripts/build-linux.sh "${{ matrix.arch }}"
       - uses: actions/upload-artifact@v7
         with:

--- a/tests/preview-upstream.test.mjs
+++ b/tests/preview-upstream.test.mjs
@@ -93,7 +93,7 @@ test('CI builds one immutable official source package set and stages it natively
   assert.match(workflow, /pnpm --dir upstream run release:pack --family vendor --out dist\/npm-vendor --concurrency 8/)
   assert.match(workflow, /pnpm --dir upstream\/native\/landlock-run\/packages\/entry pack --pack-destination/)
   assert.equal((workflow.match(/stage-preview-runtime\.mjs/g) ?? []).length, 3)
-  assert.equal((workflow.match(/--packed-root preview-packed\/upstream\/dist/g) ?? []).length, 3)
+  assert.equal((workflow.match(/--packed-root preview-packed(?:\s|$)/gm) ?? []).length, 3)
   assert.doesNotMatch(workflow, /if: steps\.preview\.outputs\.channel == 'candidate'/)
   assert.match(workflow, /build-windows\.ps1 -PreviewAppSource preview-app/)
   assert.match(workflow, /PREVIEW_APP_SOURCE="\$PWD\/preview-app" bash scripts\/build-macos\.sh/)


### PR DESCRIPTION
The stable-source artifact upload now has npm, npm-vendor, and npm-landlock at the download root because the old root marker was removed. Stage from that explicit artifact root on every platform and lock the layout in the workflow contract. Verification: 412/412 source contracts pass. The failed main run showed the same missing preview-packed/upstream/dist/npm path on Windows and both macOS architectures.