### PR TITLE
Align task notification settings smoke label

### DIFF
--- a/scripts/smoke-windows-tray-bridge.mjs
+++ b/scripts/smoke-windows-tray-bridge.mjs
@@ -402,7 +402,7 @@ try {
       updates: /(?:^|\\n)(?:Updates|更新)(?:\\n|$)/.test(text),
       product: /DSH-Portable/.test(text),
       engine: /DeepSeek Harness/.test(text),
-      notifications: /Task completion notifications|任务完成通知/.test(text),
+      notifications: /Task notifications|任务通知/.test(text),
       maintenance: /Check and repair|检查与修复/.test(text),
     }
   })()`, value => value?.title && value.updates && value.product && value.engine && value.notifications && value.maintenance, 'Portable controls in General settings')


### PR DESCRIPTION
Updates the finished-product Windows settings smoke assertion to match the current Task notifications label. Product code and release assets are unchanged. This resolves the identical stale-label assertion in the Windows 2022 and Windows 2025 qualification jobs.