### PR TITLE
Improve focused Windows verification and failure evidence

### DIFF
--- a/.github/workflows/windows-focused.yml
+++ b/.github/workflows/windows-focused.yml
@@ -1,0 +1,59 @@
+name: Focused Windows artifact verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Existing CI run containing windows-x64-build (diagnostic reuse only)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  tray-bridge:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [windows-2022, windows-2025]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+      - name: Record artifact and harness provenance
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN: ${{ inputs.run_id }}
+        run: |
+          New-Item -ItemType Directory evidence | Out-Null
+          gh api "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:SOURCE_RUN" --jq '{id,head_sha,path,conclusion,head_branch}' | Out-File evidence/source-run.json -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw 'Cannot resolve source run' }
+          git rev-parse HEAD | Out-File evidence/harness-commit.txt
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-x64-build
+          path: artifacts
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify tray bridge using existing product
+        shell: pwsh
+        run: |
+          $Root = Join-Path $env:RUNNER_TEMP 'dsh-focused'
+          New-Item -ItemType Directory -Force $Root | Out-Null
+          Get-FileHash artifacts/DSH-Portable-windows-x64-offline.zip | Format-List | Out-File evidence/artifact-sha256.txt
+          tar.exe -xf artifacts/DSH-Portable-windows-x64-offline.zip -C $Root
+          if ($LASTEXITCODE -ne 0) { throw 'Extraction failed' }
+          node scripts/smoke-windows-tray-bridge.mjs (Join-Path $Root 'DSH-Portable') 2>&1 | Tee-Object evidence/tray-bridge.log
+          if ($LASTEXITCODE -ne 0) { throw 'Tray bridge check failed; see retained evidence' }
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: focused-windows-${{ matrix.runner }}
+          path: evidence/
+          retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,15 @@ npm test
 
 Pull Request 请说明用户可见的问题、实现边界和实际完成的验证。无关重构请拆分提交。
 
+## 持续维护与故障处理
+
+- 每项修复记录复现条件、受影响模块、证据路径和验收结果；区分产品缺陷、测试工具故障和运行环境问题。未定位的失败不能写成已修复。
+- 先运行受影响模块的定向检查。排查测试工具时复用已有成品，记录成品来源提交与测试脚本提交；这种结果不能替代最终发布提交的成品验收。
+- 同一失败没有新证据不重复运行。先补齐失败阶段、进程退出信息和已脱敏的日志，再验证假设。通过的检查仅在相关代码、依赖或环境发生变化时重跑。
+- Portable、官方内核、默认插件分别维护版本与兼容边界。优先检测实际能力，只在接口确有差异时增加适配；官方已有且满足需要的实现不再复制。兼容例外须记录原因和移除条件。
+- 发布前集中验证同一提交生成的成品：启动、主题与导航、更新与回滚、数据保留、默认插件关键操作。未通过的检查保留为未通过，不用源码测试替代。
+- 清理只针对确认不再使用的构建产物与缓存；保留当前验收包、失败证据和用户数据。重构围绕具体缺陷或重复实现，不与发布修复混入无关改写。
+
 提交贡献即表示你同意按本仓库的 Apache-2.0 许可证授权该贡献。
 
 ---
@@ -46,5 +55,14 @@ Run `npm test` before opening a pull request. Platform or packaging changes must
 Use the user-accepted 0.6.4 desktop experience as the baseline: continuous loading and theme state, consistent native navigation and menus, and working shortcuts. Default plugins need real-operation checks on supported cores, beyond installation. Close issues with the specific fix and verification scope; keep component pins, assets and README screenshots aligned with the delivered product. Retain failure evidence instead of retrying until a check turns green.
 
 Explain the user-visible problem, the implementation boundary, and the verification performed. Keep unrelated refactoring in a separate pull request.
