### PR TITLE
Preserve restart during forced WebView cleanup and pin the test browser

### DIFF
--- a/.github/actions/setup-test-chrome/action.yml
+++ b/.github/actions/setup-test-chrome/action.yml
@@ -1,0 +1,20 @@
+name: Install pinned Chrome for Testing
+description: Use an isolated automation browser instead of the runner's auto-updating desktop Chrome
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      run: |
+        $Version = '153.0.8010.36'
+        $Destination = Join-Path $env:RUNNER_TEMP "chrome-for-testing-$Version"
+        $Archive = "$Destination.zip"
+        Invoke-WebRequest "https://storage.googleapis.com/chrome-for-testing-public/$Version/win64/chrome-win64.zip" -OutFile $Archive
+        New-Item -ItemType Directory -Force $Destination | Out-Null
+        tar.exe -xf $Archive -C $Destination
+        if ($LASTEXITCODE -ne 0) { throw 'Chrome for Testing extraction failed' }
+        $Executable = Join-Path $Destination 'chrome-win64/chrome.exe'
+        if (-not (Test-Path -LiteralPath $Executable)) { throw 'Chrome for Testing executable is missing' }
+        $ActualVersion = (Get-Item -LiteralPath $Executable).VersionInfo.ProductVersion
+        if ($ActualVersion -ne $Version) { throw "Unexpected browser version: $ActualVersion" }
+        "CHROME_PATH=$Executable" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        Write-Host "Chrome for Testing $ActualVersion; archive SHA256 $((Get-FileHash -LiteralPath $Archive).Hash)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-test-chrome
       - uses: actions/download-artifact@v8
         with:
           name: windows-x64-build

--- a/.github/workflows/windows-focused.yml
+++ b/.github/workflows/windows-focused.yml
@@ -33,6 +33,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-test-chrome
+        if: inputs.scope != 'migration'
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}

--- a/launcher/windows/DSH-Portable.cs
+++ b/launcher/windows/DSH-Portable.cs
@@ -3512,15 +3512,19 @@ namespace DshPortable
             }
 
             allowClose = true;
-            if (restartAfterShutdown)
-            {
-                WriteLauncherLog("restart-host", "relaunch-scheduled afterPid="
-                    + Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture));
-                PortableProcessJob.StartDetachedUpdater(Application.ExecutablePath, RestartArguments());
-            }
+            ScheduleRequestedRestart();
             DisposeTrayIcon();
             WriteLauncherLog("shutdown", "complete");
             Close();
+        }
+
+        private void ScheduleRequestedRestart()
+        {
+            if (!restartAfterShutdown) return;
+            PortableProcessJob.StartDetachedUpdater(Application.ExecutablePath, RestartArguments());
+            restartAfterShutdown = false;
+            WriteLauncherLog("restart-host", "relaunch-scheduled afterPid="
+                + Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture));
         }
 
         private void OnWebViewBrowserProcessExited(object sender, CoreWebView2BrowserProcessExitedEventArgs eventArgs)
@@ -3573,6 +3577,15 @@ namespace DshPortable
             }
             webViewProcessFailure = null;
 
+            if (PortableProcessJob.IsActive
+                && Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_AUTOMATION") == "1"
+                && Environment.GetEnvironmentVariable("DSH_PORTABLE_TEST_FORCE_JOB_CLOSE") == "1")
+            {
+                WriteLauncherLog("shutdown-webview", "job-close-test-requested");
+                ExitOwnedTreeForShutdown();
+                return;
+            }
+
             DateTime deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
             DateTime gracefulDeadline = DateTime.UtcNow.AddMilliseconds(Math.Min(WebViewGracefulShutdownMs, timeoutMs));
             bool exitEventObserved = exited.IsCompleted;
@@ -3607,8 +3620,7 @@ namespace DshPortable
                     {
                         WriteLauncherLog("shutdown-webview", "job-close-requested remaining="
                             + String.Join(";", remaining));
-                        PortableProcessJob.ExitOwnedTree();
-                        Environment.Exit(0);
+                        ExitOwnedTreeForShutdown();
                         return;
                     }
                 }
@@ -3629,6 +3641,15 @@ namespace DshPortable
                 + "\r\n\r\nOwned WebView2 processes still hold the portable folder:\r\n"
                 + String.Join("\r\n", remaining);
             throw new TimeoutException(details);
