### PR TITLE
修正 Windows 健康报告的 CI 留存目录

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,12 +302,13 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'Capsule maintenance smoke failed.' }
           $AliasRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dsh-path-alias-' + [guid]::NewGuid().ToString('N'))
           New-Item -ItemType Directory -Force -Path $AliasRoot | Out-Null
-          "DSH_PORTABLE_HEALTH_EVIDENCE=$(Join-Path $AliasRoot 'DSH-Portable\data\health-evidence.json')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $AliasRoot
           if ($LASTEXITCODE -ne 0) { throw 'Path-alias fixture extraction failed.' }
           node scripts/smoke-windows-path-alias.mjs (Join-Path $AliasRoot 'DSH-Portable')
           if ($LASTEXITCODE -ne 0) { throw 'Windows path-alias smoke failed.' }
           node scripts/smoke-windows-runtime-health.mjs (Join-Path $AliasRoot 'DSH-Portable')
+          $HealthEvidence = Join-Path $AliasRoot 'DSH-Portable\data\health-evidence.json'
+          if (Test-Path -LiteralPath $HealthEvidence) { Copy-Item -LiteralPath $HealthEvidence -Destination (Join-Path $Root 'DSH-Portable\data\health-evidence.json') -ErrorAction Stop }
           if ($LASTEXITCODE -ne 0) { throw 'Windows runtime-health smoke failed.' }
           node scripts/smoke-windows-native-restart.mjs (Join-Path $Root 'DSH-Portable')
           if ($LASTEXITCODE -ne 0) { throw "Windows native restart smoke failed with exit code $LASTEXITCODE" }
@@ -353,7 +354,7 @@ jobs:
           name: windows-native-support-${{ matrix.label }}
           path: |
             ${{ runner.temp }}/dsh-desktop-host/DSH-Portable/data/native-restart-support.json
-            ${{ env.DSH_PORTABLE_HEALTH_EVIDENCE }}
+            ${{ runner.temp }}/dsh-desktop-host/DSH-Portable/data/health-evidence.json
           if-no-files-found: warn
       - name: Upload startup transition evidence
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,8 +300,9 @@ jobs:
           ./scripts/smoke-windows-native-tray.ps1 -Root (Join-Path $Root 'DSH-Portable')
           node scripts/smoke-capsule-maintenance.mjs (Join-Path $Root 'DSH-Portable')
           if ($LASTEXITCODE -ne 0) { throw 'Capsule maintenance smoke failed.' }
-          $AliasRoot = Join-Path $env:RUNNER_TEMP ('dsh-path-alias-' + [guid]::NewGuid().ToString('N'))
+          $AliasRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dsh-path-alias-' + [guid]::NewGuid().ToString('N'))
           New-Item -ItemType Directory -Force -Path $AliasRoot | Out-Null
+          "DSH_PORTABLE_HEALTH_EVIDENCE=$(Join-Path $AliasRoot 'DSH-Portable\data\health-evidence.json')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $AliasRoot
           if ($LASTEXITCODE -ne 0) { throw 'Path-alias fixture extraction failed.' }
           node scripts/smoke-windows-path-alias.mjs (Join-Path $AliasRoot 'DSH-Portable')
@@ -352,7 +353,7 @@ jobs:
           name: windows-native-support-${{ matrix.label }}
           path: |
             ${{ runner.temp }}/dsh-desktop-host/DSH-Portable/data/native-restart-support.json
-            ${{ runner.temp }}/dsh-path-alias-*/DSH-Portable/data/health-evidence.json
+            ${{ env.DSH_PORTABLE_HEALTH_EVIDENCE }}
           if-no-files-found: warn
       - name: Upload startup transition evidence
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
           ./scripts/smoke-windows-native-tray.ps1 -Root (Join-Path $Root 'DSH-Portable')
           node scripts/smoke-capsule-maintenance.mjs (Join-Path $Root 'DSH-Portable')
           if ($LASTEXITCODE -ne 0) { throw 'Capsule maintenance smoke failed.' }
-          $AliasRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dsh-path-alias-' + [guid]::NewGuid().ToString('N'))
+          $AliasRoot = Join-Path $env:RUNNER_TEMP ('dsh-path-alias-' + [guid]::NewGuid().ToString('N'))
           New-Item -ItemType Directory -Force -Path $AliasRoot | Out-Null
           tar.exe -x -f artifacts/DSH-Portable-windows-x64-offline.zip -C $AliasRoot
           if ($LASTEXITCODE -ne 0) { throw 'Path-alias fixture extraction failed.' }


### PR DESCRIPTION
最终 34 项成品测试全部通过后，实际下载诊断 artifact 发现 Windows 的 health-evidence.json 缺失：测试目录使用系统 TEMP，上传路径使用 RUNNER_TEMP，两者不一致。

健康测试结束后将报告复制到原生宿主证据目录，与重启报告一同上传。保留路径别名测试原有的文件系统，避免因换盘影响 8.3 短路径测试，并避免 artifact 输入跨盘。产品代码不变。桌面契约 20 项通过；合并后以完整 main CI 和实际下载的两份报告验证留存。
