### PR TITLE
Complete the cross-platform core command probe context

### DIFF
--- a/scripts/smoke-update-artifact.mjs
+++ b/scripts/smoke-update-artifact.mjs
@@ -191,13 +191,14 @@ async function main() {
         const { ensureRuntimeCapsule } = await import(pathToFileURL(path.join(root, 'launcher/runtime-capsule.mjs')));
         const prepared = await ensureRuntimeCapsule(root);
         const { default: Runtime } = await import(pathToFileURL(path.join(prepared.runtimeRoot, 'app/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js')));
-        const runtime = new Runtime({ reflect: { provide: () => {} }, effect: () => () => {} });
+        const runtime = new Runtime({ reflect: { provide: () => {} }, effect: () => () => {}, logger: { warn: message => console.error(message) } });
         const handle = runtime.spawn({ argv: [process.execPath, '-e', 'process.stdout.write("portable-core-command-ok")'], cwd: root,
           stdio: { stdin: 'ignore', stdout: { maxBytes: 1024 }, stderr: { maxBytes: 1024 } }, graceMs: 1000 });
         const outcome = await handle.done;
         if (outcome.exitCode !== 0 || handle.collected.stdout.finalize().text !== 'portable-core-command-ok') throw new Error('Core subprocess execution failed');
         console.log('portable-core-command-ok');
       `, root], { encoding: 'utf8', timeout: 30000, windowsHide: true })
+      if (commandProbe.stderr) process.stderr.write(commandProbe.stderr)
       assert.equal(commandProbe.stdout.trim(), 'portable-core-command-ok', 'updated core executes a real command')
     }
     for (const [filename, content] of sentinels) assert.equal(await readFile(filename, 'utf8'), content)


### PR DESCRIPTION
The Alpha subprocess provider emits a containment warning on macOS and Linux. The isolated command probe omitted the host logger, so cross-platform acceptance failed after a successful core update with a TypeError instead of executing the command.

Provide the expected logger and preserve warning output in the CI log. Keep the real command execution assertion and all update/rollback gates. No shipped launcher, core or plugin code changes.

Validation: reproduced the missing logger in candidate core jobs on Linux ARM64 and macOS ARM64; the exact Alpha warning method passes with the complete context. Syntax validation passed. Cross-platform component acceptance will rerun with this fixture correction.