+        }
+
+        private void ExitOwnedTreeForShutdown()
+        {
+            // Closing our kill-on-close job also terminates this host. The
+            // detached restart must be outside that job before it is closed.
+            ScheduleRequestedRestart();
+            PortableProcessJob.ExitOwnedTree();
+            Environment.Exit(0);
         }
 
         private bool TryForceReleaseOwnedWebViewProcesses(List<string> remaining)

--- a/release-notes/v0.6.5-rc.1.json
+++ b/release-notes/v0.6.5-rc.1.json
@@ -5,7 +5,7 @@
     "highlights": [
       "新增「设置 → 更新」，位于通用设置下方；Portable 与官方内核分别提供版本选择、检查更新和启动检查。",
       "版本目录只收录经过验收的版本，已知问题版本不进入选项；切换通道丢弃过时结果，安装前重新核对所选版本。",
-      "顶部菜单在点击页面、窗口失焦或按 Escape 时关闭，并移除额外的弹出阴影。",
+      "顶部菜单在点击页面、窗口失焦或按 Escape 时关闭，并移除额外的弹出阴影；修复 WebView2 需要强制退出时，点击重启却只退出的问题。",
       "Windows DSH 终端直接启动本机 PowerShell，移除菜单和批处理脚本间重复的 Shell 转发及来源提示。",
       "插件安装说明指向市场和已安装页面；内置 pnpm 缺失时提供 Portable 修复入口，不尝试全局安装工具。",
       "插件市场上游变化改为生成差异审查报告，避免普通版本更新反复创建 issue；README 与实机截图同步更新。"
@@ -20,7 +20,7 @@
     "highlights": [
       "Settings → Updates now sits below General. Portable and the official core have separate version selection, update checks and startup controls.",
       "Version catalogs contain qualified releases only and omit known defective versions. Channel changes discard stale results; selected versions are revalidated before installation.",
-      "Native menus close on page clicks, window deactivation and Escape, with the extra popup shadow removed.",
+      "Native menus close on page clicks, window deactivation and Escape, with the extra popup shadow removed. Restart now relaunches the app even when WebView2 requires forced process cleanup.",
       "Windows DSH Terminal starts the installed PowerShell directly, removing redundant Shell handoffs and internal download-origin prompts.",
       "Plugin guidance points to Plugin Market and Installed. Missing bundled pnpm leads to Portable repair guidance instead of global tool installation.",
       "Routine market releases generate applicability review reports instead of repetitive issues. README text and real-machine screenshots are updated."

--- a/scripts/smoke-windows-native-restart.mjs
+++ b/scripts/smoke-windows-native-restart.mjs
@@ -8,6 +8,7 @@ import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 const root = path.resolve(process.argv[2] || '')
+const forceJobClose = process.argv.includes('--force-job-close')
 if (!process.argv[2] || process.platform !== 'win32') {
   throw new Error('usage: node smoke-windows-native-restart.mjs <DSH-Portable root> (Windows only)')
 }
@@ -127,6 +128,7 @@ try {
       DSH_PORTABLE_SKIP_UPDATE_CHECK: '1',
       DSH_PORTABLE_TEST_AUTOMATION: '1',
       DSH_PORTABLE_TEST_HIDDEN: '1',
+      DSH_PORTABLE_TEST_FORCE_JOB_CLOSE: forceJobClose ? '1' : '0',
       DSH_PORTABLE_TEST_WEBVIEW2_ARGUMENTS: `--remote-debugging-port=${debugPort}`,
     },
     stdio: 'ignore',
@@ -177,7 +179,8 @@ try {
   assert.match(log, /\[restart-host\] request-accepted/)
   assert.match(log, /\[restart-host\] reply-posted[^\n]+ok=true/)
   assert.match(log, /\[restart-host\] relaunch-scheduled/)
-  console.log(JSON.stringify({ status: 'passed', firstBoot, secondBoot, renderDiagnosticExported: true }))
+  if (forceJobClose) assert.match(log, /job-close-test-requested/)
+  console.log(JSON.stringify({ status: 'passed', firstBoot, secondBoot, forcedJobClose: forceJobClose, renderDiagnosticExported: true }))
 } finally {
   firstClient?.close()
   secondClient?.close()

--- a/scripts/smoke-windows-tray-bridge.mjs
+++ b/scripts/smoke-windows-tray-bridge.mjs
@@ -75,6 +75,9 @@ for (const filename of [portableNode, portableCli, runtimeEntry]) {
 }
 
 function chromeExecutable() {
+  if (process.env.CHROME_PATH && !existsSync(process.env.CHROME_PATH)) {
+    throw new Error(`configured Chrome is missing: ${process.env.CHROME_PATH}`)
+  }
   const candidates = [
     process.env.CHROME_PATH,
     path.join(process.env.ProgramFiles || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),

--- a/scripts/verify-windows-native-artifact.ps1
+++ b/scripts/verify-windows-native-artifact.ps1
@@ -30,6 +30,8 @@ if (Test-Path -LiteralPath $HealthEvidence) { Copy-Item -LiteralPath $HealthEvid
 if ($LASTEXITCODE -ne 0) { throw 'Windows runtime-health smoke failed.' }
 node scripts/smoke-windows-native-restart.mjs (Join-Path $Root 'DSH-Portable')
 if ($LASTEXITCODE -ne 0) { throw "Windows native restart smoke failed with exit code $LASTEXITCODE" }
+node scripts/smoke-windows-native-restart.mjs (Join-Path $Root 'DSH-Portable') --force-job-close
+if ($LASTEXITCODE -ne 0) { throw "Windows forced-job restart smoke failed with exit code $LASTEXITCODE" }
 node scripts/smoke-windows-subprocess-hide.mjs (Join-Path $Root 'DSH-Portable')
 if ($LASTEXITCODE -ne 0) { throw "Windows subprocess hiding smoke failed with exit code $LASTEXITCODE" }
 node scripts/smoke-windows-tray-bridge.mjs (Join-Path $Root 'DSH-Portable')

--- a/tests/desktop-host-contract.test.mjs
+++ b/tests/desktop-host-contract.test.mjs
@@ -176,6 +176,8 @@ test('Windows exit does not complete until the owned WebView2 runtime releases t
   )
   assert.match(webViewExit, /PortableProcessJob\.ExitOwnedTree/)
   assert.match(webViewExit, /job-close-requested/)
+  const jobExit = host.slice(host.indexOf('private void ExitOwnedTreeForShutdown()'), host.indexOf('private bool TryForceReleaseOwnedWebViewProcesses'))
+  assert.ok(jobExit.indexOf('ScheduleRequestedRestart();') < jobExit.indexOf('PortableProcessJob.ExitOwnedTree();'), 'a forced job close must schedule the detached restart before killing its host')
   assert.match(host, /日志 \/ Log:/)
 
   const webViewDataRoot = host.slice(host.indexOf('private string ResolveWebViewDataRoot()'), host.indexOf('private static bool IsTrustedLoopbackUrl'))

--- a/tests/tray-bridge.test.mjs
+++ b/tests/tray-bridge.test.mjs
@@ -346,7 +346,7 @@ test('Portable exposes a native restart contract and returns the host decision',
   assert.match(windowsHost, /dsh-portable\/restart-host/)
   assert.match(windowsHost, /trayState != null && trayState\.hasRunningSession/)
   assert.match(windowsHost, /restart-host[\s\S]*request-accepted[\s\S]*reply-posted/)
-  assert.match(windowsHost, /if \(restartAfterShutdown\)[\s\S]{0,300}RestartArguments\(\)/)
+  assert.match(windowsHost, /if \(!restartAfterShutdown\) return;[\s\S]{0,300}RestartArguments\(\)/)
   assert.match(windowsHost, /private string\[\] RestartArguments\(\)[\s\S]*--dsh-restart-after-pid/)
 
   runtime.dispose()


### PR DESCRIPTION
Restart could exit without reopening the app when WebView2 required the final kill-on-close process-job fallback: that path terminated the host before scheduling its requested restart. Schedule the detached restart before closing the owned job, share that ordering with a deterministic forced-fallback test, and retain normal shutdown behavior. Hidden local Win11 verification of the rebuilt launcher passed forced job termination, relaunch, new backend boot ID and redacted render diagnostics. The Windows CI native sequence now exercises that path explicitly.

Also pin official Chrome for Testing 153.0.8010.36 for browser acceptance, validate its version and record the download hash, avoiding an uncontrolled runner browser dependency. Keep existing timeouts and sandbox settings. Eighty affected contracts and three release-note tests passed. Windows 2022 completed the shared sequence with the pinned browser; isolated pinned-browser validation is running on both Windows runners. Final product qualification remains required.
