### PR TITLE
Fix startup readiness race and native bounds restoration

### DIFF
--- a/launcher/portable-cli.mjs
+++ b/launcher/portable-cli.mjs
@@ -655,7 +655,7 @@ async function status() {
   const state = readProcessState()
   if (!ownedState(state)) return { status: 'stopped', environment: layout.environmentId, root: layout.root }
   return {
-    status: await httpReady(state.url || state.port, 1200, { preserveAccessToken: true }) ? 'running' : 'starting',
+    status: state.url && await httpReady(state.url, 1200, { preserveAccessToken: true }) ? 'running' : 'starting',
     environment: layout.environmentId,
     root: layout.root,
     pid: state.pid,

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -3259,6 +3259,9 @@ namespace DshPortable
                 Rectangle bounds = new Rectangle(state.x, state.y, state.width, state.height);
                 if (state.schemaVersion != 1 || !IsSafeDesktopBounds(bounds)) throw new InvalidDataException();
                 StartPosition = FormStartPosition.Manual;
+                // Saved bounds are native outer bounds. Creating a captionless
+                // Sizable handle after assigning them adds the legacy frame size.
+                if (!IsHandleCreated) CreateHandle();
                 Bounds = bounds;
                 windowStateBeforeHide = state.maximized ? FormWindowState.Maximized : FormWindowState.Normal;
                 WindowState = windowStateBeforeHide;

--- a/scripts/audit-windows-startup-transition.mjs
+++ b/scripts/audit-windows-startup-transition.mjs
@@ -283,7 +283,15 @@ try {
     await new Promise(resolve => setTimeout(resolve, 20))
   }
 
-  const startupTrace = (await readFile(path.join(path.dirname(launcherLog), 'startup-latest.jsonl'), 'utf8'))
+  const logsDirectory = path.dirname(launcherLog)
+  const recentTrace = (await Promise.all(['startup-latest.jsonl', 'startup-previous.jsonl']
+    .map(name => readFile(path.join(logsDirectory, name), 'utf8').catch(() => ''))))
+    .join('\n').trim().split(/\r?\n/).filter(Boolean).map(line => JSON.parse(line))
+  const auditedStartupId = recentTrace.find(entry => entry.pid === launcher.pid)?.startupId
+  assert.match(auditedStartupId ?? '', /^[a-f0-9]{32}$/i, 'missing audited native startup identity')
+  // Another invocation can rotate the latest file while this host is loading.
+  // The per-start history is the authoritative, complete trace for this PID.
+  const startupTrace = (await readFile(path.join(logsDirectory, 'history', auditedStartupId, 'startup.jsonl'), 'utf8'))
     .trim().split(/\r?\n/).map(line => JSON.parse(line))
   const nativeLoading = startupTrace.find(entry => entry.phase === 'native-loading-ready' && entry.pid === launcher.pid)
   const nativeReady = startupTrace.find(entry => entry.phase === 'interactive-ready' && entry.pid === launcher.pid)

--- a/scripts/smoke-linux-desktop-host.sh
+++ b/scripts/smoke-linux-desktop-host.sh
@@ -56,7 +56,7 @@ if pgrep -P "$PID" -af 'firefox|chromium|google-chrome|microsoft-edge' >/dev/nul
   exit 1
 fi
 
-url="$(printf '%s' "$status" | "$NODE" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).url))')"
+url="$(printf '%s' "$recovered_status" | "$NODE" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).url))')"
 http_status="$(curl --fail --silent --show-error --location --cookie "$COOKIE_JAR" --cookie-jar "$COOKIE_JAR" --output "$RESPONSE_BODY" --write-out '%{http_code}' "$url")" || {
   cat "$LOG" >&2
   echo 'the authenticated workspace URL did not return successfully' >&2

--- a/scripts/smoke-portable.mjs
+++ b/scripts/smoke-portable.mjs
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import { workspaceDocumentReady } from '../launcher/http-readiness.mjs'
 import { renameWithRetry } from './smoke-helpers.mjs'
+import { readLogTail, redactDiagnosticText } from '../launcher/diagnostic-policy.mjs'
 
 const originalRoot = path.resolve(process.argv[2] ?? '')
 if (!originalRoot) throw new Error('usage: node smoke-portable.mjs <extracted-DSH-Portable-root>')
@@ -124,7 +125,15 @@ async function invokeCli(root, ...args) {
   const commandArgs = capsule
     ? [path.join(root, 'launcher', 'runtime-entry.mjs'), 'portable-cli.mjs', ...args]
     : [cliFor(root), ...args]
-  return run(nodeFor(root), commandArgs, { cwd: root })
+  const result = await run(nodeFor(root), commandArgs, { cwd: root })
+  if (result.code !== 0) {
+    const diagnostics = ['portable-errors.jsonl', 'dsh.stderr.log', 'startup-latest.jsonl'].map(name => {
+      try { return `${name}:\n${redactDiagnosticText(readLogTail(path.join(root, 'data', 'logs', name), 16000))}` }
+      catch { return '' }
+    }).filter(Boolean).join('\n')
+    result.stderr = `${result.stderr}\n${diagnostics}`
+  }
+  return result
 }
 
 function parseCliJson(stdout) {

--- a/tests/startup-polling.test.mjs
+++ b/tests/startup-polling.test.mjs
@@ -7,6 +7,25 @@ import vm from 'node:vm'
 const cli = await readFile(new URL('../launcher/portable-cli.mjs', import.meta.url), 'utf8')
 const waitSource = cli.slice(cli.indexOf('async function waitForHost('), cli.indexOf('\nfunction portAvailable('))
 
+test('a listening authenticated host stays starting until its workspace URL is committed', async () => {
+  const state = { pid: 123, port: 3080 }
+  let probes = 0
+  const statusSource = cli.slice(cli.indexOf('async function status()'), cli.indexOf('\nasync function openExisting()'))
+  const status = vm.runInNewContext(`(${statusSource})`, {
+    readProcessState: () => state,
+    ownedState: () => true,
+    layout: { environmentId: 'default', root: 'fixture' },
+    httpReady: async () => { probes += 1; return true },
+  })
+  assert.equal((await status()).status, 'starting')
+  assert.equal(probes, 0)
+  state.url = 'http://127.0.0.1:3080/?token=fixture'
+  const ready = await status()
+  assert.equal(ready.status, 'running')
+  assert.equal(ready.url, state.url)
+  assert.equal(probes, 1)
+})
+
 function fixture({ alive = () => true, owned = () => true } = {}) {
   let now = 0
   let identities = 0


### PR DESCRIPTION
An authenticated backend could report `running` before its complete workspace URL was committed, exposing a bare URL that returned 401. Keep that state `starting` until the URL exists. Restore saved Windows outer bounds after handle creation so a saved 960x680 window stays 960x680 instead of growing to 962x705.

Startup acceptance reads the corresponding per-start history when another invocation rotates the latest log. CLI smoke failures now include bounded, redacted diagnostic tails; Linux recovery checks the current status URL.

Validation: 550 source tests passed, one platform skip. The native frame reproduction demonstrated the old size drift; the rebuilt Windows host restored 960x680 and passed hidden native startup acceptance. A fresh runtime-cache startup also passed after correcting the audit's log selection. Full cross-platform product CI remains required before publication.
