### PR TITLE
Keep RC release notes focused on user-visible changes

### DIFF
--- a/release-notes/v0.6.5-rc.1.json
+++ b/release-notes/v0.6.5-rc.1.json
@@ -7,8 +7,7 @@
       "版本目录只收录经过验收的版本，已知问题版本不进入选项；切换通道丢弃过时结果，安装前重新核对所选版本。",
       "修复系统离线时错误暂停 localhost 连接、界面无法加载的问题。顶部菜单在点击页面、窗口失焦或按 Escape 时关闭，并移除额外的弹出阴影；修复 WebView2 强制退出时重启丢失，以及 Windows 进程身份查询偶发超时导致启动或更新中断的问题。",
       "Windows DSH 终端直接启动本机 PowerShell，移除菜单和批处理脚本间重复的 Shell 转发及来源提示。",
-      "插件安装说明指向市场和已安装页面；内置 pnpm 缺失时提供 Portable 修复入口，不尝试全局安装工具。",
-      "插件市场上游变化改为生成差异审查报告，避免普通版本更新反复创建 issue；README 与实机截图同步更新。"
+      "插件安装说明指向市场和已安装页面；内置 pnpm 缺失时提供 Portable 修复入口，不尝试全局安装工具。"
     ],
     "upgradeNotes": [
       "本版是 RC 候选版，稳定通道仍使用 0.6.4。请从此页下载完整包，或主动选择候选更新通道。",
@@ -22,8 +21,7 @@
       "Version catalogs contain qualified releases only and omit known defective versions. Channel changes discard stale results; selected versions are revalidated before installation.",
       "Localhost stays connected when the browser reports an offline network. Native menus close on page clicks, window deactivation and Escape, with the extra popup shadow removed. Restart survives forced WebView2 cleanup; one transient Windows process-inspection timeout can recover within the existing startup deadline.",
       "Windows DSH Terminal starts the installed PowerShell directly, removing redundant Shell handoffs and internal download-origin prompts.",
-      "Plugin guidance points to Plugin Market and Installed. Missing bundled pnpm leads to Portable repair guidance instead of global tool installation.",
-      "Routine market releases generate applicability review reports instead of repetitive issues. README text and real-machine screenshots are updated."
+      "Plugin guidance points to Plugin Market and Installed. Missing bundled pnpm leads to Portable repair guidance instead of global tool installation."
     ],
     "upgradeNotes": [
       "This is an RC candidate. Stable users remain on 0.6.4; download the full package here or explicitly choose the candidate channel.",


### PR DESCRIPTION
Remove the internal market-review workflow and README maintenance bullet from both Chinese and English release notes. The published RC description has been corrected to match. Documentation only; release assets are unchanged.