+
+## Ongoing maintenance and failure handling
+
+- Record reproduction conditions, affected modules, evidence paths and acceptance results. Separate product defects, test harness failures and environment failures; an unexplained failure is not a fix.
+- Run affected checks first. Reuse existing artifacts when diagnosing the harness, recording both artifact and test-script commits. Such results do not replace acceptance of the final release commit.
+- Do not repeat an unchanged failure without new evidence. Capture the failing phase, process exit information and redacted logs before testing a hypothesis. Repeat passed checks when relevant code, dependencies or environment change.
+- Version Portable, official cores and default plugins independently. Prefer capability checks; adapt only demonstrated interface differences. Do not duplicate adequate upstream behavior. Document compatibility exceptions and their removal conditions.
+- Before release, qualify artifacts from one commit for startup, theme and navigation, updates and rollback, data preservation and essential default-plugin operations. Source tests do not replace failed product checks.
+- Remove only confirmed unused build outputs and caches, preserving current acceptance artifacts, failure evidence and user data. Refactor concrete defects or duplication without mixing unrelated rewrites into release fixes.
 
 By contributing, you agree that your contribution is licensed under the repository's Apache-2.0 License.

--- a/scripts/smoke-windows-tray-bridge.mjs
+++ b/scripts/smoke-windows-tray-bridge.mjs
@@ -119,21 +119,25 @@ async function reserveLoopbackPort() {
 
 async function waitForDevTools(port, process, output, timeoutMs = 30000) {
   const deadline = Date.now() + timeoutMs
+  let lastProbe = 'not attempted'
   while (Date.now() < deadline) {
+    if (output.error) throw new Error(`headless Chrome spawn failed: ${output.error}`)
     if (process.exitCode !== null) {
       throw new Error(`headless Chrome exited before DevTools became ready (code ${process.exitCode}): ${output.stderr || output.stdout}`)
     }
     try {
-      const response = await fetch(`http://127.0.0.1:${port}/json/list`)
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(1500) })
+      lastProbe = `HTTP ${response.status}`
       if (response.ok) {
         const targets = await response.json()
+        lastProbe = JSON.stringify(targets.map(target => ({ type: target.type, url: target.url })))
         const page = targets.find(target => target.type === 'page')
         if (page?.webSocketDebuggerUrl) return page
       }
-    } catch { /* Chrome is still starting */ }
+    } catch (error) { lastProbe = String(error.cause || error) }
     await new Promise(resolve => setTimeout(resolve, 100))
   }
-  throw new Error(`timed out waiting for headless Chrome DevTools on 127.0.0.1:${port}: ${output.stderr || output.stdout}`)
+  throw new Error(`timed out waiting for headless Chrome DevTools on 127.0.0.1:${port}; pid=${process.pid}; exit=${process.exitCode}; probe=${lastProbe}; output=${JSON.stringify(output)}`)
 }
 
 class CdpClient {
@@ -271,7 +275,9 @@ try {
   profile = await mkdtemp(path.join(os.tmpdir(), 'dsh-tray-headless-'))
   const debugPort = await reserveLoopbackPort()
   const chromeOutput = { stdout: '', stderr: '' }
-  chrome = spawn(chromeExecutable(), [
+  const executable = chromeExecutable()
+  process.stdout.write(`${JSON.stringify({ phase: 'chrome-launch', executable, profile, debugPort, node: process.version })}\n`)
+  chrome = spawn(executable, [
     '--headless=new',
     `--remote-debugging-port=${debugPort}`,
     '--remote-debugging-address=127.0.0.1',
@@ -281,9 +287,11 @@ try {
     '--disable-background-networking',
     '--disable-component-update',
     '--disable-gpu',
+    '--enable-logging=stderr',
     '--window-size=1440,900',
     'about:blank',
   ], { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true })
+  chrome.on('error', error => { chromeOutput.error = String(error) })
   chrome.stdout.on('data', chunk => { chromeOutput.stdout = `${chromeOutput.stdout}${chunk}`.slice(-8000) })
   chrome.stderr.on('data', chunk => { chromeOutput.stderr = `${chromeOutput.stderr}${chunk}`.slice(-8000) })
 


### PR DESCRIPTION
Reuse an existing Windows CI artifact to diagnose the tray bridge without rebuilding other platforms. Record artifact and harness provenance, browser launch details, bounded DevTools probes, and retain failed-check output. Document maintenance and verification boundaries. Local verification: existing RC ZIP tray bridge passed; syntax and diff checks passed.