### PR TITLE
Recover a bounded transient Windows startup identity-query timeout

### DIFF
--- a/.github/workflows/windows-focused.yml
+++ b/.github/workflows/windows-focused.yml
@@ -97,3 +97,10 @@ jobs:
           name: focused-windows-${{ matrix.runner }}
           path: evidence/
           retention-days: 14
+      - name: Retain isolated product logs even when start fails
+        if: always() && inputs.scope == 'tray'
+        uses: actions/upload-artifact@v7
+        with:
+          name: focused-product-logs-${{ matrix.runner }}
+          path: ${{ runner.temp }}/dsh-focused/DSH-Portable/data/logs/
+          retention-days: 14

--- a/.github/workflows/windows-focused.yml
+++ b/.github/workflows/windows-focused.yml
@@ -11,7 +11,7 @@ on:
       scope:
         description: Isolated tray bridge or the original native check sequence
         type: choice
-        options: [tray, native, migration]
+        options: [tray, native, migration, update]
         default: tray
       node_version:
         description: Harness Node version for controlled environment comparison
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-test-chrome
-        if: inputs.scope != 'migration'
+        if: inputs.scope == 'tray' || inputs.scope == 'native'
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
@@ -82,8 +82,24 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'Extraction failed' }
           node scripts/smoke-windows-data-export.mjs (Join-Path $Root 'DSH-Portable') (Join-Path $env:RUNNER_TEMP 'dsh-native-migration-evidence-focused') 2>&1 | Tee-Object evidence/migration.log
           if ($LASTEXITCODE -ne 0) { throw 'Migration check failed' }
+      - name: Verify component update and rollback independently
+        if: inputs.scope == 'update'
+        shell: pwsh
+        run: |
+          $Root = Join-Path $env:RUNNER_TEMP 'dsh-focused-update'
+          New-Item -ItemType Directory -Force $Root | Out-Null
+          tar.exe -xf artifacts/DSH-Portable-windows-x64-offline.zip -C $Root
+          if ($LASTEXITCODE -ne 0) { throw 'Extraction failed' }
+          node scripts/smoke-update-artifact.mjs (Join-Path $Root 'DSH-Portable') artifacts/portable-update-windows-x64.json artifacts/DSH-Portable-update-windows-x64.zip 2>&1 | Tee-Object evidence/component-update.log
+          if ($LASTEXITCODE -ne 0) { throw 'Component update check failed' }
+      - name: Retain component update product logs
+        if: always() && inputs.scope == 'update'
+        uses: actions/upload-artifact@v7
+        with:
+          name: focused-update-logs-${{ matrix.runner }}
+          path: ${{ runner.temp }}/dsh-focused-update/DSH-Portable/data/logs/
       - name: Retain native structured failure evidence
-        if: always() && inputs.scope != 'tray'
+        if: always() && (inputs.scope == 'native' || inputs.scope == 'migration')
         uses: actions/upload-artifact@v7
         with:
           name: focused-native-${{ matrix.runner }}

