### PR TITLE
Release 0.6.3 startup and diagnostic improvements

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../desktop-bridge": {
       "name": "@wsl043/dsh-portable-desktop-bridge",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0"
     },
     "node_modules/@agentclientprotocol/sdk": {

--- a/desktop-bridge/package.json
+++ b/desktop-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wsl043/dsh-portable-desktop-bridge",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "main": "lib/index.js",

--- a/installer/windows/DSH-Portable.iss
+++ b/installer/windows/DSH-Portable.iss
@@ -8,7 +8,7 @@
   #error ProjectRoot is required
 #endif
 #ifndef AppVersion
-  #define AppVersion "0.6.2"
+  #define AppVersion "0.6.3"
 #endif
 
 [Setup]
@@ -38,7 +38,7 @@ LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
 CloseApplications=no
 RestartApplications=no
-VersionInfoVersion=0.6.2.65534
+VersionInfoVersion=0.6.3.65534
 VersionInfoProductName=DSH-Portable
 VersionInfoDescription=DSH-Portable offline self-extractor
 VersionInfoCompany=WSL043

--- a/launcher/linux/Cargo.lock
+++ b/launcher/linux/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-herness-linux"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "rfd",
  "semver",

--- a/launcher/linux/Cargo.toml
+++ b/launcher/linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-herness-linux"
-version = "0.6.2"
+version = "0.6.3"
 description = "Native Linux shell for DSH-Portable"
 authors = ["DSH-Portable contributors"]
 edition = "2021"

--- a/launcher/linux/package-lock.json
+++ b/launcher/linux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-portable-linux-shell-build",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/launcher/linux/package.json
+++ b/launcher/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable-linux-shell-build",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4"

--- a/launcher/linux/tauri.conf.json
+++ b/launcher/linux/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek-Herness",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "io.github.wsl043.dsh-portable",
   "build": {
     "frontendDist": "ui"

--- a/launcher/macos/Info.plist
+++ b/launcher/macos/Info.plist
@@ -17,9 +17,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-	<string>0.6.2</string>
+	<string>0.6.3</string>
   <key>CFBundleVersion</key>
-	<string>6002999</string>
+	<string>6003999</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/launcher/windows/DSH-Bootstrap.cs
+++ b/launcher/windows/DSH-Bootstrap.cs
@@ -24,8 +24,8 @@ using Microsoft.Win32.SafeHandles;
 [assembly: System.Reflection.AssemblyCompany("WSL043")]
 [assembly: System.Reflection.AssemblyProduct("DSH-Portable")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: System.Reflection.AssemblyVersion("0.6.2.65534")]
-[assembly: System.Reflection.AssemblyFileVersion("0.6.2.65534")]
+[assembly: System.Reflection.AssemblyVersion("0.6.3.65534")]
+[assembly: System.Reflection.AssemblyFileVersion("0.6.3.65534")]
 
 namespace DshPortableBootstrap
 {

--- a/launcher/windows/DSH-Command.cs
+++ b/launcher/windows/DSH-Command.cs
@@ -8,8 +8,8 @@ using System.Text;
 [assembly: AssemblyTitle("DSH-Portable Command")]
 [assembly: AssemblyProduct("DSH-Portable")]
 [assembly: AssemblyCompany("WSL043")]
-[assembly: AssemblyVersion("0.6.2.65534")]
-[assembly: AssemblyFileVersion("0.6.2.65534")]
+[assembly: AssemblyVersion("0.6.3.65534")]
+[assembly: AssemblyFileVersion("0.6.3.65534")]
 
 internal static class DshCommand
 {

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -28,8 +28,8 @@ using Windows.UI.Notifications;
 [assembly: AssemblyCompany("WSL043")]
 [assembly: AssemblyProduct("DeepSeek-Herness")]
 [assembly: AssemblyCopyright("Copyright © WSL043 2026")]
-[assembly: AssemblyVersion("0.6.2.65534")]
-[assembly: AssemblyFileVersion("0.6.2.65534")]
+[assembly: AssemblyVersion("0.6.3.65534")]
+[assembly: AssemblyFileVersion("0.6.3.65534")]
 
 namespace DshPortable
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-portable",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/release-notes/v0.6.3.json
+++ b/release-notes/v0.6.3.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.6.3",
+  "zh": {
+    "summary": "改善启动等待体验，保持亮暗主题一致，并保留多次启动的诊断记录，便于定位偶发卡顿。",
+    "highlights": [
+      "后台尚未就绪时显示加载进度；从启动窗口、加载页到工作台遵守保存的亮色、暗色或跟随系统设置，避免初始化时闪白。",
+      "修复旧加载页面取消事件误判工作台启动失败的问题，即使存在未完成的资源请求也能正确识别界面就绪。",
+      "启动和健康日志按启动 ID 保留 14 天内最近 30 次记录，总量上限 32 MiB；支持报告保留多轮记录、执行脱敏并明确标记截断。",
+      "减少客户端包换行扫描和模块链接父目录的重复处理；健康记录增加采样间隔及系统内存，便于对齐卡顿时的状态。",
+      "启动体验、诊断与性能改进见 PR #95：https://github.com/WSL043/DSH-Portable/pull/95。"
+    ],
+    "upgradeNotes": ["从 0.6.2 或更早版本使用内置更新，或下载完整便携包按现有升级流程操作；请保留原 data 目录。"],
+    "knownIssues": ["此前实机曾出现 18–24 秒的后台导入；后续启动和系统跟踪未复现相同长延迟，尚未确认其唯一根因。本版不宣称已根治该偶发问题，若再次发生请导出支持报告。"]
+  },
+  "en": {
+    "summary": "Improve startup feedback and theme continuity, and retain diagnostics across launches to investigate intermittent stalls.",
+    "highlights": [
+      "Show loading progress before the backend is ready. The native window, loading page and workspace respect the saved light, dark or system preference without flashing the default white background.",
+      "Prevent cancellation of an old loading page from failing the workspace navigation; unfinished resource requests no longer confuse workspace readiness.",
+      "Retain the latest 30 startup and health histories within 14 days, capped at 32 MiB. Support reports include multiple launches, redact sensitive values and identify truncated streams.",
+      "Reduce client bundle newline scanning and duplicate parent-directory creation during module-link repair. Health samples now include sampling intervals and system memory.",
+      "Startup, diagnostic and performance changes: PR #95, https://github.com/WSL043/DSH-Portable/pull/95."
+    ],
+    "upgradeNotes": ["Use the built-in updater from 0.6.2 or earlier, or follow the existing full-package upgrade procedure; preserve the original data directory."],
+    "knownIssues": ["Earlier local runs recorded 18–24-second backend imports. Later launches and system traces did not reproduce that delay, and its unique cause remains unconfirmed. This release does not claim to eliminate the intermittent stall; export a support report if it recurs."]
+  }
+}


### PR DESCRIPTION
Prepare 0.6.3 with synchronized product versions and bilingual release notes for the startup/theme/history fixes from #95. Preserve the documented intermittent-import limitation. Version and release-note tests passed (10/10); full main artifact qualification and Windows 11 acceptance are required before publishing.