### PR TITLE
Avoid false dependency errors after normal shutdown

### DIFF
--- a/launcher/repair-core.mjs
+++ b/launcher/repair-core.mjs
@@ -91,7 +91,12 @@ async function runtimeChecks(layout) {
 }
 
 async function generatedChecks(layout) {
-  const profileResolver = await inspectManagedProfileModuleFallback(layout)
+  // Normal shutdown removes these move-sensitive links; startup recreates them.
+  const pendingStartup = !existsSync(path.join(layout.dshHome, 'profiles', 'node_modules'))
+    && !existsSync(layout.processState)
+  const profileResolver = pendingStartup
+    ? { ok: true, repairable: true, detail: 'created-on-start' }
+    : await inspectManagedProfileModuleFallback(layout)
   return [
     {
       id: 'generated.dshProfileResolver',

--- a/tests/repair-core.test.mjs
+++ b/tests/repair-core.test.mjs
@@ -64,6 +64,21 @@ test('doctor reports a missing Windows desktop dependency as a complete-package 
   assert.equal(broken.checks.some((check) => check.id === 'shell.webView2Loader' && check.status === 'error'), true)
 })
 
+test('doctor accepts shutdown-cleaned links but detects their loss while a host is recorded', async t => {
+  const layout = await fixture(t)
+  const resolverRoot = path.join(layout.dshHome, 'profiles', 'node_modules')
+  await rm(resolverRoot, { recursive: true })
+  const stopped = await diagnosePortable(layout)
+  assert.equal(stopped.ok, true)
+  assert.equal(stopped.checks.find(check => check.id === 'generated.dshProfileResolver').detail, 'created-on-start')
+  await assert.rejects(realpath(resolverRoot), { code: 'ENOENT' }, 'diagnosis must not create links')
+  await mkdir(path.dirname(layout.processState), { recursive: true })
+  await writeFile(layout.processState, JSON.stringify({ pid: process.pid }))
+  const running = await diagnosePortable(layout)
+  assert.equal(running.ok, false)
+  assert.equal(running.checks.find(check => check.id === 'generated.dshProfileResolver').status, 'error')
+})
+
 test('doctor detects a missing transitive DSH package before the profile fails to boot', async (t) => {
   const layout = await fixture(t)
   await writeFile(path.join(layout.appDir, 'node_modules', '@deepseek-ai', 'dsh', 'package.json'), JSON.stringify({


### PR DESCRIPTION
A support report exported after normal shutdown incorrectly reported hundreds of missing dependencies. Shutdown deliberately removes move-sensitive generated profile links. Report them as created on the next start when the complete resolver directory and host state are absent; partial damage and missing links with a recorded host still fail. Eleven repair/report tests pass, and the corrected diagnostic reports the stopped real Win11 acceptance installation as healthy without recreating its links.
