### PR TITLE
Show the offered DSH core version in update feedback

### DIFF
--- a/desktop-bridge/lib/client.js
+++ b/desktop-bridge/lib/client.js
@@ -544,7 +544,7 @@ window.__ModuleLoader__.load({
         }).then(res => res.json()).then(body => {
           if (body.error) throw new Error(body.error)
           if (body.status === 'current') setStatus(name, t('current'))
-          else if (body.status === 'available' || body.status === 'full-package-required') setStatus(name, format(t('available'), body.latest || ''))
+          else if (body.status === 'available' || body.status === 'full-package-required') setStatus(name, format(t('available'), (scope === 'engine' ? body.engineLatest : body.latest) || ''))
           else if (body.status === 'core-incompatible') setStatus(name, t('incompatible'))
           else if (body.status === 'engine-follows-product') setStatus(name, t('engineFollowsProduct'))
           else if (body.status === 'channel-unpublished') setStatus(name, t('channelUnpublished'))

--- a/tests/desktop-bridge-settings-channel.test.mjs
+++ b/tests/desktop-bridge-settings-channel.test.mjs
@@ -203,6 +203,27 @@ function settings(updateChannel = 'stable', overrides = {}) {
   }
 }
 
+test('core update feedback names the DSH version instead of the Portable version', async () => {
+  const client = await loadSettingsComponent(async url => {
+    if (url === '/dsh-portable/settings') return jsonResponse({ settings: settings('candidate'), versions: { portable: '0.6.4', engine: '0.1.2-rc.1' } })
+    if (url === '/dsh-portable/engine-versions') return jsonResponse({ schemaVersion: 1, releaseChannel: 'candidate', versions: [] })
+    if (url === '/dsh-portable/check-update') return jsonResponse({ status: 'available', latest: '0.6.4', engineLatest: '0.1.3-alpha.2' })
+    throw Error(`unexpected request: ${url}`)
+  })
+  const mounted = client.mount()
+  try {
+    await settle()
+    const row = findNode(mounted.tree, node => node.type === 'div' && node.children?.length === 2 && textContent(node.children[0]).startsWith('DeepSeek Harness'))
+    assert.ok(row)
+    const button = findNode(row.children[1], node => typeof node.props?.onClick === 'function')
+    button.props.onClick()
+    await settle()
+    const feedback = findNode(mounted.tree, node => node.props?.role === 'status' && textContent(node).includes('available'))
+    assert.match(textContent(feedback), /0\.1\.3-alpha\.2/)
+    assert.doesNotMatch(textContent(feedback), /0\.6\.4/)
+  } finally { mounted.unmount() }
+})
+
 test('channel catalog state follows the final confirmed save and localizes unavailable versions', async () => {
   const calls = []
   const settingsGet = deferred()


### PR DESCRIPTION
Checking for a DSH core update displayed the Portable version (0.6.4) instead of the offered core version (0.1.3-alpha.2). Use engineLatest for core feedback while preserving the product update field and existing API contract.

Validation: the rendered settings regression first reproduced the incorrect 0.6.4 message and now passes; all 20 related settings, bridge and CLI checks passed. Native Windows/macOS update descriptions already use the separate core fields.
