### PR TITLE
Fix preview session relocation and backup restore

### DIFF
--- a/launcher/data-transfer.mjs
+++ b/launcher/data-transfer.mjs
@@ -254,11 +254,8 @@ function relocatePortableWorkspaceEntry(file, bytes, before, after) {
     const parsed = JSON.parse(bytes.toString('utf8'))
     return { archivePath, bytes: Buffer.from(`${JSON.stringify(replaceExactStrings(parsed, before, after), null, 2)}\n`, 'utf8') }
   }
-  if (file.path.startsWith(sourcePrefix) && file.path.endsWith('/session.jsonl.zstd')) {
-    return { archivePath, bytes: relocateSessionHeaderBytes(bytes, before, after, true) }
-  }
-  if (file.path.startsWith(sourcePrefix) && file.path.endsWith('/session.jsonl')) {
-    return { archivePath, bytes: relocateSessionHeaderBytes(bytes, before, after, false) }
+  if (file.path.startsWith(sourcePrefix) && /\/session(?:\.v2)?\.jsonl(?:\.zstd)?$/.test(file.path)) {
+    return { archivePath, bytes: relocateSessionHeaderBytes(bytes, before, after, file.path.endsWith('.zstd')) }
   }
   return { archivePath, bytes }
 }

--- a/launcher/portable-core.mjs
+++ b/launcher/portable-core.mjs
@@ -1068,10 +1068,14 @@ async function migrateSessionDirectory(dshHome, before, after) {
   for (const entry of await readdir(targetDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue
     const sessionDir = path.join(targetDir, entry.name)
-    const zstd = path.join(sessionDir, 'session.jsonl.zstd')
-    const plain = path.join(sessionDir, 'session.jsonl')
-    if (existsSync(zstd) && await migrateSessionHeader(zstd, before, after, true)) changed += 1
-    else if (existsSync(plain) && await migrateSessionHeader(plain, before, after, false)) changed += 1
+    let migrated = false
+    // Preview cores can retain legacy logs alongside their v2 session log.
+    // Update every existing header, without rewriting historical events.
+    for (const name of ['session.jsonl.zstd', 'session.jsonl', 'session.v2.jsonl.zstd', 'session.v2.jsonl']) {
+      const filename = path.join(sessionDir, name)
+      if (existsSync(filename) && await migrateSessionHeader(filename, before, after, name.endsWith('.zstd'))) migrated = true
+    }
+    if (migrated) changed += 1
   }
   return changed
 }

--- a/scripts/smoke-windows-desktop-host.ps1
+++ b/scripts/smoke-windows-desktop-host.ps1
@@ -206,7 +206,11 @@ try {
     $Status = Get-ProductStatus
 
     if ($Process.MainWindowHandle -eq [IntPtr]::Zero) { throw 'DeepSeek-Herness.exe did not create a native top-level window.' }
-    if ($Status.Status -ne 'running') { throw 'DeepSeek Harness did not become ready behind the desktop host.' }
+    if ($Status.Status -ne 'running') {
+        $ErrorLog = Join-Path $Root 'data\logs\portable-errors.jsonl'
+        $StartupErrors = if (Test-Path -LiteralPath $ErrorLog) { (Get-Content -LiteralPath $ErrorLog -Tail 3) -join "`n" } else { 'No structured startup error was recorded.' }
+        throw "DeepSeek Harness did not become ready behind the desktop host at $Root.`n$($Status.Raw)`n$StartupErrors"
+    }
     if ($Process.MainWindowTitle) { throw "The compact desktop chrome must not repeat product identity: $($Process.MainWindowTitle)" }
 
     $AppId = [WindowAppIdentity]::GetAppUserModelId($Process.MainWindowHandle)

--- a/scripts/smoke-windows-desktop-move.ps1
+++ b/scripts/smoke-windows-desktop-move.ps1
@@ -64,6 +64,7 @@ function Assert-BoundedPerformance {
     }
 }
 
+Write-Host "Verifying original desktop lifecycle: $Root"
 $First = & $DesktopSmoke -Root $Root
 if ($LASTEXITCODE -ne 0) { throw "First desktop lifecycle failed with exit code $LASTEXITCODE" }
 Assert-BoundedPerformance -Result $First -Label 'First launch' -ColdStartLimit $EffectiveFirstColdStartLimit
@@ -71,6 +72,7 @@ Assert-BoundedPerformance -Result $First -Label 'First launch' -ColdStartLimit $
 Move-PortableDirectory -Source $Root -Destination $MovedRoot
 if (Test-Path -LiteralPath $Root) { throw 'The original portable folder still exists after the move.' }
 
+Write-Host "Verifying moved desktop lifecycle: $MovedRoot"
 $Second = & $DesktopSmoke -Root $MovedRoot
 if ($LASTEXITCODE -ne 0) { throw "Moved desktop lifecycle failed with exit code $LASTEXITCODE" }
 Assert-BoundedPerformance -Result $Second -Label 'Moved launch' -ColdStartLimit $PerformanceBudget.movedColdStartSeconds

--- a/tests/data-transfer.test.mjs
+++ b/tests/data-transfer.test.mjs
@@ -98,12 +98,13 @@ test('restore keeps target conflicts by default and imports missing data', async
   assert.equal(await readFile(path.join(target.layout.dshHome, 'sessions', 'workspace-b', 'session-two', 'session.jsonl.zstd'), 'utf8'), 'target')
 })
 
