### PR TITLE
Keep Portable localhost connected when the browser reports offline

### DIFF
--- a/release-notes/v0.6.5-rc.1.json
+++ b/release-notes/v0.6.5-rc.1.json
@@ -5,7 +5,7 @@
     "highlights": [
       "新增「设置 → 更新」，位于通用设置下方；Portable 与官方内核分别提供版本选择、检查更新和启动检查。",
       "版本目录只收录经过验收的版本，已知问题版本不进入选项；切换通道丢弃过时结果，安装前重新核对所选版本。",
-      "顶部菜单在点击页面、窗口失焦或按 Escape 时关闭，并移除额外的弹出阴影；修复 WebView2 强制退出时重启丢失，以及 Windows 进程身份查询偶发超时导致启动或更新中断的问题。",
+      "修复系统离线时错误暂停 localhost 连接、界面无法加载的问题。顶部菜单在点击页面、窗口失焦或按 Escape 时关闭，并移除额外的弹出阴影；修复 WebView2 强制退出时重启丢失，以及 Windows 进程身份查询偶发超时导致启动或更新中断的问题。",
       "Windows DSH 终端直接启动本机 PowerShell，移除菜单和批处理脚本间重复的 Shell 转发及来源提示。",
       "插件安装说明指向市场和已安装页面；内置 pnpm 缺失时提供 Portable 修复入口，不尝试全局安装工具。",
       "插件市场上游变化改为生成差异审查报告，避免普通版本更新反复创建 issue；README 与实机截图同步更新。"
@@ -20,7 +20,7 @@
     "highlights": [
       "Settings → Updates now sits below General. Portable and the official core have separate version selection, update checks and startup controls.",
       "Version catalogs contain qualified releases only and omit known defective versions. Channel changes discard stale results; selected versions are revalidated before installation.",
-      "Native menus close on page clicks, window deactivation and Escape, with the extra popup shadow removed. Restart survives forced WebView2 cleanup; one transient Windows process-inspection timeout can recover within the existing startup deadline.",
+      "Localhost stays connected when the browser reports an offline network. Native menus close on page clicks, window deactivation and Escape, with the extra popup shadow removed. Restart survives forced WebView2 cleanup; one transient Windows process-inspection timeout can recover within the existing startup deadline.",
       "Windows DSH Terminal starts the installed PowerShell directly, removing redundant Shell handoffs and internal download-origin prompts.",
       "Plugin guidance points to Plugin Market and Installed. Missing bundled pnpm leads to Portable repair guidance instead of global tool installation.",
       "Routine market releases generate applicability review reports instead of repetitive issues. README text and real-machine screenshots are updated."

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -143,6 +143,7 @@ fi
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-theme-bootstrap.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-native-boot-handoff.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-native-settings-command.mjs" "$STAGE/app"
+"$NODE_EXE" "$PROJECT_ROOT/scripts/patch-loopback-connection.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-portable-hero-context.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-client-module-startup.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-windows-subprocess-hide.mjs" "$STAGE/app"

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -136,6 +136,7 @@ fi
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-theme-bootstrap.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-native-boot-handoff.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-native-settings-command.mjs" "$STAGE/app"
+"$NODE_EXE" "$PROJECT_ROOT/scripts/patch-loopback-connection.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-portable-hero-context.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-client-module-startup.mjs" "$STAGE/app"
 "$NODE_EXE" "$PROJECT_ROOT/scripts/patch-windows-subprocess-hide.mjs" "$STAGE/app"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -239,6 +239,8 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "Native boot handoff adaptation failed with exit code $LASTEXITCODE" }
     & $NodeExe (Join-Path $ProjectRoot 'scripts\patch-native-settings-command.mjs') (Join-Path $Stage 'app')
     if ($LASTEXITCODE -ne 0) { throw "Native settings command adaptation failed with exit code $LASTEXITCODE" }
+    & $NodeExe (Join-Path $ProjectRoot 'scripts\patch-loopback-connection.mjs') (Join-Path $Stage 'app')
+    if ($LASTEXITCODE -ne 0) { throw "Loopback connection adaptation failed with exit code $LASTEXITCODE" }
     & $NodeExe (Join-Path $ProjectRoot 'scripts\patch-portable-hero-context.mjs') (Join-Path $Stage 'app')
     if ($LASTEXITCODE -ne 0) { throw "Portable Hero context adaptation failed with exit code $LASTEXITCODE" }
     & $NodeExe (Join-Path $ProjectRoot 'scripts\patch-client-module-startup.mjs') (Join-Path $Stage 'app')

--- a/scripts/patch-loopback-connection.mjs
+++ b/scripts/patch-loopback-connection.mjs
@@ -1,0 +1,24 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const MARKER = 'dsh-portable-loopback-connection-v1'
+const ORIGINAL = 'stopNetworkWatch: watchBrowserNetwork(controller)'
+const REPLACEMENT = `stopNetworkWatch: handle.isLoopback ? () => {} : watchBrowserNetwork(controller) /* ${MARKER} */`
+
+export function patchLoopbackConnection(source) {
+  if (source.includes(MARKER)) return source
+  const matches = source.split(ORIGINAL).length - 1
+  if (matches !== 1) throw new Error(`Loopback connection seam changed: expected 1 match, found ${matches}`)
+  return source.replace(ORIGINAL, REPLACEMENT)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  if (!process.argv[2]) throw new Error('usage: node patch-loopback-connection.mjs <app root>')
+  const appRoot = path.resolve(process.argv[2])
+  const filename = path.join(appRoot, 'node_modules', '@deepseek-ai', 'dsh-client-connection', 'lib', 'client.js')
+  const source = await readFile(filename, 'utf8')
+  const patched = patchLoopbackConnection(source)
+  if (patched !== source) await writeFile(filename, patched, 'utf8')
+  console.log(filename)
+}

--- a/scripts/smoke-windows-tray-bridge.mjs
+++ b/scripts/smoke-windows-tray-bridge.mjs
@@ -213,6 +213,8 @@ async function waitForValue(client, expression, predicate, label, timeoutMs = 30
 }
 
 const initScript = String.raw`(() => {
+  // Localhost must remain usable when Windows reports no external network.
+  Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });
   const listeners = new Set()
   const posted = []
   const webview = {
@@ -772,6 +774,7 @@ try {
   await evaluate(client, `window.chrome.webview.__emit({ type: 'dsh-portable/action', action: 'new-session' })`)
   const afterClear = await waitForValue(client, stateCountExpression, value => value > beforeClear, 'SessionRuntime.clear state update')
   assert.ok(afterClear > beforeClear)
+  assert.equal(await evaluate(client, 'navigator.onLine'), false)
   assert.deepEqual(exceptions, [])
 
   process.stdout.write(`${JSON.stringify({
@@ -780,6 +783,7 @@ try {
     theme: state.theme,
     sessions: state.sessions.length,
     headless: true,
+    offlineLoopback: true,
   })}\n`)
 } finally {
   client?.close()

--- a/tests/patch-loopback-connection.test.mjs
+++ b/tests/patch-loopback-connection.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import { patchLoopbackConnection } from '../scripts/patch-loopback-connection.mjs'
+
+const sourceFile = new URL('../app/node_modules/@deepseek-ai/dsh-client-connection/lib/client.js', import.meta.url)
+const original = 'stopNetworkWatch: watchBrowserNetwork(controller)'
+const replacementExpression = 'handle.isLoopback ? () => {} : watchBrowserNetwork(controller)'
+const replacement = `stopNetworkWatch: ${replacementExpression}`
+
+function count(source, value) {
+  return source.split(value).length - 1
+}
+
+test('loopback patch applies to the current client seam and is idempotent', async () => {
+  const source = await readFile(sourceFile, 'utf8')
+  assert.equal(count(source, original), 1)
+
+  const patched = patchLoopbackConnection(source)
+  assert.equal(count(patched, original), 0)
+  assert.equal(count(patched, replacement), 1)
+  assert.match(patched, /dsh-portable-loopback-connection-v1/)
+  assert.equal(patchLoopbackConnection(patched), patched)
+})
+
+test('loopback patch rejects a changed or ambiguous seam', async () => {
+  const source = await readFile(sourceFile, 'utf8')
+  assert.throws(
+    () => patchLoopbackConnection(source.replace(original, 'stopNetworkWatch: changed')),
+    /expected 1 match, found 0/,
+  )
+  assert.throws(
+    () => patchLoopbackConnection(`${source}\n${original}`),
+    /expected 1 match, found 2/,
+  )
+})
+
+function runStopNetworkWatch(expression, isLoopback) {
+  return vm.runInNewContext(`
+    const calls = []
+    const controller = {}
+    const handle = { isLoopback: ${String(isLoopback)} }
+    const watchBrowserNetwork = () => {
+      calls.push('watch')
+      return () => calls.push('cleanup')
+    }
+    const current = { stopNetworkWatch: (${expression}) }
+    current.stopNetworkWatch();
+    JSON.stringify({ calls, stopType: typeof current.stopNetworkWatch })
+  `)
+}
+
+test('the replacement skips network watching only for loopback and keeps cleanup otherwise', () => {
+  assert.deepEqual(JSON.parse(runStopNetworkWatch('watchBrowserNetwork(controller)', true)), {
+    calls: ['watch', 'cleanup'],
+    stopType: 'function',
+  })
+  assert.deepEqual(JSON.parse(runStopNetworkWatch(replacementExpression, true)), {
+    calls: [],
+    stopType: 'function',
+  })
+  assert.deepEqual(JSON.parse(runStopNetworkWatch(replacementExpression, false)), {
+    calls: ['watch', 'cleanup'],
+    stopType: 'function',
+  })
+})


### PR DESCRIPTION
When Windows reports no external network, the browser offline signal suspends the core connection controller even though Portable talks to localhost. The current 0.1.3-alpha.2 Windows artifact reproduced Disconnected and no model list with navigator.onLine=false; restoring only the online signal loaded the workspace and model immediately.

Skip the browser network watcher only for the core's existing isLoopback connection classification. Remote connections retain the original watcher and cleanup. Apply the narrow, checked adaptation when packaging all three platforms. The existing Windows tray/UI acceptance now runs with the browser reporting offline.

Validation: 31 affected tests pass. A hidden Win11 native artifact A/B test with an isolated runtime cache showed the patched app loading the workspace and DeepSeek-V4-Flash while navigator.onLine remained false. This controls the browser signal; it is not a physical network-disconnection or offline model-inference test. Final packaged CI qualification follows merge.

Refs #128. Keep open until final artifact qualification.
