### PR TITLE
Support official Alpha startup and stable Windows core compatibility

### DIFF
--- a/docs/update-startup-0.6.4.md
+++ b/docs/update-startup-0.6.4.md
@@ -2,6 +2,9 @@
 
 ## Confirmed defects and changes
 
+- Alpha `0.1.3-alpha.2` moved subprocess helpers into `runner-launch-*.js` and already hides the ordinary spawn/taskkill paths. The adapter now validates that exact upstream shape and still patches both shared Win32 native process paths. Its exported `runCli()` also requires an explicit call when imported by Portable; otherwise the control process stayed alive without starting HTTP, causing a real 60-second timeout and successful rollback. Portable now calls the official exported entry when present, retaining the self-executing stable entry. The entry mode is recorded in startup logs.
+- Windows C# and manifest checkout line endings caused different fingerprints for the same source. Compatibility hashing now canonicalizes those text files while continuing to reject actual code changes and verifying archive hashes independently.
+
 - Exact local package acceptance caught a transient theme mismatch after a previous light launch. The official client initialized its preference to `system` before asynchronous durable settings arrived. The bootstrap now carries the host's accepted preference into the client's initial snapshot. Native chrome also reapplies the WebView preference when only the preference changes, even if the resolved color stays the same. Theme acceptance samples through two seconds after interactive readiness.
 - Local rebuilding exposed development `node_modules` being copied into the bundled bridge and market. All three builders now share staging that excludes development dependencies. The unchanged package footprint limit caught the defect and passes with the filtered build.
 
@@ -22,6 +25,8 @@ The isolated loading-theme run `edbec745d2eb455d838a25eaf89ae8ec` also recorded 
 A subsequent no-backend launch with system tracing, `c7178d99195942b185ec9d5a070446cb`, recorded a 2,178 ms import and 3,464 ms interactive time. This normal run does not explain or disprove the earlier long waits. The installed user's process was not stopped or replaced for these checks.
 
 ## Release qualification boundary
+
+Main runs `34161602880` and `34162454110` each passed all 34 product gates without skips. Subsequent Alpha-entry and fingerprint changes require qualification at their final head. Core run `34162478625` passed stable on all five targets but correctly rejected Alpha at the changed subprocess adapter. The repaired Alpha development installation then passed update, real command execution, default-plugin retention, forced rollback, native startup, settings-channel confirmation/failure handling and Windows ordinary/restricted subprocess visibility. Its no-backend native start `c080219ca8a841d78e1b207953a847da` reached the loading page at 359 ms and the workspace at 2,241 ms. Those development checks used a locally corrected host and are not a substitute for the final CI-built artifact.
 
 Local Win11 rebuild SHA-256 `6710b6f74c1c020ce296e3e4b17fdbe0b44ef20b2a31213b88e6bdb5687c42ad` passed an empty-cache, no-backend start: loading 401 ms, capsule extraction 4,699 ms, official import 1,257 ms and interactive readiness 8,748 ms (`6f5fe0765ce54cbe8e0ae35537bd3234`). Four subsequent theme checks passed, including reduced motion and two seconds of sampling after readiness. Their five-second observation hold is excluded from performance conclusions. The same build passed real stable-core reinstallation, default-plugin preservation and injected-failure rollback. The baseline start assertion was corrected to require the CLI's `started` result followed by a separate healthy `running` status, rather than confusing the two command contracts.
 

