### PR TITLE
Fix asynchronous onboarding acceptance and startup deadline

### DIFF
--- a/scripts/audit-windows-startup-transition.mjs
+++ b/scripts/audit-windows-startup-transition.mjs
@@ -194,6 +194,7 @@ try {
   }).catch(() => {})
   await mkdir(output, { recursive: true })
   const debugPort = await reservePort()
+  const startupDeadline = Date.now() + startupTimeoutSeconds * 1000
   launcher = spawn(executable, environmentId ? ['--environment', environmentId] : [], {
     cwd: root,
     env: {
@@ -216,7 +217,7 @@ try {
     '-TargetProcessId', String(launcher.pid), '-OutputDirectory', path.join(output, '01-native-loader'),
   ], { windowsHide: true, timeout: 20000 }) : Promise.resolve()
   nativeCapture.catch(() => {}) // Keep errors for the awaited capture below.
-  const page = await waitForTarget(debugPort, launcher)
+  const page = await waitForTarget(debugPort, launcher, Math.max(1, startupDeadline - Date.now()))
   client = new CdpClient(page.webSocketDebuggerUrl)
   await client.open()
   await client.send('Runtime.enable')
@@ -228,8 +229,7 @@ try {
   let capturedReveal = false
   let capturedWorkspace = false
   let workspaceStableSamples = 0
-  const deadline = Date.now() + startupTimeoutSeconds * 1000
-  while (Date.now() < deadline) {
+  while (Date.now() < startupDeadline) {
     const state = await evaluate(client, `(() => {
       const visible = node => {
         if (!(node instanceof Element)) return false

--- a/scripts/smoke-windows-market-categories.mjs
+++ b/scripts/smoke-windows-market-categories.mjs
@@ -42,19 +42,27 @@ try {
   await send('Runtime.enable')
   await send('Page.enable')
 
-  await delay(1000)
+  // Onboarding is asynchronous: keep handling it until the settings dialog
+  // actually opens, rather than declaring success before the first notice mounts.
   await until(`(() => {
-    const notice = [...document.querySelectorAll('[role="dialog"]')].find(item =>
-      /Internal Testing Notice|内测声明|Add an API key to get started|添加 API 密钥/.test(item.textContent || '') && item.getBoundingClientRect().width > 0)
-    if (!notice) return true
-    const button = [...notice.querySelectorAll('button')].find(item =>
-      ['Continue', '继续', 'Configure later', '稍后配置'].includes((item.textContent || '').trim()) && !item.disabled)
-    button?.click()
+    const dialogs = [...document.querySelectorAll('dialog,[role="dialog"],[role="alertdialog"]')]
+      .filter(item => item.getBoundingClientRect().width > 0)
+    const notice = dialogs.find(item =>
+      /Internal Testing Notice|内测声明|Add an API key to get started|添加 API 密钥|添加一个 API Key/.test(item.textContent || ''))
+    if (notice) {
+      const button = [...notice.querySelectorAll('button')].find(item =>
+        ['Continue', '继续', 'Configure later', '稍后配置'].includes((item.textContent || '').trim()) && !item.disabled)
+      button?.click()
+      return false
+    }
+    if (dialogs.length) return true
+    const settings = [...document.querySelectorAll('button')].find(item =>
+      ['Settings', '设置'].includes((item.textContent || '').trim()))
+    if (settings && settings.getBoundingClientRect().width > 0 && !settings.closest('[inert]')) {
+      chrome.webview.postMessage({type:'dsh-portable/test-desktop',key:131260})
+    }
     return false
-  })()`, Boolean, 'isolated onboarding dismissed')
-  // Exercise the same native command dispatcher used by Ctrl+, and the File menu.
-  await until(`(() => {const button=[...document.querySelectorAll('button')].find(item => ['Settings','设置'].includes((item.textContent||'').trim())); return Boolean(button && !button.closest('[inert]'))})()`, Boolean, 'settings trigger ready')
-  await evaluate(`chrome.webview.postMessage({type:'dsh-portable/test-desktop',key:131260})`)
+  })()`, Boolean, 'native settings command opens after onboarding')
 
   const generalBorders = await until(`(() => {
     const textOf = node => (node?.textContent || '').replace(/\\s+/g, ' ').trim()
@@ -112,7 +120,10 @@ try {
   passed=true;
 } finally {
   try {
-    if (evaluate) await writeFile(path.join(output, 'page.txt'), await evaluate('document.body.innerText').catch(String))
+    if (evaluate) {
+      await writeFile(path.join(output, 'page.txt'), await evaluate('document.body.innerText').catch(String))
+      await writeFile(path.join(output, 'page.html'), await evaluate('document.documentElement.outerHTML').catch(String))
+    }
   } finally {
     socket?.close()
     try {


### PR DESCRIPTION
The native market smoke could miss the asynchronously mounted onboarding notice, then wait for settings while the notice kept the workspace inert. Keep handling known onboarding dialogs until a dialog actually opens through the native settings command, then verify the expected settings content. Capture disposable page HTML on failure for diagnosis.

The startup transition audit now shares its declared startup deadline between CDP connection and workspace readiness instead of stopping CDP discovery at an unrelated 30 seconds and then starting another full deadline.

Validation: both corrected scripts passed against the unchanged CI Windows package on an isolated Win11 installation; market checks cover 580/1200/580 widths and general settings borders. Original CI and intermediate local failures are retained. No product payload changes.