-test('restore relocates the source portable workspace without rewriting historical event text', async () => {
+for (const sessionFilename of ['session.jsonl.zstd', 'session.v2.jsonl.zstd', 'session.jsonl', 'session.v2.jsonl']) {
+test(`restore relocates ${sessionFilename} without rewriting historical event text`, async () => {
   const source = await fixture()
   const sessionId = 'session-11111111-1111-4111-8111-111111111111'
   const workspaceStore = path.join(source.layout.dshHome, 'storages', 'workspace.json')
   const projectionStore = path.join(source.layout.dshHome, 'storages', 'session_projcache.json')
-  const sourceSession = path.join(source.layout.dshHome, 'sessions', projectKey(source.layout.workspace), sessionId, 'session.jsonl.zstd')
+  const sourceSession = path.join(source.layout.dshHome, 'sessions', projectKey(source.layout.workspace), sessionId, sessionFilename)
   const externalWorkspace = path.join(source.root, 'external-project')
   await mkdir(path.dirname(sourceSession), { recursive: true })
   await mkdir(path.dirname(workspaceStore), { recursive: true })
@@ -114,8 +115,9 @@ test('restore relocates the source portable workspace without rewriting historic
   await writeFile(projectionStore, `${JSON.stringify({ sessions: { [sessionId]: { cwd: source.layout.workspace } } })}\n`)
   const header = `${JSON.stringify({ type: 'session', id: sessionId, cwd: source.layout.workspace })}\n`
   const events = `${JSON.stringify({ type: 'user/message', data: { content: `historical ${source.layout.workspace}` } })}\n`
-  const eventFrame = zstdCompressSync(Buffer.from(events))
-  await writeFile(sourceSession, Buffer.concat([zstdCompressSync(Buffer.from(header)), eventFrame]))
+  const compressed = sessionFilename.endsWith('.zstd')
+  const eventFrame = compressed ? zstdCompressSync(Buffer.from(events)) : Buffer.from(events)
+  await writeFile(sourceSession, Buffer.concat([compressed ? zstdCompressSync(Buffer.from(header)) : Buffer.from(header), eventFrame]))
 
   const output = path.join(source.layout.root, 'portable-workspace.dshdata')
   await createDataArchive(source.layout, output, { categories: ['sessions'] })
@@ -123,20 +125,21 @@ test('restore relocates the source portable workspace without rewriting historic
   const target = layoutForRoot(targetRoot, process.platform)
   await restoreDataArchive(target, output)
 
-  const targetSession = path.join(target.dshHome, 'sessions', projectKey(target.workspace), sessionId, 'session.jsonl.zstd')
+  const targetSession = path.join(target.dshHome, 'sessions', projectKey(target.workspace), sessionId, sessionFilename)
   assert.equal(existsSync(path.join(target.dshHome, 'sessions', projectKey(source.layout.workspace))), false)
   const restoredWorkspaces = JSON.parse(await readFile(workspaceStore.replace(source.layout.dshHome, target.dshHome), 'utf8')).workspaces
   assert.equal(restoredWorkspaces.portable.path, target.workspace)
   assert.equal(restoredWorkspaces.external.path, externalWorkspace)
   assert.equal(JSON.parse(await readFile(projectionStore.replace(source.layout.dshHome, target.dshHome), 'utf8')).sessions[sessionId].cwd, target.workspace)
   const restoredBytes = await readFile(targetSession)
-  const restoredHeader = JSON.parse(zstdDecompressSync(restoredBytes).toString('utf8').trim())
+  const restoredHeader = JSON.parse((compressed ? zstdDecompressSync(restoredBytes) : restoredBytes).toString('utf8').split('\n')[0])
   assert.equal(restoredHeader.cwd, target.workspace)
   assert.equal(restoredBytes.subarray(-eventFrame.length).equals(eventFrame), true)
   const repeated = await restoreDataArchive(target, output)
   assert.deepEqual(repeated.conflicts, [])
   assert.equal(repeated.unchanged, 4)
 })
+}
 
 test('restore can explicitly replace conflicts after creating a rollback snapshot', async () => {
   const source = await fixture()

--- a/tests/portable-contract.test.mjs
+++ b/tests/portable-contract.test.mjs
@@ -631,7 +631,10 @@ test('moving the whole folder migrates only its owned workspace references', asy
   await mkdir(sessionDir, { recursive: true })
   const headerFrame = zstdCompressSync(Buffer.from(`${JSON.stringify({ type: 'session', version: 0, id: 'session-one', createdAt: 1, cwd: first.workspace, isSeeded: false, delegationDepth: 0 })}\n`))
   const eventFrame = zstdCompressSync(Buffer.from(`${JSON.stringify({ type: 'event', text: first.workspace })}\n`))
-  await writeFile(path.join(sessionDir, 'session.jsonl.zstd'), Buffer.concat([headerFrame, eventFrame]))
+  const compressedNames = ['session.jsonl.zstd', 'session.v2.jsonl.zstd']
+  const plainNames = ['session.jsonl', 'session.v2.jsonl']
+  for (const name of compressedNames) await writeFile(path.join(sessionDir, name), Buffer.concat([headerFrame, eventFrame]))
+  for (const name of plainNames) await writeFile(path.join(sessionDir, name), Buffer.concat([zstdDecompressSync(headerFrame), zstdDecompressSync(eventFrame)]))
 
   await rename(firstRoot, movedRoot)
   const moved = layoutForRoot(movedRoot)
@@ -642,9 +645,16 @@ test('moving the whole folder migrates only its owned workspace references', asy
   assert.equal(workspaceStore.tables.workspaces.portable.path, moved.workspace)
   assert.equal(workspaceStore.tables.workspaces.external.path, 'C:\\External Project')
 
-  const migratedFile = path.join(moved.dshHome, 'sessions', projectKey(moved.workspace), 'session-one', 'session.jsonl.zstd')
-  const migratedBytes = await readFile(migratedFile)
-  const secondFrame = migratedBytes.indexOf(Buffer.from([0x28, 0xB5, 0x2F, 0xFD]), 4)
-  assert.equal(JSON.parse(zstdDecompressSync(migratedBytes.subarray(0, secondFrame)).toString('utf8')).cwd, moved.workspace)
-  assert.equal(JSON.parse(zstdDecompressSync(migratedBytes.subarray(secondFrame)).toString('utf8')).text, first.workspace, 'historical message content is not rewritten')
+  const migratedDir = path.join(moved.dshHome, 'sessions', projectKey(moved.workspace), 'session-one')
+  for (const name of compressedNames) {
+    const migratedBytes = await readFile(path.join(migratedDir, name))
+    const secondFrame = migratedBytes.indexOf(Buffer.from([0x28, 0xB5, 0x2F, 0xFD]), 4)
+    assert.equal(JSON.parse(zstdDecompressSync(migratedBytes.subarray(0, secondFrame)).toString('utf8')).cwd, moved.workspace)
+    assert.deepEqual(migratedBytes.subarray(secondFrame), eventFrame, 'historical compressed events are byte-identical')
+  }
+  for (const name of plainNames) {
+    const [header, event] = (await readFile(path.join(migratedDir, name), 'utf8')).trim().split('\n').map(JSON.parse)
+    assert.equal(header.cwd, moved.workspace)
+    assert.equal(event.text, first.workspace, 'historical message content is not rewritten')
+  }
 })


### PR DESCRIPTION
Preview cores write session.v2.jsonl(.zstd), while Portable relocation and backup restore only rewrote legacy session.jsonl headers. Moving an upgraded installation therefore left the new log's cwd pointing at the old directory and the official core refused to start.

Handle both generations, compressed and plain, including coexisting files. Relocate header paths only; preserve historical event bytes and count each session once. CI desktop lifecycle failures now identify the original/moved phase and include the structured startup error.

Validation: legacy/v2 coexistence relocation and backup restore tests pass. A Windows CI ZIP with the corrected launcher module passes real backend startup, directory relocation, and restart through smoke-portable.mjs. Existing release budgets and qualification requirements remain unchanged; RC publication waits for the rebuilt main CI.