--- a/launcher/portable-host.mjs
+++ b/launcher/portable-host.mjs
@@ -80,7 +80,12 @@ healthPhase('official-dsh-import')
 const importStartedAt = performance.now()
 const importCpu = process.cpuUsage()
 try {
-  await import(pathToFileURL(path.resolve(dshBin)).href)
+  const entry = await import(pathToFileURL(path.resolve(dshBin)).href)
+  const explicitCli = typeof entry.runCli === 'function'
+  appendStartupTrace(startupTrace, 'portable-host', 'official-dsh-entry-ready', {
+    mode: explicitCli ? 'exported-cli' : 'self-executing',
+  })
+  if (explicitCli) await entry.runCli()
   healthPhase('official-dsh-import-complete')
   const cpu = process.cpuUsage(importCpu)
   appendStartupTrace(startupTrace, 'portable-host', 'official-dsh-import-complete', {

--- a/release-notes/v0.6.4.json
+++ b/release-notes/v0.6.4.json
@@ -7,7 +7,7 @@
       "更新通道保存成功后再加载对应内核目录，避免旧请求和快速切换造成错误列表；获取失败会显示原因，网络查询不再占用启动和停止的锁。",
       "不兼容的内核版本提供明确说明，不再无声消失；候选内核可针对当前稳定版 Portable 独立构建和验证。",
       "修复同版本内核重新构建仍引用旧包的目录问题；发布前验证精确外壳、更新启动、默认插件保留及失败回滚。",
-      "稳定版内核保持 0.1.2-rc.1，官方 0.1.3-alpha.2 进入独立候选内核验证；上游跟进同时核对源代码构建工具和真实包清单。",
+      "稳定版内核保持 0.1.2-rc.1；适配官方 0.1.3-alpha.2 的显式启动入口和共享子进程模块，并修复源码换行导致的兼容性误判。候选内核仍须单独通过验证才会提供。",
       "默认插件安装失败日志保留经过脱敏的具体输出，便于定位依赖冲突；继续保留多轮启动历史。"
     ],
     "upgradeNotes": ["本版包含原生启动器修复，请使用内置完整包更新或下载完整包，保留原 data 目录。候选内核只对主动选择候选通道的用户提供，切换通道不会自动安装或降级。"],
@@ -20,7 +20,7 @@
       "Load catalogs after saving the channel, reject stale responses and explain failures. Network update queries no longer hold the startup and shutdown lock.",
       "Explain incompatible core versions instead of silently hiding them. Candidate cores can be built and qualified independently against the current stable Portable shell.",
       "Replace stale same-version catalog records after a core rebuild. Qualify exact-shell compatibility, update startup, default-plugin preservation and failure rollback before core publication.",
-      "Keep the stable core at 0.1.2-rc.1 and intake official 0.1.3-alpha.2 for independent candidate qualification. Upstream intake also verifies source build tools and package inventories.",
+      "Keep the stable core at 0.1.2-rc.1. Adapt official 0.1.3-alpha.2's explicit CLI entry and shared subprocess module, and prevent source line endings from rejecting compatible builds. Candidate cores remain gated by independent qualification.",
       "Retain redacted installer output when a default plugin fails, making dependency conflicts diagnosable while preserving multi-launch startup history."
     ],
     "upgradeNotes": ["This release changes the native launcher. Use the built-in full-package update or download the complete package, preserving the original data directory. Candidate cores require an explicit candidate-channel selection; changing channels never installs or downgrades automatically."],

--- a/scripts/patch-windows-subprocess-hide.mjs
+++ b/scripts/patch-windows-subprocess-hide.mjs
@@ -15,6 +15,16 @@ function replaceRequired(source, needle, replacement, label) {
 
 export function patchWindowsSubprocessHide(source) {
   if (source.includes(SUBPROCESS_MARKER)) return source
+  const upstreamHidden = [
+    `\t\t...force ? ["/F"] : []\n\t], {\n\t\tstdio: "ignore",\n\t\twindowsHide: true\n\t});`,
+    `\t\t"/F"\n\t], {\n\t\tstdio: "ignore",\n\t\twindowsHide: true\n\t});`,
+    `\t\tdetached: platform !== "win32",\n\t\twindowsHide: platform === "win32"\n\t});`,
+  ]
+  // Alpha owns these helpers in a shared runner chunk and already hides them.
+  // Keep the exact three verified seams; an unknown shape still fails below.
+  if (upstreamHidden.every(needle => source.split(needle).length === 2)) {
+    return `/* ${SUBPROCESS_MARKER} */\n${source}`
+  }
   let output = replaceRequired(
     source,
     `\t\t...force ? ["/F"] : []\n\t], { stdio: "ignore" });`,
@@ -34,6 +44,12 @@ export function patchWindowsSubprocessHide(source) {
     'subprocess spawn seam changed upstream',
   )
   return `/* ${SUBPROCESS_MARKER} */\n${output}`
+}
+
+export function subprocessHideModule(indexSource) {
+  const chunks = [...indexSource.matchAll(/from "\.\/(runner-launch-[A-Za-z0-9_-]+\.js)";/g)]
+  if (chunks.length > 1) throw new Error('Ambiguous Windows subprocess runner module')
+  return chunks[0]?.[1] || 'index.js'
 }
 
 export function patchWindowsAclHide(source) {
@@ -76,7 +92,8 @@ export function patchWindowsWin32ProcessHide(source) {
 async function main() {
   if (!process.argv[2]) throw new Error('usage: node patch-windows-subprocess-hide.mjs <app-root>')
   const appRoot = path.resolve(process.argv[2])
-  const subprocessFilename = path.join(appRoot, 'node_modules', '@deepseek-ai', 'dsh-subprocess-local', 'lib', 'index.js')
+  const subprocessLib = path.join(appRoot, 'node_modules', '@deepseek-ai', 'dsh-subprocess-local', 'lib')
+  const subprocessFilename = path.join(subprocessLib, subprocessHideModule(await readFile(path.join(subprocessLib, 'index.js'), 'utf8')))
   const aclLib = path.join(appRoot, 'node_modules', '@deepseek-ai', 'dsh-sandbox-windows-acl', 'lib')
   const aclCandidates = (await readdir(aclLib)).filter(name => /^types-[A-Za-z0-9_-]+\.js$/.test(name))
   if (aclCandidates.length !== 1) {

--- a/scripts/shell-fingerprint.mjs
+++ b/scripts/shell-fingerprint.mjs
@@ -1,37 +1,45 @@
 import { createHash } from 'node:crypto'
 import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const root = path.resolve(import.meta.dirname, '..')
-const platform = process.argv[2]
 const platformDirectories = {
   windows: 'launcher/windows',
   macos: 'launcher/macos',
   linux: 'launcher/linux',
 }
-if (!platformDirectories[platform]) throw new Error('Usage: node scripts/shell-fingerprint.mjs <windows|macos|linux>')
 
-async function filesBelow(relativeDirectory) {
+async function filesBelow(root, relativeDirectory) {
   const directory = path.join(root, relativeDirectory)
   const entries = await readdir(directory, { withFileTypes: true })
   const files = []
   for (const entry of entries) {
     const relative = path.posix.join(relativeDirectory.replaceAll('\\', '/'), entry.name)
-    if (entry.isDirectory()) files.push(...await filesBelow(relative))
+    if (entry.isDirectory()) files.push(...await filesBelow(root, relative))
     else if (entry.isFile()) files.push(relative)
   }
   return files
 }
 
-const shared = (await readdir(path.join(root, 'launcher'), { withFileTypes: true }))
-  .filter((entry) => entry.isFile() && entry.name.endsWith('.mjs'))
-  .map((entry) => `launcher/${entry.name}`)
-const files = [...shared, ...await filesBelow(platformDirectories[platform])].sort()
-const digest = createHash('sha256')
-for (const filename of files) {
-  digest.update(filename)
-  digest.update('\0')
-  digest.update(await readFile(path.join(root, filename)))
-  digest.update('\0')
+export async function computeShellFingerprint(root, platform) {
+  if (!platformDirectories[platform]) throw new Error('Unsupported shell platform')
+  const shared = (await readdir(path.join(root, 'launcher'), { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.mjs'))
+    .map((entry) => `launcher/${entry.name}`)
+  const files = [...shared, ...await filesBelow(root, platformDirectories[platform])].sort()
+  const digest = createHash('sha256')
+  for (const filename of files) {
+    digest.update(filename)
+    digest.update('\0')
+    const bytes = await readFile(path.join(root, filename))
+    // Git's Windows checkout conversion must not change source compatibility.
+    // Other shell files already have explicit line endings in .gitattributes.
+    digest.update(/\.(cs|manifest)$/.test(filename) ? bytes.toString('utf8').replaceAll('\r\n', '\n') : bytes)
+    digest.update('\0')
+  }
+  return digest.digest('hex')
 }
-process.stdout.write(`${digest.digest('hex')}\n`)
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.stdout.write(`${await computeShellFingerprint(path.resolve(import.meta.dirname, '..'), process.argv[2])}\n`)
+}

--- a/scripts/smoke-update-artifact.mjs
+++ b/scripts/smoke-update-artifact.mjs
@@ -184,6 +184,21 @@ async function main() {
       for (const plugin of installed.defaultPlugins ?? []) {
         assert.ok(JSON.stringify(plugins.installed).includes(plugin.package), `${plugin.package} remains installed`)
       }
+      const commandProbe = await execFileAsync(node, ['--input-type=module', '-e', `
+        import path from 'node:path';
+        import { pathToFileURL } from 'node:url';
+        const root = process.argv[1];
+        const { ensureRuntimeCapsule } = await import(pathToFileURL(path.join(root, 'launcher/runtime-capsule.mjs')));
+        const prepared = await ensureRuntimeCapsule(root);
+        const { default: Runtime } = await import(pathToFileURL(path.join(prepared.runtimeRoot, 'app/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js')));
+        const runtime = new Runtime({ reflect: { provide: () => {} }, effect: () => () => {} });
+        const handle = runtime.spawn({ argv: [process.execPath, '-e', 'process.stdout.write("portable-core-command-ok")'], cwd: root,
+          stdio: { stdin: 'ignore', stdout: { maxBytes: 1024 }, stderr: { maxBytes: 1024 } }, graceMs: 1000 });
+        const outcome = await handle.done;
+        if (outcome.exitCode !== 0 || handle.collected.stdout.finalize().text !== 'portable-core-command-ok') throw new Error('Core subprocess execution failed');
+        console.log('portable-core-command-ok');
+      `, root], { encoding: 'utf8', timeout: 30000, windowsHide: true })
+      assert.equal(commandProbe.stdout.trim(), 'portable-core-command-ok', 'updated core executes a real command')
     }
     for (const [filename, content] of sentinels) assert.equal(await readFile(filename, 'utf8'), content)
 

--- a/scripts/smoke-windows-subprocess-hide.mjs
+++ b/scripts/smoke-windows-subprocess-hide.mjs
@@ -6,6 +6,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
+import { subprocessHideModule } from './patch-windows-subprocess-hide.mjs'
 
 const execFileAsync = promisify(execFile)
 const root = path.resolve(process.argv[2] || '')
@@ -79,7 +80,8 @@ async function runChild() {
 }
 
 async function runParent() {
-  const subprocessSource = await readFile(path.join(appRoot, 'node_modules', '@deepseek-ai', 'dsh-subprocess-local', 'lib', 'index.js'), 'utf8')
+  const subprocessLib = path.join(appRoot, 'node_modules', '@deepseek-ai', 'dsh-subprocess-local', 'lib')
+  const subprocessSource = await readFile(path.join(subprocessLib, subprocessHideModule(await readFile(path.join(subprocessLib, 'index.js'), 'utf8'))), 'utf8')
   const aclLib = path.join(appRoot, 'node_modules', '@deepseek-ai', 'dsh-sandbox-windows-acl', 'lib')
   assert.match(subprocessSource, /dsh-portable-windows-subprocess-hide-v1/)
   const { readdir } = await import('node:fs/promises')

--- a/tests/portable-host.test.mjs
+++ b/tests/portable-host.test.mjs
@@ -40,15 +40,18 @@ async function waitForPipe(pipe) {
   throw new Error('portable host control pipe did not open')
 }
 
-test('portable host authenticates shutdown and invokes the official signal path', { skip: process.platform !== 'win32' }, async (t) => {
+for (const entryMode of ['legacy', 'exported']) test(`portable host starts the ${entryMode} CLI once and authenticates graceful shutdown`, { skip: process.platform !== 'win32' }, async (t) => {
   const temp = await mkdtemp(path.join(os.tmpdir(), 'dsh-host-'))
   const marker = path.join(temp, 'disposed.txt')
+  const bootMarker = path.join(temp, 'started.txt')
   const fakeDsh = path.join(temp, 'fake-dsh.mjs')
-  await writeFile(fakeDsh, [
-    "import { writeFileSync } from 'node:fs'",
+  const body = [
+    "writeFileSync(process.env.DSH_TEST_BOOT, 'started', { flag: 'wx' })",
     "process.on('SIGTERM', () => { writeFileSync(process.env.DSH_TEST_MARKER, 'graceful'); process.exit(0) })",
     'setInterval(() => {}, 1000)',
-  ].join('\n'))
+  ].join('\n')
+  await writeFile(fakeDsh, "import { writeFileSync } from 'node:fs'\n" +
+    (entryMode === 'exported' ? `export async function runCli() {\n${body}\n}` : body))
 
   const pipe = `\\\\.\\pipe\\dsh-portable-test-${process.pid}-${randomUUID()}`
   const token = randomUUID()
@@ -58,6 +61,7 @@ test('portable host authenticates shutdown and invokes the official signal path'
       DSH_PORTABLE_CONTROL_PIPE: pipe,
       DSH_PORTABLE_CONTROL_TOKEN: token,
       DSH_TEST_MARKER: marker,
+      DSH_TEST_BOOT: bootMarker,
       DSH_PORTABLE_STATE_ROOT: temp,
       DSH_PORTABLE_STARTUP_ID: 'b'.repeat(32),
       DSH_PORTABLE_STARTUP_STARTED_AT: String(Date.now()),
@@ -75,6 +79,7 @@ test('portable host authenticates shutdown and invokes the official signal path'
     await new Promise(resolve => setTimeout(resolve, 25))
   }
   assert.match(await readFile(traceFile, 'utf8'), /official-dsh-import-complete/)
+  assert.equal(await readFile(bootMarker, 'utf8'), 'started')
 
   assert.equal(await request(pipe, 'wrong-token'), 401)
   assert.equal(child.exitCode, null)

--- a/tests/shell-fingerprint.test.mjs
+++ b/tests/shell-fingerprint.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { computeShellFingerprint } from '../scripts/shell-fingerprint.mjs'
+
+test('Windows source checkout line endings do not reject a compatible core, but code changes do', async t => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dsh-shell-fingerprint-'))
+  t.after(() => rm(root, { recursive: true, force: true }))
+  await mkdir(path.join(root, 'launcher/windows'), { recursive: true })
+  await writeFile(path.join(root, 'launcher/host.mjs'), 'export const version = 1\n')
+  const source = path.join(root, 'launcher/windows/Host.cs')
+  const manifest = path.join(root, 'launcher/windows/Host.manifest')
+  await writeFile(source, 'class Host {\n  const int Version = 1;\n}\n')
+  await writeFile(manifest, '<assembly>\n</assembly>\n')
+  const original = await computeShellFingerprint(root, 'windows')
+  await writeFile(source, 'class Host {\r\n  const int Version = 1;\n}\r\n')
+  await writeFile(manifest, '<assembly>\r\n</assembly>\r\n')
+  assert.equal(await computeShellFingerprint(root, 'windows'), original)
+  await writeFile(source, 'class Host {\r\n  const int Version = 2;\r\n}\r\n')
+  assert.notEqual(await computeShellFingerprint(root, 'windows'), original)
+  await writeFile(source, 'class Host {\n  const int Version = 1;\n}\n')
+  await writeFile(path.join(root, 'launcher/host.mjs'), 'export const version = 2\n')
+  assert.notEqual(await computeShellFingerprint(root, 'windows'), original)
+})

--- a/tests/windows-subprocess-hide.test.mjs
+++ b/tests/windows-subprocess-hide.test.mjs
@@ -6,6 +6,7 @@ import {
   patchWindowsAclHide,
   patchWindowsSubprocessHide,
   patchWindowsWin32ProcessHide,
+  subprocessHideModule,
 } from '../scripts/patch-windows-subprocess-hide.mjs'
 
 const fixture = `function taskkillTree(pid, force) {
@@ -36,6 +37,18 @@ test('official DSH subprocess patch hides every Windows child and taskkill helpe
   assert.match(output, /dsh-portable-windows-subprocess-hide-v1/)
   assert.equal(output.match(/windowsHide: true/g)?.length, 3)
   assert.equal(patchWindowsSubprocessHide(output), output)
+})
+
+test('Alpha shared runner keeps upstream-hidden helpers and rejects an unsafe changed helper', () => {
+  const alpha = fixture
+    .replaceAll('{ stdio: "ignore" });', '{\n\t\tstdio: "ignore",\n\t\twindowsHide: true\n\t});')
+    .replace('detached: platform !== "win32"', 'detached: platform !== "win32",\n\t\twindowsHide: platform === "win32"')
+  const patched = patchWindowsSubprocessHide(alpha)
+  assert.equal(patched.match(/windowsHide:/g)?.length, 3)
+  assert.equal(patchWindowsSubprocessHide(patched), patched)
+  assert.equal(subprocessHideModule('import { E as spawnSubprocess } from "./runner-launch-COYGu0Dl.js";'), 'runner-launch-COYGu0Dl.js')
+  assert.equal(subprocessHideModule(fixture), 'index.js')
+  assert.throws(() => patchWindowsSubprocessHide(alpha.replace('windowsHide: true', 'windowsHide: false')), /seam changed upstream/)
 })
 
 const aclFixture = `function spawnSandboxed() {


### PR DESCRIPTION
Official 0.1.3-alpha.2 exports runCli rather than starting on import. Invoke that entry explicitly while preserving the legacy self-executing entry, and recognize its shared subprocess module with the three upstream window-hiding paths verified. Core update acceptance now executes a real subprocess after startup and plugin preservation checks.

Canonicalize C# and manifest line endings for shell compatibility fingerprints so identical Windows sources remain compatible across local and CI checkouts. Unknown subprocess layouts still fail the build.

Validation: 509 source checks passed (one promotion-only skip); local Windows development acceptance passed Alpha update, command execution, default plugin preservation, rollback, hidden subprocesses, actual channel settings, and four startup theme/spinner cases. The development root was patched for diagnosis; final unmodified CI artifacts still require full product qualification.
