### PR TITLE
发布修正版 0.6.2，覆盖已安装撤回版本的用户

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../desktop-bridge": {
       "name": "@wsl043/dsh-portable-desktop-bridge",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0"
     },
     "node_modules/@agentclientprotocol/sdk": {

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/docs/performance-0.6.2.md
+++ b/docs/performance-0.6.2.md
@@ -1,0 +1,30 @@
+# 0.6.2 repair qualification / 修复验收
+
+0.6.1 remains withdrawn. Version 0.6.2 includes the repairs in PR #91 and the completed market review in PR #92. A higher version is required because installed 0.6.1 updaters ignore a replacement with the same version. Both 0.6.0 and 0.6.1 detect the repaired shell as requiring a full-package update.
+
+0.6.1 保持撤回。0.6.2 包含 PR #91 的后续修复和 PR #92 完成的市场采纳审阅；递增版本使曾安装撤回包的用户也能收到修复。0.6.0 和 0.6.1 均已验证会提示更新完整包。
+
+## Completed evidence / 已完成验证
+
+| Check | Evidence |
+| --- | --- |
+| Confirmed performance defects | [Historical repair evidence](performance-0.6.1.md): unchanged event burst reduced from 4001 projections to one, old tray disposal failure reproduced and repaired, process identity queries reduced, bounded log reads, path-alias ownership and maintenance entry repaired |
+| Failed-start cleanup | Regression fails before repair; cleanup failure retains process state and original/cleanup errors, and prevents retry |
+| Windows inspection failure | Query errors propagate instead of meaning absence; process state survives inspection failure; bounded redacted error causes enter the report |
+| Market updates and reporting | Exact target requirements checked before npm update; incompatible versions rejected before mutation; render failures isolated and sanitized events persisted in support reports |
+| Windows 11 finished product | Hidden native restart changes backend boot ID; a submitted market diagnostic appears in the JSON support report without the fixture secret; injected UI stall/recovery, responsive backend and clean exit pass |
+| Cross-platform finished product | [Run 34100016493](https://github.com/WSL043/DSH-Portable/actions/runs/34100016493): all 34 jobs passed, including Windows 2022/2025, macOS x64/arm64 and Linux x64/arm64 native checks |
+| Windows close behavior in that run | Native close-to-exit: 0.508/0.509 seconds on Windows 2022 and 0.634/0.668 seconds on Windows 2025; stall diagnostics, report correlation and restart pass |
+| Local contracts | 480 tests passed before the final bounded error-cause addition; its 13 targeted diagnostic/query/cleanup tests passed afterward. Version/release-note/update-core checks pass after advancing to 0.6.2 |
+
+The final release must use a successful complete main build of its exact commit. Its generated qualification and checksums identify the actual distributed packages; earlier branch or local packages are supporting evidence, not substitutes. Windows and macOS CI preserve support-report artifacts for investigation. Local Windows checks use process/control interfaces and hidden native hosts without desktop input automation.
+
+最终发布使用对应提交的完整 main 成品流水线，发布证明和 SHA-256 对应实际下载包。上述历史分支、本机结果是补充证据。Windows 与 macOS CI 保留支持报告，本机使用后台接口和隐藏原生宿主，不控制用户鼠标或窗口。
+
+## Evidence boundary / 证据边界
+
+Issue #89's original report records a 60-second DSH import timeout. It lacks the contemporaneous CPU/thread evidence needed to establish its unique cause; successful later launches were separate launches, not demonstrated automatic recovery. The original Windows 10 machine is unavailable. GitHub Windows runners and local Windows 11 provide repeatable product verification, not a claim that a Windows Server runner is Windows 10.
+
+Regression fixtures prove the confirmed defects above, and failure injection proves diagnostic coverage. They do not prove the historical timeout's unique root cause or an unlimited-duration workload's stability. A recurrence should be investigated using the new correlated startup, native/backend heartbeat, cleanup and error-cause records.
+
+#89 原始附件中的 60 秒导入超时缺少同期 CPU/线程证据，无法据此认定唯一根因。已有回归证明已确认缺陷得到修复，故障注入证明日志能捕获和关联异常；两者均不冒充原始超时的独立复现。缺少原机器由 GitHub CI 加本机 Win11 补充验证，保留系统差异这一事实。若再次发生，应使用新增的启动、双端心跳、清理和底层错误链继续定位。

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.6.1"
+  #define AppVersion "0.6.2"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.6.1.65534
+VersionInfoVersion=0.6.2.65534
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.6.1"
+version = "0.6.2"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.6.1</string>
+	<string>0.6.2</string>
   <key>CFBundleVersion</key>
-	<string>6001999</string>
+	<string>6002999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -24,8 +24,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.6.1.65534")]
-[assembly: System.Reflection.AssemblyFileVersion("0.6.1.65534")]
+[assembly: System.Reflection.AssemblyVersion("0.6.2.65534")]
+[assembly: System.Reflection.AssemblyFileVersion("0.6.2.65534")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -8,8 +8,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.6.1.65534")]
-[assembly: AssemblyFileVersion("0.6.1.65534")]
+[assembly: AssemblyVersion("0.6.2.65534")]
+[assembly: AssemblyFileVersion("0.6.2.65534")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -28,8 +28,8 @@ using Windows.UI.Notifications;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.6.1.65534")]
-[assembly: AssemblyFileVersion("0.6.1.65534")]
+[assembly: AssemblyVersion("0.6.2.65534")]
+[assembly: AssemblyFileVersion("0.6.2.65534")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/release-notes/UNRELEASED.md
+++ b/release-notes/UNRELEASED.md
@@ -1,6 +1,6 @@
 # 待发布 / Unreleased
 
-以下累积改动归入 0.6.2（0.6.1 已撤回），双语版本说明见 [v0.6.2.json](v0.6.2.json)，本机与基础修复验收见 [性能修复证据](../docs/performance-0.6.1.md)。最终发布状态、提交和成品校验值以 GitHub Release 的发布证据为准。
+以下累积改动归入 0.6.2（0.6.1 已撤回），双语版本说明见 [v0.6.2.json](v0.6.2.json)，本机与基础修复验收见 [性能修复证据](../docs/performance-0.6.2.md)。最终发布状态、提交和成品校验值以 GitHub Release 的发布证据为准。
 
 ## 用户变化候选
 
@@ -24,7 +24,7 @@
 
 ## English
 
-These accumulated changes belong to 0.6.2 (0.6.1 was withdrawn). See its [bilingual descriptor](v0.6.2.json) and [local and baseline performance evidence](../docs/performance-0.6.1.md). The GitHub Release qualification records the authoritative publication state, commit and download checksums.
+These accumulated changes belong to 0.6.2 (0.6.1 was withdrawn). See its [bilingual descriptor](v0.6.2.json) and [local and baseline performance evidence](../docs/performance-0.6.2.md). The GitHub Release qualification records the authoritative publication state, commit and download checksums.
 
 - Coalesce streamed session events, suppress duplicate tray projections, and dispose retired native menu resources.
 - Reduce Windows startup process inspection, bound log reads, and resolve capsule runtime paths for maintenance commands.

--- a/release-notes/UNRELEASED.md
+++ b/release-notes/UNRELEASED.md
@@ -1,6 +1,6 @@
 # 待发布 / Unreleased
 
-以下累积改动归入 0.6.1，双语版本说明见 [v0.6.1.json](v0.6.1.json)，本机与基础修复验收见 [性能修复证据](../docs/performance-0.6.1.md)。最终发布状态、提交和成品校验值以 GitHub Release 的发布证据为准。
+以下累积改动归入 0.6.2（0.6.1 已撤回），双语版本说明见 [v0.6.2.json](v0.6.2.json)，本机与基础修复验收见 [性能修复证据](../docs/performance-0.6.1.md)。最终发布状态、提交和成品校验值以 GitHub Release 的发布证据为准。
 
 ## 用户变化候选
 
@@ -24,7 +24,7 @@
 
 ## English
 
-These accumulated changes belong to 0.6.1. See its [bilingual descriptor](v0.6.1.json) and [local and baseline performance evidence](../docs/performance-0.6.1.md). The GitHub Release qualification records the authoritative publication state, commit and download checksums.
+These accumulated changes belong to 0.6.2 (0.6.1 was withdrawn). See its [bilingual descriptor](v0.6.2.json) and [local and baseline performance evidence](../docs/performance-0.6.1.md). The GitHub Release qualification records the authoritative publication state, commit and download checksums.
 
 - Coalesce streamed session events, suppress duplicate tray projections, and dispose retired native menu resources.
 - Reduce Windows startup process inspection, bound log reads, and resolve capsule runtime paths for maintenance commands.

--- a/release-notes/v0.6.2.json
+++ b/release-notes/v0.6.2.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.6.2",
+  "zh": {
+    "summary": "0.6.2 改进流式任务期间的桌面响应、托盘资源释放、启动等待与诊断，并包含此前积累的插件修复。",
+    "highlights": [
+      "合并密集会话事件，相同状态不再反复刷新原生托盘；菜单重建释放旧资源，减少长时间运行的重复开销。",
+      "启动期间减少 Windows 进程查询；查询失败不再被当成进程已退出，启动清理失败保留运行状态和两段错误，避免遗留进程失去记录。",
+      "修正维护命令的 capsule 运行时入口；已有配置目录缺少插件清单时不再中断启动或升级检查，并保留该目录中的用户文件。",
+      "修正 Windows 长短路径双向进程识别，避免切换路径写法后重复启动后台、遗留进程和占用便携目录。",
+      "新增可关联启动 ID 和进程 ID 的后台与原生窗口健康日志，捕获心跳延迟、恢复、CPU 和内存变化，并补齐导入完成与退出阶段；支持报告在日志较大时仍可导出。",
+      "随附 pnpm 11.11.0；补齐 Git prepare 与 tarball 错误分类、插件更新前版本要求检查、市场页面异常隔离，并将脱敏市场事件纳入 JSON 支持报告。"
+    ],
+    "knownIssues": [
+      "Issue #89 的用户环境曾在 DSH 导入阶段发生 60 秒超时；本次修复减少已确认的桌面与启动开销，但尚未单独复现该环境的超时。若仍发生，请在故障后导出支持报告，新日志可区分后台与原生窗口的心跳延迟。"
+    ],
+    "upgradeNotes": [
+      "0.6.1 已撤回；修复以 0.6.2 发布，确保曾安装 0.6.1 的用户也能收到更新。本次涉及原生外壳，请按更新提示升级完整安装包或便携包，保留原有数据目录。",
+      "安装更新前结束运行中的任务并备份数据。保持产品发布与上游内核发布独立。"
+    ]
+  },
+  "en": {
+    "summary": "0.6.2 improves desktop responsiveness during streaming, tray resource disposal, startup polling and diagnostics, and includes accumulated plugin fixes.",
+    "highlights": [
+      "Coalesce session bursts and skip unchanged native tray projections. Dispose retired menu resources to reduce repeated work during long sessions.",
+      "Reduce Windows process inspection during startup. Failed inspection no longer means the process exited; failed startup cleanup preserves state and both errors instead of losing track of a surviving backend.",
+      "Route maintenance commands through the capsule runtime entry. An existing profile without a plugin manifest no longer interrupts startup or upgrade preflight; existing files are preserved.",
+      "Recognize Windows short and long paths in both directions to prevent duplicate backends and orphaned processes holding the portable directory.",
+      "Correlate backend and native-window health logs by startup and process IDs, including heartbeat delay/recovery, CPU, memory, import completion and shutdown. Large logs no longer prevent support-report export.",
+      "Bundle pnpm 11.11.0; classify Git prepare and tarball failures, check target host requirements before plugin updates, isolate market render failures, and include sanitized market events in JSON support reports."
+    ],
+    "knownIssues": [
+      "Issue #89 includes a 60-second timeout during DSH import. These changes reduce confirmed overhead, but that environment's timeout has not been independently reproduced. If it recurs, export a support report; the new logs distinguish backend and native-window heartbeat delays."
+    ],
+    "upgradeNotes": [
+      "Release 0.6.1 was withdrawn. The repairs ship as 0.6.2 so existing 0.6.1 installations also receive an update. Native-shell changes require a full installer or portable package; retain the existing data directory.",
+      "Finish active tasks and back up data before updating. Portable publishing remains independent of upstream engine releases."
+    ]
+  }
+}


### PR DESCRIPTION
0.6.1 曾公开后撤回，而现有更新器会将同版本包视为 current。修复包递增为 0.6.2，确保已经安装 0.6.1 的用户同样收到完整包更新；保留撤回版本的标签和草稿记录。

通过统一版本脚本更新各平台产品元数据，新增双语 0.6.2 发布说明，功能代码不变。版本/发布说明/更新核心 43 项测试通过；0.6.0 与 0.6.1 均可识别 0.6.2 外壳变更为 full-package-required。发布仍取最终 main 的完整成品 CI。
