### PR TITLE
Fix runtime cache directory aliases and optional native package discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
           pnpm --dir upstream run release:pack --family dsh --out dist/npm --concurrency 8
           pnpm --dir upstream run release:pack --family vendor --out dist/npm-vendor --concurrency 8
           mkdir -p upstream/dist/npm-landlock
-          pnpm --dir upstream/native/landlock-run/packages/entry pack --pack-destination "$PWD/upstream/dist/npm-landlock"
+          if [ '${{ steps.preview.outputs.landlockCount }}' = 1 ]; then
+            pnpm --dir upstream/native/landlock-run/packages/entry pack --pack-destination "$PWD/upstream/dist/npm-landlock"
+          fi
           test "$(find upstream/dist/npm -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.dshCount }}"
           test "$(find upstream/dist/npm-vendor -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.vendorCount }}"
           test "$(find upstream/dist/npm-landlock -maxdepth 1 -name '*.tgz' | wc -l)" -eq "${{ steps.preview.outputs.landlockCount }}"

--- a/launcher/startup-source-cache.mjs
+++ b/launcher/startup-source-cache.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { registerHooks } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -17,6 +17,9 @@ export function startSourceCache(portableRoot, runtimeRoot, env = process.env) {
   try {
     const manifest = JSON.parse(readFileSync(path.join(portableRoot, 'runtime-capsule.json'), 'utf8'))
     if (!/^[a-f0-9]{64}$/.test(manifest.sha256) || path.basename(runtimeRoot) !== manifest.sha256) return { result, finish }
+    // Node resolves module URLs through directory aliases (notably /var on
+    // macOS). Resolve the root once, rather than doing filesystem IO per module.
+    const canonicalRoot = realpathSync(runtimeRoot)
     const compressed = readFileSync(path.join(portableRoot, 'runtime', 'DSH-App.dshpack'))
     if (compressed.length !== manifest.bytes || createHash('sha256').update(compressed).digest('hex') !== manifest.sha256)
       throw new Error('capsule-integrity')
@@ -30,7 +33,7 @@ export function startSourceCache(portableRoot, runtimeRoot, env = process.env) {
       if (!Number.isSafeInteger(entry.size) || entry.size < 0 || end > payload.length) throw new Error('capsule-entry')
       if (entry.path.startsWith('app/node_modules/') && /\.(?:mjs|cjs|js|json)$/.test(entry.path)
         && !entry.path.split('/').some(part => part === '..' || part === '.')) {
-        const filename = path.resolve(runtimeRoot, ...entry.path.split('/'))
+        const filename = path.resolve(canonicalRoot, ...entry.path.split('/'))
         // Index byte ranges, then decode only modules actually requested. Eager
         // decoding also loads unused package-manager/tooling sources into V8.
         sources.set(filename, { offset, end })

--- a/scripts/stage-preview-runtime.mjs
+++ b/scripts/stage-preview-runtime.mjs
@@ -59,7 +59,10 @@ export async function inventoryPackedRuntime({ packedRoot, lock }) {
   const packages = []
   for (const [family, directoryName] of families) {
     const directory = path.join(packedRoot, directoryName)
-    const filenames = (await readdir(directory)).filter((name) => name.endsWith('.tgz')).sort()
+    const filenames = (await readdir(directory).catch(error => {
+      if (error.code === 'ENOENT' && lock.dsh.packedFamilies[family] === 0) return []
+      throw error
+    })).filter((name) => name.endsWith('.tgz')).sort()
     assert.equal(filenames.length, lock.dsh.packedFamilies[family], `${family} packed package count`)
     for (const filename of filenames) {
       const tarball = path.join(directory, filename)

--- a/scripts/upstream-source-metadata.mjs
+++ b/scripts/upstream-source-metadata.mjs
@@ -70,11 +70,9 @@ function countPackedFamilies(tree) {
   }).length
   const vendor = paths.filter((entry) => VENDOR_PACKAGE.test(entry)).length
   if (!dsh || !vendor) throw new Error('official source tree has an empty release family')
-  if (!paths.includes(LANDLOCK_ENTRY)) {
-    throw new Error(`official source tree is missing ${LANDLOCK_ENTRY}`)
-  }
-
-  return { dsh, vendor, landlock: 1 }
+  // Newer official releases no longer ship this standalone native package.
+  // Record its actual presence; staging still validates the complete closure.
+  return { dsh, vendor, landlock: paths.includes(LANDLOCK_ENTRY) ? 1 : 0 }
 }
 
 /**
@@ -82,7 +80,7 @@ function countPackedFamilies(tree) {
  *
  * @param {string} commit - Full immutable upstream commit SHA.
  * @param {{ json: (url: string) => Promise<unknown>, text: (url: string) => Promise<string> }} callbacks - Authenticated fetch wrappers.
- * @returns {Promise<{ packageManager: string, packedFamilies: { dsh: number, vendor: number, landlock: 1 } }>}
+ * @returns {Promise<{ packageManager: string, packedFamilies: { dsh: number, vendor: number, landlock: number } }>}
  */
 export async function readOfficialSourceMetadata(commit, callbacks) {
   if (!/^[0-9a-f]{40}$/.test(commit ?? '')) {

--- a/tests/startup-source-cache.test.mjs
+++ b/tests/startup-source-cache.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -22,9 +22,11 @@ test('startup cache preserves ESM, CommonJS and JSON, leaves profile files alone
     for (const [name, source] of Object.entries(sources)) await writeFile(path.join(target, name), name === 'package.json' ? source : name === 'data.json' ? '{"answer":0}' : 'throw Error("disk source read")')
     const mutable = path.join(root, 'profile.mjs')
     await writeFile(mutable, 'export default 99')
+    const alias = path.join(root, 'root-alias')
+    await symlink(root, alias, process.platform === 'win32' ? 'junction' : 'dir')
     const code = `import assert from 'node:assert/strict';
       import {startSourceCache} from ${JSON.stringify(new URL('../launcher/startup-source-cache.mjs', import.meta.url).href)};
-      const cache=startSourceCache(${JSON.stringify(root)},${JSON.stringify(runtime)},{});
+      const cache=startSourceCache(${JSON.stringify(root)},${JSON.stringify(path.join(alias, manifest.sha256))},{});
       assert.equal(cache.result.status,'ready');
       assert.equal((await import(${JSON.stringify(pathToFileURL(path.join(target, 'main.mjs')).href)})).default,41);
       assert.equal((await import(${JSON.stringify(pathToFileURL(path.join(target, 'legacy.cjs')).href)})).default,7);

--- a/tests/upstream-source-metadata.test.mjs
+++ b/tests/upstream-source-metadata.test.mjs
@@ -52,6 +52,14 @@ test('rejects a truncated official source tree', async () => {
   )
 })
 
+test('official releases may remove the standalone landlock package', async () => {
+  const callbacks = fixture()
+  const tree = await callbacks.json('/git/trees/fixture')
+  tree.tree = tree.tree.filter(entry => !entry.path.startsWith('native/landlock-run/'))
+  const metadata = await readOfficialSourceMetadata(commit, fixture({ tree }))
+  assert.deepEqual(metadata.packedFamilies, { dsh: 2, vendor: 1, landlock: 0 })
+})
+
 test('rejects an unknown release family glob instead of guessing its count', async () => {
   const unknownFamilies = familiesSource.replace(
     "readonly patterns = ['vendor/*/package.json'] as const",


### PR DESCRIPTION
Fix the macOS contract failure from run 34312707576: Node canonicalizes module URLs through /var directory aliases, so index startup sources using the real runtime root once. The existing ESM/CommonJS/JSON behavior test now also exercises an aliased root.

Allow official releases that no longer include the standalone landlock package to declare a zero count. Keep exact package-count and dependency-closure validation, and only permit a missing archive directory when its reviewed count is zero. The official 0.1.5-alpha.1 source resolves to 260 DSH packages, nine vendor packages and zero standalone landlock packages. This repairs discovery without promoting that core before product acceptance.

Focused alias, source-metadata and preview tests passed locally. Cross-platform CI remains required before release; the earlier failed main run was cancelled after retaining its error evidence.