--- a/launcher/portable-cli.mjs
+++ b/launcher/portable-cli.mjs
@@ -170,6 +170,28 @@ async function waitForHost(state, timeoutMs = 60000, launchOutput = null, onPhas
   let attempts = 0
   let urlReported = false
   let identityVerified = false
+  let inspectionTimeoutRetried = false
+  const inspectOwnership = () => {
+    const queryStarted = Date.now()
+    if (onPhase) onPhase('host-process-query-begin', { final: identityVerified })
+    try {
+      const owned = ownedState(state)
+      if (onPhase) onPhase('host-process-query-end', { durationMs: Date.now() - queryStarted, owned })
+      return owned
+    } catch (error) {
+      if (onPhase) onPhase('host-process-query-failed', { durationMs: Date.now() - queryStarted, code: error?.cause?.code || 'inspection-failed' })
+      // A cold PowerShell/CIM query can time out while the child is healthy.
+      // Unknown identity is never ownership. Permit one fresh read only while
+      // the existing startup deadline still allows the bounded 10-second query.
+      if (layout.platform === 'win32' && !inspectionTimeoutRetried
+          && error?.cause?.code === 'ETIMEDOUT' && Date.now() + 10000 <= deadline) {
+        inspectionTimeoutRetried = true
+        if (onPhase) onPhase('host-process-query-retry', { attempts, reason: 'inspection-timeout' })
+        return null
+      }
+      throw error
+    }
+  }
   if (onPhase) onPhase('host-wait-begin', { pid: state.pid, port: state.port })
   while (Date.now() < deadline) {
     attempts += 1
@@ -177,7 +199,12 @@ async function waitForHost(state, timeoutMs = 60000, launchOutput = null, onPhas
       if (onPhase) onPhase('host-process-exited', { attempts })
       return null
     }
-    if (!identityVerified && !ownedState(state)) {
+    const ownership = identityVerified ? true : inspectOwnership()
+    if (ownership === null) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      continue
+    }
+    if (!ownership) {
       // WMI/CIM can briefly lag a just-spawned process on Windows. A live PID
       // gets a short identity grace period; mismatched or exited processes do
       // not get treated as owned and are never terminated here.
@@ -204,7 +231,12 @@ async function waitForHost(state, timeoutMs = 60000, launchOutput = null, onPhas
     if (await httpReady(url, 1200, { preserveAccessToken: true })) {
       // Revalidate before returning the URL; polling liveness alone never grants
       // ownership for reuse or termination of a process.
-      if (!ownedState(state)) return null
+      const finalOwnership = inspectOwnership()
+      if (finalOwnership === null) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        continue
+      }
+      if (!finalOwnership) return null
       if (onPhase) onPhase('host-http-ready', { attempts, port: state.port })
       return url
     }

--- a/release-notes/v0.6.5-rc.1.json
+++ b/release-notes/v0.6.5-rc.1.json
@@ -5,7 +5,7 @@
     "highlights": [
       "新增「设置 → 更新」，位于通用设置下方；Portable 与官方内核分别提供版本选择、检查更新和启动检查。",
       "版本目录只收录经过验收的版本，已知问题版本不进入选项；切换通道丢弃过时结果，安装前重新核对所选版本。",
-      "顶部菜单在点击页面、窗口失焦或按 Escape 时关闭，并移除额外的弹出阴影；修复 WebView2 需要强制退出时，点击重启却只退出的问题。",
+      "顶部菜单在点击页面、窗口失焦或按 Escape 时关闭，并移除额外的弹出阴影；修复 WebView2 强制退出时重启丢失，以及 Windows 进程身份查询偶发超时导致启动或更新中断的问题。",
       "Windows DSH 终端直接启动本机 PowerShell，移除菜单和批处理脚本间重复的 Shell 转发及来源提示。",
       "插件安装说明指向市场和已安装页面；内置 pnpm 缺失时提供 Portable 修复入口，不尝试全局安装工具。",
       "插件市场上游变化改为生成差异审查报告，避免普通版本更新反复创建 issue；README 与实机截图同步更新。"
@@ -20,7 +20,7 @@
     "highlights": [
       "Settings → Updates now sits below General. Portable and the official core have separate version selection, update checks and startup controls.",
       "Version catalogs contain qualified releases only and omit known defective versions. Channel changes discard stale results; selected versions are revalidated before installation.",
-      "Native menus close on page clicks, window deactivation and Escape, with the extra popup shadow removed. Restart now relaunches the app even when WebView2 requires forced process cleanup.",
+      "Native menus close on page clicks, window deactivation and Escape, with the extra popup shadow removed. Restart survives forced WebView2 cleanup; one transient Windows process-inspection timeout can recover within the existing startup deadline.",
       "Windows DSH Terminal starts the installed PowerShell directly, removing redundant Shell handoffs and internal download-origin prompts.",
       "Plugin guidance points to Plugin Market and Installed. Missing bundled pnpm leads to Portable repair guidance instead of global tool installation.",
       "Routine market releases generate applicability review reports instead of repetitive issues. README text and real-machine screenshots are updated."

--- a/tests/startup-polling.test.mjs
+++ b/tests/startup-polling.test.mjs
@@ -33,6 +33,7 @@ function fixture({ alive = () => true, owned = () => true } = {}) {
   const wait = vm.runInNewContext(`(${waitSource})`, {
     Date: { now: () => now },
     setTimeout: (callback, delay) => { now += delay; callback() },
+    layout: { platform: 'win32' },
     processExists: () => { polls += 1; return alive(now) },
     ownedState: () => owned(++identities, now),
     officialWorkspaceUrl: () => now >= 5000 ? 'http://127.0.0.1:3080/?token=test' : null,
@@ -64,4 +65,34 @@ test('identity grace expires and a live but silent host still respects the start
   const phases = []
   assert.equal(await silent.wait({ pid: 123, port: 3080 }, 1000, null, phase => phases.push(phase)), null)
   assert.equal(phases.at(-1), 'host-wait-timeout')
+})
+
+function inspectionTimeout() {
+  return new Error('Could not inspect process', { cause: Object.assign(new Error('CIM timeout'), { code: 'ETIMEDOUT' }) })
+}
+
+test('startup retries one timed-out identity read and still verifies final ownership', async () => {
+  const phases = []
+  const probe = fixture({ owned: call => { if (call === 1) throw inspectionTimeout(); return true } })
+  const url = await probe.wait({ pid: 123, port: 3080 }, 20000, { filename: 'fixture', offset: 0 }, phase => phases.push(phase))
+  assert.match(url, /127\.0\.0\.1/)
+  assert.equal(probe.identities, 3)
+  assert.equal(phases.filter(phase => phase === 'host-process-query-retry').length, 1)
+})
+
+test('repeated timeouts and non-timeout inspection errors remain failures', async () => {
+  const repeated = fixture({ owned: () => { throw inspectionTimeout() } })
+  await assert.rejects(repeated.wait({ pid: 123, port: 3080 }, 20000), /Could not inspect process/)
+  assert.equal(repeated.identities, 2)
+  const denied = fixture({ owned: () => { throw new Error('Access denied') } })
+  await assert.rejects(denied.wait({ pid: 123, port: 3080 }, 20000), /Access denied/)
+  assert.equal(denied.identities, 1)
+})
+
+test('an inspection retry neither grants ownership nor extends the startup deadline', async () => {
+  const changed = fixture({ owned: call => { if (call === 1) throw inspectionTimeout(); return false } })
+  assert.equal(await changed.wait({ pid: 123, port: 3080 }, 20000), null)
+  const expired = fixture({ owned: () => { throw inspectionTimeout() } })
+  await assert.rejects(expired.wait({ pid: 123, port: 3080 }, 1000), /Could not inspect process/)
+  assert.equal(expired.identities, 1)
 })


### PR DESCRIPTION
A Windows process-identity query timed out inside the post-update startup health check, causing an otherwise recoverable update to fail. Startup now permits one fresh identity query only for the observed nested ETIMEDOUT error and only if the existing deadline has room for the bounded query. Unknown identity never grants ownership; a second timeout, access denial or mismatched identity still fails. Record process-query duration, failure and retry phases in startup logs.

The focused workflow also retains product logs for early startup failures and offers isolated component-update/rollback verification, so generic public errors no longer hide the failure evidence from CI.

Validation: 39 affected startup/process-ownership contracts passed, covering successful recovery, repeated timeout, access denial, ownership mismatch and insufficient deadline. The prior final ZIP passed local update/rollback with all sentinels preserved and hidden UI acceptance. A backend-only fault-injection acceptance of the changed startup code is running before merge. Full release qualification remains required.
